### PR TITLE
Finetuning of two BERT models

### DIFF
--- a/src/AlBERTo_finetune_binary.ipynb
+++ b/src/AlBERTo_finetune_binary.ipynb
@@ -1,0 +1,2677 @@
+{
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "c4HnTWtmSBD2"
+      },
+      "source": [
+        "# 2nd model: [AlBERTo](https://huggingface.co/m-polignano-uniba/bert_uncased_L-12_H-768_A-12_italian_alb3rt0)\n",
+        "\n",
+        "In this script, we'll use a pre-trained BERT\n",
+        "(https://arxiv.org/abs/1810.04805) model for text classification\n",
+        "using PyTorch and PyTorch-Transformers\n",
+        "(https://github.com/huggingface/pytorch-transformers). This script\n",
+        "is based on \"Predicting Movie Review Sentiment with BERT on TF Hub\"\n",
+        "(https://github.com/google-research/bert/blob/master/predicting_movie_reviews_with_bert_on_tf_hub.ipynb)\n",
+        "by Google and \"BERT Fine-Tuning Tutorial with PyTorch\"\n",
+        "(https://mccormickml.com/2019/07/22/BERT-fine-tuning/) by Chris\n",
+        "McCormick.\n",
+        "\n",
+        "**Note that using a GPU with this script is highly recommended.**\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 1,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "BX_5tmtfSZFx",
+        "outputId": "a0df8ee5-bac8-4ea9-bb85-31bc9adcccf6"
+      },
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "Requirement already satisfied: transformers in /usr/local/lib/python3.10/dist-packages (4.47.1)\n",
+            "Requirement already satisfied: filelock in /usr/local/lib/python3.10/dist-packages (from transformers) (3.16.1)\n",
+            "Requirement already satisfied: huggingface-hub<1.0,>=0.24.0 in /usr/local/lib/python3.10/dist-packages (from transformers) (0.27.0)\n",
+            "Requirement already satisfied: numpy>=1.17 in /usr/local/lib/python3.10/dist-packages (from transformers) (1.26.4)\n",
+            "Requirement already satisfied: packaging>=20.0 in /usr/local/lib/python3.10/dist-packages (from transformers) (24.2)\n",
+            "Requirement already satisfied: pyyaml>=5.1 in /usr/local/lib/python3.10/dist-packages (from transformers) (6.0.2)\n",
+            "Requirement already satisfied: regex!=2019.12.17 in /usr/local/lib/python3.10/dist-packages (from transformers) (2024.11.6)\n",
+            "Requirement already satisfied: requests in /usr/local/lib/python3.10/dist-packages (from transformers) (2.32.3)\n",
+            "Requirement already satisfied: tokenizers<0.22,>=0.21 in /usr/local/lib/python3.10/dist-packages (from transformers) (0.21.0)\n",
+            "Requirement already satisfied: safetensors>=0.4.1 in /usr/local/lib/python3.10/dist-packages (from transformers) (0.4.5)\n",
+            "Requirement already satisfied: tqdm>=4.27 in /usr/local/lib/python3.10/dist-packages (from transformers) (4.67.1)\n",
+            "Requirement already satisfied: fsspec>=2023.5.0 in /usr/local/lib/python3.10/dist-packages (from huggingface-hub<1.0,>=0.24.0->transformers) (2024.10.0)\n",
+            "Requirement already satisfied: typing-extensions>=3.7.4.3 in /usr/local/lib/python3.10/dist-packages (from huggingface-hub<1.0,>=0.24.0->transformers) (4.12.2)\n",
+            "Requirement already satisfied: charset-normalizer<4,>=2 in /usr/local/lib/python3.10/dist-packages (from requests->transformers) (3.4.0)\n",
+            "Requirement already satisfied: idna<4,>=2.5 in /usr/local/lib/python3.10/dist-packages (from requests->transformers) (3.10)\n",
+            "Requirement already satisfied: urllib3<3,>=1.21.1 in /usr/local/lib/python3.10/dist-packages (from requests->transformers) (2.2.3)\n",
+            "Requirement already satisfied: certifi>=2017.4.17 in /usr/local/lib/python3.10/dist-packages (from requests->transformers) (2024.12.14)\n",
+            "Requirement already satisfied: torch in /usr/local/lib/python3.10/dist-packages (2.5.1+cu121)\n",
+            "Requirement already satisfied: torchvision in /usr/local/lib/python3.10/dist-packages (0.20.1+cu121)\n",
+            "Requirement already satisfied: filelock in /usr/local/lib/python3.10/dist-packages (from torch) (3.16.1)\n",
+            "Requirement already satisfied: typing-extensions>=4.8.0 in /usr/local/lib/python3.10/dist-packages (from torch) (4.12.2)\n",
+            "Requirement already satisfied: networkx in /usr/local/lib/python3.10/dist-packages (from torch) (3.4.2)\n",
+            "Requirement already satisfied: jinja2 in /usr/local/lib/python3.10/dist-packages (from torch) (3.1.4)\n",
+            "Requirement already satisfied: fsspec in /usr/local/lib/python3.10/dist-packages (from torch) (2024.10.0)\n",
+            "Requirement already satisfied: sympy==1.13.1 in /usr/local/lib/python3.10/dist-packages (from torch) (1.13.1)\n",
+            "Requirement already satisfied: mpmath<1.4,>=1.1.0 in /usr/local/lib/python3.10/dist-packages (from sympy==1.13.1->torch) (1.3.0)\n",
+            "Requirement already satisfied: numpy in /usr/local/lib/python3.10/dist-packages (from torchvision) (1.26.4)\n",
+            "Requirement already satisfied: pillow!=8.3.*,>=5.3.0 in /usr/local/lib/python3.10/dist-packages (from torchvision) (11.0.0)\n",
+            "Requirement already satisfied: MarkupSafe>=2.0 in /usr/local/lib/python3.10/dist-packages (from jinja2->torch) (3.0.2)\n",
+            "Collecting datasets\n",
+            "  Downloading datasets-3.2.0-py3-none-any.whl.metadata (20 kB)\n",
+            "Requirement already satisfied: filelock in /usr/local/lib/python3.10/dist-packages (from datasets) (3.16.1)\n",
+            "Requirement already satisfied: numpy>=1.17 in /usr/local/lib/python3.10/dist-packages (from datasets) (1.26.4)\n",
+            "Requirement already satisfied: pyarrow>=15.0.0 in /usr/local/lib/python3.10/dist-packages (from datasets) (17.0.0)\n",
+            "Collecting dill<0.3.9,>=0.3.0 (from datasets)\n",
+            "  Downloading dill-0.3.8-py3-none-any.whl.metadata (10 kB)\n",
+            "Requirement already satisfied: pandas in /usr/local/lib/python3.10/dist-packages (from datasets) (2.2.2)\n",
+            "Requirement already satisfied: requests>=2.32.2 in /usr/local/lib/python3.10/dist-packages (from datasets) (2.32.3)\n",
+            "Requirement already satisfied: tqdm>=4.66.3 in /usr/local/lib/python3.10/dist-packages (from datasets) (4.67.1)\n",
+            "Collecting xxhash (from datasets)\n",
+            "  Downloading xxhash-3.5.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl.metadata (12 kB)\n",
+            "Collecting multiprocess<0.70.17 (from datasets)\n",
+            "  Downloading multiprocess-0.70.16-py310-none-any.whl.metadata (7.2 kB)\n",
+            "Collecting fsspec<=2024.9.0,>=2023.1.0 (from fsspec[http]<=2024.9.0,>=2023.1.0->datasets)\n",
+            "  Downloading fsspec-2024.9.0-py3-none-any.whl.metadata (11 kB)\n",
+            "Requirement already satisfied: aiohttp in /usr/local/lib/python3.10/dist-packages (from datasets) (3.11.10)\n",
+            "Requirement already satisfied: huggingface-hub>=0.23.0 in /usr/local/lib/python3.10/dist-packages (from datasets) (0.27.0)\n",
+            "Requirement already satisfied: packaging in /usr/local/lib/python3.10/dist-packages (from datasets) (24.2)\n",
+            "Requirement already satisfied: pyyaml>=5.1 in /usr/local/lib/python3.10/dist-packages (from datasets) (6.0.2)\n",
+            "Requirement already satisfied: aiohappyeyeballs>=2.3.0 in /usr/local/lib/python3.10/dist-packages (from aiohttp->datasets) (2.4.4)\n",
+            "Requirement already satisfied: aiosignal>=1.1.2 in /usr/local/lib/python3.10/dist-packages (from aiohttp->datasets) (1.3.2)\n",
+            "Requirement already satisfied: async-timeout<6.0,>=4.0 in /usr/local/lib/python3.10/dist-packages (from aiohttp->datasets) (4.0.3)\n",
+            "Requirement already satisfied: attrs>=17.3.0 in /usr/local/lib/python3.10/dist-packages (from aiohttp->datasets) (24.3.0)\n",
+            "Requirement already satisfied: frozenlist>=1.1.1 in /usr/local/lib/python3.10/dist-packages (from aiohttp->datasets) (1.5.0)\n",
+            "Requirement already satisfied: multidict<7.0,>=4.5 in /usr/local/lib/python3.10/dist-packages (from aiohttp->datasets) (6.1.0)\n",
+            "Requirement already satisfied: propcache>=0.2.0 in /usr/local/lib/python3.10/dist-packages (from aiohttp->datasets) (0.2.1)\n",
+            "Requirement already satisfied: yarl<2.0,>=1.17.0 in /usr/local/lib/python3.10/dist-packages (from aiohttp->datasets) (1.18.3)\n",
+            "Requirement already satisfied: typing-extensions>=3.7.4.3 in /usr/local/lib/python3.10/dist-packages (from huggingface-hub>=0.23.0->datasets) (4.12.2)\n",
+            "Requirement already satisfied: charset-normalizer<4,>=2 in /usr/local/lib/python3.10/dist-packages (from requests>=2.32.2->datasets) (3.4.0)\n",
+            "Requirement already satisfied: idna<4,>=2.5 in /usr/local/lib/python3.10/dist-packages (from requests>=2.32.2->datasets) (3.10)\n",
+            "Requirement already satisfied: urllib3<3,>=1.21.1 in /usr/local/lib/python3.10/dist-packages (from requests>=2.32.2->datasets) (2.2.3)\n",
+            "Requirement already satisfied: certifi>=2017.4.17 in /usr/local/lib/python3.10/dist-packages (from requests>=2.32.2->datasets) (2024.12.14)\n",
+            "Requirement already satisfied: python-dateutil>=2.8.2 in /usr/local/lib/python3.10/dist-packages (from pandas->datasets) (2.8.2)\n",
+            "Requirement already satisfied: pytz>=2020.1 in /usr/local/lib/python3.10/dist-packages (from pandas->datasets) (2024.2)\n",
+            "Requirement already satisfied: tzdata>=2022.7 in /usr/local/lib/python3.10/dist-packages (from pandas->datasets) (2024.2)\n",
+            "Requirement already satisfied: six>=1.5 in /usr/local/lib/python3.10/dist-packages (from python-dateutil>=2.8.2->pandas->datasets) (1.17.0)\n",
+            "Downloading datasets-3.2.0-py3-none-any.whl (480 kB)\n",
+            "\u001b[2K   \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m480.6/480.6 kB\u001b[0m \u001b[31m14.7 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+            "\u001b[?25hDownloading dill-0.3.8-py3-none-any.whl (116 kB)\n",
+            "\u001b[2K   \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m116.3/116.3 kB\u001b[0m \u001b[31m8.9 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+            "\u001b[?25hDownloading fsspec-2024.9.0-py3-none-any.whl (179 kB)\n",
+            "\u001b[2K   \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m179.3/179.3 kB\u001b[0m \u001b[31m13.2 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+            "\u001b[?25hDownloading multiprocess-0.70.16-py310-none-any.whl (134 kB)\n",
+            "\u001b[2K   \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m134.8/134.8 kB\u001b[0m \u001b[31m10.2 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+            "\u001b[?25hDownloading xxhash-3.5.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (194 kB)\n",
+            "\u001b[2K   \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m194.1/194.1 kB\u001b[0m \u001b[31m15.0 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+            "\u001b[?25hInstalling collected packages: xxhash, fsspec, dill, multiprocess, datasets\n",
+            "  Attempting uninstall: fsspec\n",
+            "    Found existing installation: fsspec 2024.10.0\n",
+            "    Uninstalling fsspec-2024.10.0:\n",
+            "      Successfully uninstalled fsspec-2024.10.0\n",
+            "\u001b[31mERROR: pip's dependency resolver does not currently take into account all the packages that are installed. This behaviour is the source of the following dependency conflicts.\n",
+            "gcsfs 2024.10.0 requires fsspec==2024.10.0, but you have fsspec 2024.9.0 which is incompatible.\u001b[0m\u001b[31m\n",
+            "\u001b[0mSuccessfully installed datasets-3.2.0 dill-0.3.8 fsspec-2024.9.0 multiprocess-0.70.16 xxhash-3.5.0\n"
+          ]
+        }
+      ],
+      "source": [
+        "!pip3 install transformers\n",
+        "!pip3 install torch torchvision\n",
+        "!pip install datasets"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 2,
+      "metadata": {
+        "id": "rLa0OltsR369"
+      },
+      "outputs": [],
+      "source": [
+        "from pathlib import Path\n",
+        "\n",
+        "import torch\n",
+        "from torch.utils.data import (TensorDataset, DataLoader,\n",
+        "                              RandomSampler, SequentialSampler)\n",
+        "\n",
+        "from transformers import BertTokenizer, BertConfig\n",
+        "from transformers import BertForSequenceClassification\n",
+        "\n",
+        "from transformers import AdamW, get_linear_schedule_with_warmup\n",
+        "\n",
+        "from distutils.version import LooseVersion as LV\n",
+        "\n",
+        "from sklearn.model_selection import train_test_split\n",
+        "from sklearn.metrics import precision_score, recall_score, f1_score, classification_report, confusion_matrix\n",
+        "\n",
+        "import io\n",
+        "import os\n",
+        "import pandas as pd\n",
+        "import numpy as np\n",
+        "\n",
+        "import matplotlib\n",
+        "matplotlib.use('Agg')\n",
+        "import matplotlib.pyplot as plt\n",
+        "import seaborn as sns\n",
+        "sns.set()"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 3,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "Sr_7M6TySQCC",
+        "outputId": "5491b3ec-82b2-4433-d661-05a47110b2df"
+      },
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "Using PyTorch version: 2.5.1+cu121 Device: cuda [Tesla T4]\n"
+          ]
+        },
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": [
+            "<ipython-input-3-d1a1187c676c>:10: DeprecationWarning: distutils Version classes are deprecated. Use packaging.version instead.\n",
+            "  assert(LV(torch.__version__) >= LV(\"1.0.0\"))\n"
+          ]
+        }
+      ],
+      "source": [
+        "if torch.cuda.is_available():\n",
+        "    device = torch.device('cuda')\n",
+        "    devicename = '['+torch.cuda.get_device_name(0)+']'\n",
+        "else:\n",
+        "    device = torch.device('cpu')\n",
+        "    devicename = \"\"\n",
+        "\n",
+        "print('Using PyTorch version:', torch.__version__,\n",
+        "      'Device:', device, devicename)\n",
+        "assert(LV(torch.__version__) >= LV(\"1.0.0\"))"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "b1J4daS74g5D"
+      },
+      "source": [
+        "# Loading the dataset\n",
+        "\n",
+        "N.B. If you rerun this code on Colab, remember to comment the `!git clone` command, or to delete runtime before rerunning."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "try:\n",
+        "    from google.colab import drive\n",
+        "    #drive.mount('/content/drive')\n",
+        "    COLAB = True\n",
+        "    !git clone https://github.com/g-fabiani4-unipi/txa_project.git\n",
+        "    %cd txa_project\n",
+        "except:\n",
+        "    COLAB = False"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "12-BEjZHu_Jm",
+        "outputId": "f39c31b5-b017-492b-82b2-8d84dd3dea94"
+      },
+      "execution_count": 4,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "Cloning into 'txa_project'...\n",
+            "remote: Enumerating objects: 505, done.\u001b[K\n",
+            "remote: Counting objects: 100% (130/130), done.\u001b[K\n",
+            "remote: Compressing objects: 100% (110/110), done.\u001b[K\n",
+            "remote: Total 505 (delta 46), reused 55 (delta 20), pack-reused 375 (from 1)\u001b[K\n",
+            "Receiving objects: 100% (505/505), 163.19 MiB | 11.64 MiB/s, done.\n",
+            "Resolving deltas: 100% (257/257), done.\n",
+            "Updating files: 100% (63/63), done.\n",
+            "/content/txa_project\n"
+          ]
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "#N.B. We have two test sets\n",
+        "\n",
+        "data_dir = Path(\"./data\")\n",
+        "\n",
+        "training_set_dir = \"haspeede2_dev\"\n",
+        "training_file = \"haspeede2_dev_taskAB.tsv\"\n",
+        "\n",
+        "test_set_dir = \"haspeede2_reference\"\n",
+        "test_file_tweets = \"haspeede2_reference_taskAB-tweets.tsv\"\n",
+        "test_file_news = \"haspeede2_reference_taskAB-news.tsv\"\n",
+        "\n",
+        "train_path = data_dir / training_set_dir / training_file\n",
+        "test_path_tweets = data_dir / test_set_dir / test_file_tweets\n",
+        "test_path_news = data_dir / test_set_dir / test_file_news"
+      ],
+      "metadata": {
+        "id": "Vq8X0qPZQuhB"
+      },
+      "execution_count": 5,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "def load_tsv_file(file_path):\n",
+        "    \"\"\"\n",
+        "    Loads a .tvs file w/ or w/out an header in a pandas dataframe w/ columns\n",
+        "    'id', 'text' and 'hs' ('stereotype' is ignored).\n",
+        "    \"\"\"\n",
+        "    try:\n",
+        "\n",
+        "        df = pd.read_csv(file_path, sep='\\\\t', header=None, engine='python') #engine='python' → else tweets w/ id 8094 and 9261 are not loaded\n",
+        "        # Check for header → train file\n",
+        "        if df.iloc[0, 0] == 'id': #df.iloc[row, col]\n",
+        "            df = df.iloc[1:]  # If header → skip first line\n",
+        "\n",
+        "        df.columns = ['id', 'text', 'hs', 'stereotype'] #rename col\n",
+        "        df = df[['id', 'text', 'hs']] #select the cols of intereste\n",
+        "\n",
+        "        #Convert number to int\n",
+        "        df['id'] = df['id'].astype(int)\n",
+        "        df['hs'] = df['hs'].astype(int)\n",
+        "\n",
+        "        return df\n",
+        "    except Exception as e:\n",
+        "        raise ValueError(f\"Errore durante la lettura del file: {e}\")"
+      ],
+      "metadata": {
+        "id": "j2QbiYPFWHHj"
+      },
+      "execution_count": 6,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "#Dataframes w/ the datasets\n",
+        "df_train = load_tsv_file(train_path)\n",
+        "df_test_tweets = load_tsv_file(test_path_tweets)\n",
+        "df_test_news = load_tsv_file(test_path_news)"
+      ],
+      "metadata": {
+        "id": "7EeW_XGjSDXx"
+      },
+      "execution_count": 7,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "def list_x_y(df):\n",
+        "  \"\"\"\n",
+        "  For a df (dataset), create for each record (tweet) a list contaning the text (x) and a list contaning its label (y),\n",
+        "  so that their indexes correspond.\n",
+        "  \"\"\"\n",
+        "  x = list()\n",
+        "  y = list()\n",
+        "  for index, row in df.iterrows():\n",
+        "      x.append(row['text'])\n",
+        "      y.append(row['hs'])\n",
+        "  return x, y\n",
+        "\n",
+        "x_train, y_train = list_x_y(df_train)\n",
+        "x_test_tweets, y_test_tweets = list_x_y(df_test_tweets)\n",
+        "x_test_news, y_test_news = list_x_y(df_test_news)"
+      ],
+      "metadata": {
+        "id": "JoFsXoIKCcLR"
+      },
+      "execution_count": 8,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "len(x_train),len(y_train),  len(x_test_tweets),len(y_test_tweets),  len(x_test_news),len(y_test_news)\n"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "WgmWswkeg3MF",
+        "outputId": "ba54beab-6a82-410f-a4b8-c46dfee0c0c0"
+      },
+      "execution_count": 9,
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "(6839, 6839, 1263, 1263, 500, 500)"
+            ]
+          },
+          "metadata": {},
+          "execution_count": 9
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 10,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "62X87ZY84g5Z",
+        "outputId": "2d369e03-9497-4915-bd04-baaf737b0aea"
+      },
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "({0, 1}, {0, 1}, {0, 1})"
+            ]
+          },
+          "metadata": {},
+          "execution_count": 10
+        }
+      ],
+      "source": [
+        "set(y_train), set(y_test_tweets), set(y_test_news)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 11,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "r42x4ICg4g5e",
+        "outputId": "2e232be5-e901-4494-fd55-8c0c14f44fb3"
+      },
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "È terrorismo anche questo, per mettere in uno stato di soggezione le persone e renderle innocue, mentre qualcuno... URL \n",
+            "0\n"
+          ]
+        }
+      ],
+      "source": [
+        "sample_idx = 0\n",
+        "print(x_train[sample_idx])\n",
+        "print(y_train[sample_idx])"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "#y_train[sample_idx]"
+      ],
+      "metadata": {
+        "id": "3lTQi8a9IXnL"
+      },
+      "execution_count": 12,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "4O3HWztTUmaE"
+      },
+      "source": [
+        "# Preparation of the text for BERT.\n",
+        "\n",
+        "The tokenizer is already fit on the same dataset on which BERT has been pretrained and it is included in the BERT model.\n",
+        "To be properly handled by BERT we need to add the `[CLS]` token at the beginning of each tweet."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 13,
+      "metadata": {
+        "id": "K46G-KVgUhNQ"
+      },
+      "outputs": [],
+      "source": [
+        "sentences_train = [\"[CLS] \" + s for s in x_train]\n",
+        "sentences_test_tweets = [\"[CLS] \" + s for s in x_test_tweets]\n",
+        "sentences_test_news = [\"[CLS] \" + s for s in x_test_news]\n",
+        "\n",
+        "labels_train = y_train\n",
+        "labels_test_tweets = y_test_tweets\n",
+        "labels_test_news = y_test_news"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "sentences_train[0]"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 36
+        },
+        "id": "1a0IDScSSeNL",
+        "outputId": "00b30813-cdce-4d0d-8241-723c3ed181cd"
+      },
+      "execution_count": 14,
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "'[CLS] È terrorismo anche questo, per mettere in uno stato di soggezione le persone e renderle innocue, mentre qualcuno... URL '"
+            ],
+            "application/vnd.google.colaboratory.intrinsic+json": {
+              "type": "string"
+            }
+          },
+          "metadata": {},
+          "execution_count": 14
+        }
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "1bcbtpRjhbCN"
+      },
+      "source": [
+        "Next we use the BERT tokenizer to convert the sentences into tokens that match the data BERT was trained on."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 15,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 396,
+          "referenced_widgets": [
+            "28bdd31f56c147928235762b80391c6f",
+            "b629edd4da2f44ff981e52704bb80b06",
+            "3b8fbd932edc4a96b64f3f003fd1125c",
+            "3c812cdc92d14961a60e0c5306991643",
+            "4bddcf4e5a7846db974357270fb0f8a5",
+            "67991eabd9d2439ebe56c41ed0026db3",
+            "b8f91bb1736c4621adefe6912dcac88f",
+            "7f5b469bd3eb42e79d268dff00874214",
+            "ec21c6a06c5942e98137c5d05b14f67b",
+            "cbb4c015d35243179bd6b8db4b3db78c",
+            "47808be39e0641f3a301984e95c4a53b",
+            "1542cfad9dc048f887fd958994b392aa",
+            "e837339546a842b6a0ce9b6fd63f7e3d",
+            "f50a75d806f44d7f9a950de500482512",
+            "f2ee89268723449e8e92f6f202a968ec",
+            "38035e10b23d4d9585f15b6fe2eaa468",
+            "f179284b1da54b4e9a8d08fca88daee0",
+            "c4d3214d601b4f1ea8191e68bbc634d9",
+            "998686baebd9472583634c26fe597867",
+            "e968f0ca73c14b73be9b2a4f075d5224",
+            "f8eeeccfd660405b9ffa0b5b15ce6ba7",
+            "d98c125fb41349f6921294034af5e751"
+          ]
+        },
+        "id": "KpKdIgJvSD-b",
+        "outputId": "f3aefff2-4a29-4a2f-b18c-ee19ccbd2ffa"
+      },
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": [
+            "/usr/local/lib/python3.10/dist-packages/huggingface_hub/utils/_auth.py:94: UserWarning: \n",
+            "The secret `HF_TOKEN` does not exist in your Colab secrets.\n",
+            "To authenticate with the Hugging Face Hub, create a token in your settings tab (https://huggingface.co/settings/tokens), set it as secret in your Google Colab and restart your session.\n",
+            "You will be able to reuse this secret in all of your notebooks.\n",
+            "Please note that authentication is recommended but still optional to access public models or datasets.\n",
+            "  warnings.warn(\n"
+          ]
+        },
+        {
+          "output_type": "display_data",
+          "data": {
+            "text/plain": [
+              "vocab.txt:   0%|          | 0.00/1.11M [00:00<?, ?B/s]"
+            ],
+            "application/vnd.jupyter.widget-view+json": {
+              "version_major": 2,
+              "version_minor": 0,
+              "model_id": "28bdd31f56c147928235762b80391c6f"
+            }
+          },
+          "metadata": {}
+        },
+        {
+          "output_type": "display_data",
+          "data": {
+            "text/plain": [
+              "config.json:   0%|          | 0.00/625 [00:00<?, ?B/s]"
+            ],
+            "application/vnd.jupyter.widget-view+json": {
+              "version_major": 2,
+              "version_minor": 0,
+              "model_id": "1542cfad9dc048f887fd958994b392aa"
+            }
+          },
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "BertTokenizer(name_or_path='m-polignano-uniba/bert_uncased_L-12_H-768_A-12_italian_alb3rt0', vocab_size=128000, model_max_length=1000000000000000019884624838656, is_fast=False, padding_side='right', truncation_side='right', special_tokens={'unk_token': '[UNK]', 'sep_token': '[SEP]', 'pad_token': '[PAD]', 'cls_token': '[CLS]', 'mask_token': '[MASK]'}, clean_up_tokenization_spaces=True, added_tokens_decoder={\n",
+              "\t0: AddedToken(\"[PAD]\", rstrip=False, lstrip=False, single_word=False, normalized=False, special=True),\n",
+              "\t1: AddedToken(\"[UNK]\", rstrip=False, lstrip=False, single_word=False, normalized=False, special=True),\n",
+              "\t2: AddedToken(\"[CLS]\", rstrip=False, lstrip=False, single_word=False, normalized=False, special=True),\n",
+              "\t3: AddedToken(\"[SEP]\", rstrip=False, lstrip=False, single_word=False, normalized=False, special=True),\n",
+              "\t4: AddedToken(\"[MASK]\", rstrip=False, lstrip=False, single_word=False, normalized=False, special=True),\n",
+              "}\n",
+              ")"
+            ]
+          },
+          "metadata": {},
+          "execution_count": 15
+        }
+      ],
+      "source": [
+        "BERTMODEL = \"m-polignano-uniba/bert_uncased_L-12_H-768_A-12_italian_alb3rt0\" #dbmdz/bert-base-italian-cased\n",
+        "\n",
+        "tokenizer = BertTokenizer.from_pretrained(BERTMODEL)\n",
+        "tokenizer"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 16,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "mXuRy_9Pg3sJ",
+        "outputId": "23fa75c2-4c56-4cd6-a2d7-ac2959e492b1"
+      },
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": [
+            "100%|██████████| 6839/6839 [00:10<00:00, 641.62it/s] \n",
+            "100%|██████████| 1263/1263 [00:01<00:00, 1227.06it/s]\n",
+            "100%|██████████| 500/500 [00:00<00:00, 3108.96it/s]\n"
+          ]
+        }
+      ],
+      "source": [
+        "from tqdm import tqdm #library that displays progress bars\n",
+        "\n",
+        "tokenized_train = [tokenizer.tokenize(s) for s in tqdm(sentences_train)]\n",
+        "tokenized_test_tweets  = [tokenizer.tokenize(s) for s in tqdm(sentences_test_tweets)]\n",
+        "tokenized_test_news  = [tokenizer.tokenize(s) for s in tqdm(sentences_test_news)]"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "sentences_train[0]"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 36
+        },
+        "id": "Tqs-1u-HiRGE",
+        "outputId": "5fe81598-7dfd-4866-bc91-a5a768a8a67e"
+      },
+      "execution_count": 17,
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "'[CLS] È terrorismo anche questo, per mettere in uno stato di soggezione le persone e renderle innocue, mentre qualcuno... URL '"
+            ],
+            "application/vnd.google.colaboratory.intrinsic+json": {
+              "type": "string"
+            }
+          },
+          "metadata": {},
+          "execution_count": 17
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 18,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "JswOYlyGhfu3",
+        "outputId": "83cb4d60-56e0-4366-ed99-e709fd92a8ab"
+      },
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "The full tokenized first training sentence:\n",
+            "['[CLS]', 'e', 'terrorismo', 'anche', 'questo', '[UNK]', 'per', 'mettere', 'in', 'uno', 'stato', 'di', 'soggezione', 'le', 'persone', 'e', 'render', '##le', 'innocue', '[UNK]', 'mentre', 'qualcuno', '[UNK]', '[UNK]', '[UNK]', 'ur', '##l']\n"
+          ]
+        }
+      ],
+      "source": [
+        "print (\"The full tokenized first training sentence:\")\n",
+        "print (tokenized_train[0])"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "M1bclIl2hoEG"
+      },
+      "source": [
+        "BERT has several embeddings that pass through many levels...\n",
+        "\n",
+        "...but this is not a variable encoding! **BERT exploits fixed-length encoding**\n",
+        "\n",
+        "Thus, we set the maximum sequence lengths for our training and test sentences as `MAX_LEN_TRAIN` and `MAX_LEN_TEST`. The maximum length supported by the used BERT model is 512.\n",
+        "\n",
+        "The token `[SEP]` (separation token) is another special token required by BERT at the end of the sentence, e.g., useful in Q/A."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 19,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "OAtcXAOzhvMD",
+        "outputId": "73a63b06-6a71-4bc4-8040-51e0f64582f5"
+      },
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "The truncated tokenized first training sentence:\n",
+            "['[CLS]', 'e', 'terrorismo', 'anche', 'questo', '[UNK]', 'per', 'mettere', 'in', 'uno', 'stato', 'di', 'soggezione', 'le', 'persone', 'e', 'render', '##le', 'innocue', '[UNK]', 'mentre', 'qualcuno', '[UNK]', '[UNK]', '[UNK]', 'ur', '##l', 'SEP']\n"
+          ]
+        }
+      ],
+      "source": [
+        "MAX_LEN_TRAIN, MAX_LEN_TEST = 128, 512\n",
+        "\n",
+        "tokenized_train = [t[:(MAX_LEN_TRAIN-1)]+['SEP'] for t in tokenized_train]\n",
+        "tokenized_test_tweets  = [t[:(MAX_LEN_TEST-1)]+['SEP'] for t in tokenized_test_tweets]\n",
+        "tokenized_test_news  = [t[:(MAX_LEN_TEST-1)]+['SEP'] for t in tokenized_test_news]\n",
+        "\n",
+        "print (\"The truncated tokenized first training sentence:\")\n",
+        "print (tokenized_train[0])"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "xDBDbn4Ch7sP"
+      },
+      "source": [
+        "Next we use the BERT tokenizer to convert each token into an integer index in the BERT vocabulary *= Which is the proper embedding to get?*\n",
+        "\n",
+        "We also pad any shorter sequences to `MAX_LEN_TRAIN` or `MAX_LEN_TEST` indices with trailing zeros.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 20,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "BrcrPP8eh_ef",
+        "outputId": "9e2b1ae7-3f21-4047-8314-29d551ad7918"
+      },
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "The indices of the first training sentence:\n",
+            "[    2    13  4923    23    79     1    22   605    24   153   184    12\n",
+            " 49535    40   234    13 20897  1041 90954     1   408   271     1     1\n",
+            "     1 14013   902     1     0     0     0     0     0     0     0     0\n",
+            "     0     0     0     0     0     0     0     0     0     0     0     0\n",
+            "     0     0     0     0     0     0     0     0     0     0     0     0\n",
+            "     0     0     0     0     0     0     0     0     0     0     0     0\n",
+            "     0     0     0     0     0     0     0     0     0     0     0     0\n",
+            "     0     0     0     0     0     0     0     0     0     0     0     0\n",
+            "     0     0     0     0     0     0     0     0     0     0     0     0\n",
+            "     0     0     0     0     0     0     0     0     0     0     0     0\n",
+            "     0     0     0     0     0     0     0     0]\n"
+          ]
+        }
+      ],
+      "source": [
+        "ids_train = [tokenizer.convert_tokens_to_ids(t) for t in tokenized_train]\n",
+        "ids_train = np.array([np.pad(i, (0, MAX_LEN_TRAIN-len(i)),\n",
+        "                             mode='constant') for i in ids_train])\n",
+        "\n",
+        "ids_test_tweets = [tokenizer.convert_tokens_to_ids(t) for t in tokenized_test_tweets]\n",
+        "ids_test_tweets = np.array([np.pad(i, (0, MAX_LEN_TEST-len(i)),\n",
+        "                            mode='constant') for i in ids_test_tweets])\n",
+        "\n",
+        "ids_test_news = [tokenizer.convert_tokens_to_ids(t) for t in tokenized_test_news]\n",
+        "ids_test_news = np.array([np.pad(i, (0, MAX_LEN_TEST-len(i)),\n",
+        "                            mode='constant') for i in ids_test_news])\n",
+        "\n",
+        "print (\"The indices of the first training sentence:\")\n",
+        "print (ids_train[0])"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "OiKEIwpIiOeF"
+      },
+      "source": [
+        "BERT also requires *attention masks*, with 1 for each real token in the sequences and 0 for the padding.\n",
+        "\n",
+        "The attention mask tells which positions you have tokens in and which are just empty and do not have tokens."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 21,
+      "metadata": {
+        "id": "SrJ1QioFiQOr"
+      },
+      "outputs": [],
+      "source": [
+        "amasks_train, amasks_test_tweets, amasks_test_news = [], [], []\n",
+        "\n",
+        "for seq in ids_train:\n",
+        "  seq_mask = [float(i>0) for i in seq]\n",
+        "  amasks_train.append(seq_mask)\n",
+        "\n",
+        "for seq in ids_test_tweets:\n",
+        "  seq_mask = [float(i>0) for i in seq]\n",
+        "  amasks_test_tweets.append(seq_mask)\n",
+        "\n",
+        "for seq in ids_test_news:\n",
+        "  seq_mask = [float(i>0) for i in seq]\n",
+        "  amasks_test_news.append(seq_mask)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "PaaKi8FwiU0_"
+      },
+      "source": [
+        "We use scikit-learn's train_test_split() to use 10% of our training data as a validation set.\n",
+        "\n",
+        "So far, we are working with Python lists, i.e., lists of integers. In order for these lists to be correctly handled by BERT, we must convert our lists into other dedicated structures, i.e., using `torch.tensors` into tensor data structures."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 22,
+      "metadata": {
+        "id": "8MFbb7zNPspK"
+      },
+      "outputs": [],
+      "source": [
+        "from sklearn.model_selection import train_test_split"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 23,
+      "metadata": {
+        "id": "S6BDKPqtiSbL"
+      },
+      "outputs": [],
+      "source": [
+        "(train_inputs, validation_inputs,\n",
+        " train_labels, validation_labels) = train_test_split(ids_train, labels_train,\n",
+        "                                                     random_state=42,\n",
+        "                                                     test_size=0.1)\n",
+        "(train_masks, validation_masks,\n",
+        " _, _) = train_test_split(amasks_train, ids_train,\n",
+        "                          random_state=42, test_size=0.1)\n",
+        "\n",
+        "#From lists of int into tensor data structures\n",
+        "train_inputs = torch.tensor(train_inputs)\n",
+        "train_labels = torch.tensor(train_labels)\n",
+        "train_masks  = torch.tensor(train_masks)\n",
+        "validation_inputs = torch.tensor(validation_inputs)\n",
+        "validation_labels = torch.tensor(validation_labels)\n",
+        "validation_masks  = torch.tensor(validation_masks)\n",
+        "\n",
+        "test_inputs_tweets = torch.tensor(ids_test_tweets)\n",
+        "test_labels_tweets = torch.tensor(labels_test_tweets)\n",
+        "test_masks_tweets  = torch.tensor(amasks_test_tweets)\n",
+        "\n",
+        "test_inputs_news = torch.tensor(ids_test_news)\n",
+        "test_labels_news = torch.tensor(labels_test_news)\n",
+        "test_masks_news = torch.tensor(amasks_test_news)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "FwJkAHmbicwU"
+      },
+      "source": [
+        "Now we are almost ready to use our data into a fitting process.\n",
+        "\n",
+        "Next we create PyTorch *DataLoader*s for all data sets.\n",
+        "\n",
+        "For fine-tuning BERT on a specific task, the authors recommend a batch size of 16 or 32."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 24,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "H5wj7YLOiZfZ",
+        "outputId": "3f63aa21-75b3-42cb-d8f4-f5d231912518"
+      },
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "Datasets:\n",
+            "Train: 6155 documents\n",
+            "Validation: 684 documents\n",
+            "Test 1 (Tweets): 1263 documents\n",
+            "Test 2 (News): 500 documents\n"
+          ]
+        }
+      ],
+      "source": [
+        "BATCH_SIZE = 32 # How many training examples in one shot are processed in parallel\n",
+        "\n",
+        "print('Datasets:')\n",
+        "print('Train: ', end=\"\")\n",
+        "train_data = TensorDataset(train_inputs, train_masks,\n",
+        "                           train_labels) # The tensor defines the training documents, the training labels, and labels\n",
+        "train_sampler = RandomSampler(train_data) # Random sampling to avoid creating patterns that are not there, and helps in generalizing\n",
+        "train_dataloader = DataLoader(train_data, sampler=train_sampler,\n",
+        "                              batch_size=BATCH_SIZE) # We wrap data into a Data Loader that will take care of moving objs from the GPU to the CPU\n",
+        "print(len(train_data), 'documents')\n",
+        "\n",
+        "# We do the same for Validation and for the two Test datasets\n",
+        "\n",
+        "print('Validation: ', end=\"\")\n",
+        "validation_data = TensorDataset(validation_inputs, validation_masks,\n",
+        "                                validation_labels)\n",
+        "validation_sampler = SequentialSampler(validation_data)\n",
+        "validation_dataloader = DataLoader(validation_data,\n",
+        "                                   sampler=validation_sampler,\n",
+        "                                   batch_size=BATCH_SIZE)\n",
+        "print(len(validation_data), 'documents')\n",
+        "\n",
+        "print('Test 1 (Tweets): ', end=\"\")\n",
+        "test_data_tweets = TensorDataset(test_inputs_tweets, test_masks_tweets, test_labels_tweets)\n",
+        "test_sampler_tweets = SequentialSampler(test_data_tweets)\n",
+        "test_dataloader_tweets = DataLoader(test_data_tweets, sampler=test_sampler_tweets,\n",
+        "                             batch_size=BATCH_SIZE)\n",
+        "print(len(test_data_tweets), 'documents')\n",
+        "\n",
+        "print('Test 2 (News): ', end=\"\")\n",
+        "test_data_news = TensorDataset(test_inputs_news, test_masks_news, test_labels_news)\n",
+        "test_sampler_news = SequentialSampler(test_data_news)\n",
+        "test_dataloader_news = DataLoader(test_data_news, sampler=test_sampler_news,\n",
+        "                             batch_size=BATCH_SIZE)\n",
+        "print(len(test_data_news), 'documents')"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "nEgt4NkqirRi"
+      },
+      "source": [
+        "# BERT Model Inizialization\n",
+        "\n",
+        "We now load a pretrained BERT model (using `BertForSequenceClassification` class) with a single linear classification layer added on top. We pass the\n",
+        "\n",
+        "We pass as input the same model that we passed to the tokenizer → stored in the `BERTMODEL` variable.\n",
+        "\n",
+        "We also have to pass the labels. In our case we have a binary classification, therefore `num_labels=2`.\n",
+        "\n",
+        "\n",
+        "`.cuda()` comes from NVIDIA, but there is also a more open resource, that is *opencl*.\n",
+        "\n",
+        "\n",
+        "`740M/740M` is the size of the zipped BERT model.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 25,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 121,
+          "referenced_widgets": [
+            "a67e1b4bf617448f9db20fd46dc56f46",
+            "11d1b591773d4b829d98d9d780c25161",
+            "53bfe85b38c848b0b3ea02abed50f33d",
+            "db5c52b41b0e4242bca881dc14b642a3",
+            "cd751523a0ae4a46892f13602c5b5916",
+            "344289826beb4c56aa3f612891a82135",
+            "a444a7b7eff94a94a24f6ada365bf6c5",
+            "c95a34b695814dc29bc440ec6c45d658",
+            "f7c8b37f6a3545ad8fff6b634a6f8406",
+            "05954e578fac410891c0ed47b466a136",
+            "7b7007bb5269451da6a576835b8b6953"
+          ]
+        },
+        "id": "sOG0wOuaiiVr",
+        "outputId": "3815ca4d-49b7-43c6-86fc-fd526ea92408"
+      },
+      "outputs": [
+        {
+          "output_type": "display_data",
+          "data": {
+            "text/plain": [
+              "pytorch_model.bin:   0%|          | 0.00/740M [00:00<?, ?B/s]"
+            ],
+            "application/vnd.jupyter.widget-view+json": {
+              "version_major": 2,
+              "version_minor": 0,
+              "model_id": "a67e1b4bf617448f9db20fd46dc56f46"
+            }
+          },
+          "metadata": {}
+        },
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": [
+            "Some weights of BertForSequenceClassification were not initialized from the model checkpoint at m-polignano-uniba/bert_uncased_L-12_H-768_A-12_italian_alb3rt0 and are newly initialized: ['classifier.bias', 'classifier.weight']\n",
+            "You should probably TRAIN this model on a down-stream task to be able to use it for predictions and inference.\n"
+          ]
+        },
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "Pretrained BERT model \"m-polignano-uniba/bert_uncased_L-12_H-768_A-12_italian_alb3rt0\" loaded\n"
+          ]
+        }
+      ],
+      "source": [
+        "model = BertForSequenceClassification.from_pretrained(BERTMODEL,\n",
+        "                                                      num_labels=2)\n",
+        "model.cuda() # Move to the cuda computing\n",
+        "print('Pretrained BERT model \"{}\" loaded'.format(BERTMODEL))"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "You can go into detail about the model and if you want you can intervene by customizing it, e.g., adding or moving layers."
+      ],
+      "metadata": {
+        "id": "y9-9od7dvdNg"
+      }
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 26,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "LElGRFEMUCZS",
+        "outputId": "7e848516-c868-4b1f-aa7f-3ed8079f8edb"
+      },
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "BertForSequenceClassification(\n",
+            "  (bert): BertModel(\n",
+            "    (embeddings): BertEmbeddings(\n",
+            "      (word_embeddings): Embedding(128000, 768, padding_idx=0)\n",
+            "      (position_embeddings): Embedding(512, 768)\n",
+            "      (token_type_embeddings): Embedding(2, 768)\n",
+            "      (LayerNorm): LayerNorm((768,), eps=1e-12, elementwise_affine=True)\n",
+            "      (dropout): Dropout(p=0.1, inplace=False)\n",
+            "    )\n",
+            "    (encoder): BertEncoder(\n",
+            "      (layer): ModuleList(\n",
+            "        (0-11): 12 x BertLayer(\n",
+            "          (attention): BertAttention(\n",
+            "            (self): BertSdpaSelfAttention(\n",
+            "              (query): Linear(in_features=768, out_features=768, bias=True)\n",
+            "              (key): Linear(in_features=768, out_features=768, bias=True)\n",
+            "              (value): Linear(in_features=768, out_features=768, bias=True)\n",
+            "              (dropout): Dropout(p=0.1, inplace=False)\n",
+            "            )\n",
+            "            (output): BertSelfOutput(\n",
+            "              (dense): Linear(in_features=768, out_features=768, bias=True)\n",
+            "              (LayerNorm): LayerNorm((768,), eps=1e-12, elementwise_affine=True)\n",
+            "              (dropout): Dropout(p=0.1, inplace=False)\n",
+            "            )\n",
+            "          )\n",
+            "          (intermediate): BertIntermediate(\n",
+            "            (dense): Linear(in_features=768, out_features=3072, bias=True)\n",
+            "            (intermediate_act_fn): GELUActivation()\n",
+            "          )\n",
+            "          (output): BertOutput(\n",
+            "            (dense): Linear(in_features=3072, out_features=768, bias=True)\n",
+            "            (LayerNorm): LayerNorm((768,), eps=1e-12, elementwise_affine=True)\n",
+            "            (dropout): Dropout(p=0.1, inplace=False)\n",
+            "          )\n",
+            "        )\n",
+            "      )\n",
+            "    )\n",
+            "    (pooler): BertPooler(\n",
+            "      (dense): Linear(in_features=768, out_features=768, bias=True)\n",
+            "      (activation): Tanh()\n",
+            "    )\n",
+            "  )\n",
+            "  (dropout): Dropout(p=0.1, inplace=False)\n",
+            "  (classifier): Linear(in_features=768, out_features=2, bias=True)\n",
+            ")\n"
+          ]
+        }
+      ],
+      "source": [
+        "print(model)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "The first layer of the network is an embedding layer,\n",
+        "```\n",
+        "(embeddings): BertEmbeddings(\n",
+        "      (word_embeddings): Embedding(30522, 768, padding_idx=0)\n",
+        "      (position_embeddings) : Embedding(512, 768)\n",
+        "      ...\n",
+        "```\n",
+        "So, the number you have assigned to a feature is converted to a vector of 768 and has more than 30,000 different embeddings.\n",
+        "Then there is the position embedding...\n",
+        "\n",
+        "Note we are using a\n",
+        "```\n",
+        "(encoder): BertEncoder(\n",
+        "      ...)\n",
+        "```\n",
+        "so, you can see the Q, K, V decomposition\n",
+        "```\n",
+        "(query): Linear(in_features=768, out_features=768, bias=True)\n",
+        "(key): Linear(in_features=768, out_features=768, bias=True)\n",
+        "(value): Linear(in_features=768, out_features=768, bias=True)\n",
+        "\n",
+        "```"
+      ],
+      "metadata": {
+        "id": "EGjweYmewVoy"
+      }
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "JjtNQUINizE2"
+      },
+      "source": [
+        "We set the remaining hyperparameters needed for fine-tuning the pretrained model:\n",
+        " * EPOCHS: the number of training epochs in fine-tuning\n",
+        "   (recommended values between 2 and 4)\n",
+        " * WEIGHT_DECAY: weight decay for the Adam optimizer\n",
+        " * LR: learning rate for the Adam optimizer (2e-5 to 5e-5 recommended)\n",
+        " * WARMUP_STEPS: number of warmup steps to (linearly) reach the set learning rate\n",
+        "\n",
+        "We also need to grab the training parameters from the pretrained model."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 27,
+      "metadata": {
+        "id": "naOcRV62iwAR",
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "outputId": "5d10bf8e-66ff-46d2-d93f-32feefe1ebc8"
+      },
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": [
+            "/usr/local/lib/python3.10/dist-packages/transformers/optimization.py:591: FutureWarning: This implementation of AdamW is deprecated and will be removed in a future version. Use the PyTorch implementation torch.optim.AdamW instead, or set `no_deprecation_warning=True` to disable this warning\n",
+            "  warnings.warn(\n"
+          ]
+        }
+      ],
+      "source": [
+        "EPOCHS = 4\n",
+        "WEIGHT_DECAY = 0.01\n",
+        "LR = 2e-5\n",
+        "WARMUP_STEPS =int(0.2*len(train_dataloader))\n",
+        "\n",
+        "no_decay = ['bias', 'LayerNorm.weight']\n",
+        "optimizer_grouped_parameters = [\n",
+        "    {'params': [p for n, p in model.named_parameters()\n",
+        "                if not any(nd in n for nd in no_decay)],\n",
+        "     'weight_decay': WEIGHT_DECAY},\n",
+        "    {'params': [p for n, p in model.named_parameters()\n",
+        "                if any(nd in n for nd in no_decay)],\n",
+        "     'weight_decay': 0.0}\n",
+        "]\n",
+        "optimizer = AdamW(optimizer_grouped_parameters, lr=LR, eps=1e-8)\n",
+        "scheduler = get_linear_schedule_with_warmup(optimizer, num_warmup_steps=WARMUP_STEPS,\n",
+        "                                 num_training_steps =len(train_dataloader)*EPOCHS)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "dk4A50LtjIQS"
+      },
+      "source": [
+        "## Training\n",
+        "\n",
+        "Let's now define functions to train() and evaluate() the model. Since we are working with pythorch and not with keras we have to set up the forward pass, steps..."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 28,
+      "metadata": {
+        "id": "Y617BgqjjAJG"
+      },
+      "outputs": [],
+      "source": [
+        "def train(epoch, loss_vector=None, log_interval=200): #loss_vector = train_lossv\n",
+        "  # Set model to training mode\n",
+        "  model.train()\n",
+        "\n",
+        "  # Loop over each batch from the training set\n",
+        "  for step, batch in enumerate(train_dataloader):\n",
+        "\n",
+        "    # Copy data to GPU if needed\n",
+        "    batch = tuple(t.to(device) for t in batch)\n",
+        "\n",
+        "    # Unpack the inputs from our dataloader\n",
+        "    b_input_ids, b_input_mask, b_labels = batch\n",
+        "\n",
+        "    # Zero gradient buffers\n",
+        "    optimizer.zero_grad()\n",
+        "\n",
+        "    # Forward pass\n",
+        "    outputs = model(b_input_ids, token_type_ids=None,\n",
+        "                    attention_mask=b_input_mask, labels=b_labels)\n",
+        "\n",
+        "    loss = outputs[0]\n",
+        "    if loss_vector is not None:\n",
+        "        loss_vector.append(loss.item())\n",
+        "\n",
+        "    # Backward pass\n",
+        "    loss.backward()\n",
+        "\n",
+        "    # Update weights\n",
+        "    optimizer.step()\n",
+        "    scheduler.step()\n",
+        "\n",
+        "    if step % log_interval == 0:\n",
+        "        print('Train Epoch: {} [{}/{} ({:.0f}%)]\\tLoss: {:.6f}'.format(\n",
+        "                epoch, step * len(b_input_ids),\n",
+        "                len(train_dataloader.dataset),\n",
+        "                100. * step / len(train_dataloader), loss))\n",
+        "\n",
+        "\n",
+        "def evaluate(loader, loss_vector=None):\n",
+        "    # Set model to evaluation mode\n",
+        "    model.eval()\n",
+        "\n",
+        "    all_predictions = []\n",
+        "    all_labels = []\n",
+        "\n",
+        "    for batch in loader:\n",
+        "        batch = tuple(t.to(device) for t in batch)\n",
+        "        b_input_ids, b_input_mask, b_labels = batch\n",
+        "\n",
+        "        with torch.no_grad():\n",
+        "            outputs = model(b_input_ids, token_type_ids=None,\n",
+        "                            attention_mask=b_input_mask, labels=b_labels) #we provide the labels to get the loss\n",
+        "            loss = outputs[0]  # Compute validation loss\n",
+        "            if loss_vector is not None:\n",
+        "                loss_vector.append(loss.item())  # Append loss to loss vector\n",
+        "\n",
+        "            logits = outputs[1]  # Get logits\n",
+        "            logits = logits.detach().cpu().numpy()\n",
+        "            predictions = np.argmax(logits, axis=1)\n",
+        "\n",
+        "            labels = b_labels.to('cpu').numpy()\n",
+        "            all_predictions.extend(predictions)\n",
+        "            all_labels.extend(labels)\n",
+        "\n",
+        "    # Calculate metrics\n",
+        "    accuracy = np.mean(np.array(all_predictions) == np.array(all_labels))\n",
+        "    precision = precision_score(all_labels, all_predictions, average='macro')\n",
+        "    recall = recall_score(all_labels, all_predictions, average='macro')\n",
+        "    f1 = f1_score(all_labels, all_predictions, average='macro')\n",
+        "\n",
+        "    print('Accuracy: {:.4f}'.format(accuracy))\n",
+        "    print('Precision: {:.4f}'.format(precision))\n",
+        "    print('Recall: {:.4f}'.format(recall))\n",
+        "    print('F1 Score: {:.4f}'.format(f1))"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "o0x87vj4jLG8"
+      },
+      "source": [
+        "Now we are ready to train our model using the train() function. After each epoch, we evaluate the model using the validation set and evaluate()."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 29,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "CtNwgXKDjJQ3",
+        "outputId": "9d03e488-b995-4de8-86a4-3d62c6711a56"
+      },
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "\n",
+            "Train Epoch: 1 [0/6155 (0%)]\tLoss: 0.647841\n",
+            "\n",
+            "Validation set:\n",
+            "Accuracy: 0.8056\n",
+            "Precision: 0.8001\n",
+            "Recall: 0.8039\n",
+            "F1 Score: 0.8016\n",
+            "\n",
+            "Train Epoch: 2 [0/6155 (0%)]\tLoss: 0.274380\n",
+            "\n",
+            "Validation set:\n",
+            "Accuracy: 0.8129\n",
+            "Precision: 0.8082\n",
+            "Recall: 0.8146\n",
+            "F1 Score: 0.8100\n",
+            "\n",
+            "Train Epoch: 3 [0/6155 (0%)]\tLoss: 0.357836\n",
+            "\n",
+            "Validation set:\n",
+            "Accuracy: 0.8143\n",
+            "Precision: 0.8102\n",
+            "Recall: 0.8065\n",
+            "F1 Score: 0.8081\n",
+            "\n",
+            "Train Epoch: 4 [0/6155 (0%)]\tLoss: 0.162856\n",
+            "\n",
+            "Validation set:\n",
+            "Accuracy: 0.8114\n",
+            "Precision: 0.8060\n",
+            "Recall: 0.8099\n",
+            "F1 Score: 0.8075\n"
+          ]
+        }
+      ],
+      "source": [
+        "#Lists to store the train/eval batch losses (lists w/ loss for each batch)\n",
+        "train_lossv = []\n",
+        "eval_lossv = []\n",
+        "\n",
+        "for epoch in range(1, EPOCHS + 1):\n",
+        "    print()\n",
+        "    train(epoch, train_lossv)\n",
+        "    print('\\nValidation set:')\n",
+        "    evaluate(validation_dataloader, eval_lossv)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "W8fr0OSRjmaS"
+      },
+      "source": [
+        "Let's take a look at our training loss over all batches.\n",
+        "\n",
+        "We see a steady decay, as hoped: it means that the model is learning."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 30,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 652
+        },
+        "id": "zmEaoKyxjQQ2",
+        "outputId": "dc05b496-c88f-43af-b571-93854fbb8e2d"
+      },
+      "outputs": [
+        {
+          "output_type": "display_data",
+          "data": {
+            "text/plain": [
+              "<Figure size 1500x800 with 1 Axes>"
+            ],
+            "image/png": "iVBORw0KGgoAAAANSUhEUgAABNwAAALGCAYAAACeUYzXAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjguMCwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy81sbWrAAAACXBIWXMAAA9hAAAPYQGoP6dpAAEAAElEQVR4nOzdd5gkVb0+8Lequnvizmxid1nyLlFBQJLkIIggeq+Kijlcw1UURb2K/tCrV0UEI1y8qIgoKCiiYkBFQMKSc3JZFpawgd2d3Z0cOlTV74/uU3XOqVOdpns6zPvx8Zme7uqq0901w9R3v8Hyfd8HERERERERERER1YTd6AUQERERERERERG1EwbciIiIiIiIiIiIaogBNyIiIiIiIiIiohpiwI2IiIiIiIiIiKiGGHAjIiIiIiIiIiKqIQbciIiIiIiIiIiIaogBNyIiIiIiIiIiohpiwI2IiIiIiIiIiKiGGHAjIiIiIiIiIiKqIQbciIiIiFrYOeecgxNOOKGq51588cXYa6+9aryi8kxn3URERETNLtHoBRARERG1o3IDWb/4xS9w2GGH1Xk1RERERDSTLN/3/UYvgoiIiKjdXH/99ZHv77zzTlxwwQXK/UceeSQWLlxY9XGy2Sx830cqlar4ublcDq7roqOjo+rjV+ucc87Bfffdh1tuuWXGj01ERERUb8xwIyIiIqqDf/u3f1O+f/TRR3HnnXdG7tdNTk6iq6ur7OMkk8mq1gcAiUQCiQT/HCQiIiKqNfZwIyIiImqQd7/73TjttNPwxBNP4J3vfCf2339/fPe73wUA3HTTTfjwhz+Mo446Cvvuuy9OPPFEXHLJJXBdV9mH3gtt3bp12GuvvfDTn/4Uv/71r3HiiSdi3333xZvf/GY89thjynNNPdz22msv/M///A9uuukmnHbaadh3333xute9Drfffntk/ffeey/e9KY3Yb/99sOJJ56Ia665Zlp94SYmJnD++efj2GOPxb777ouTTz4ZP/3pT6EXZNx55514+9vfjoMPPhgHHnggTj755OB9E6688kq87nWvw/77749DDjkEb3rTm/CnP/2pqnURERERVYr/pElERETUQENDQ/jQhz6E173udXjDG96ABQsWAAB+//vfo7u7G+9///vR3d2Ne+65BxdddBHGxsbw+c9/vuR+//znP2N8fBxve9vbYFkWLrvsMnziE5/ATTfdVDIr7sEHH8SNN96Id7zjHejp6cGVV16Js846C//85z8xb948AMC//vUvfPCDH8R2222HT3ziE/A8D5dccgnmz59f1fvg+z4++tGP4t5778Xpp5+OffbZB3fccQcuuOACbNq0CV/84hcBAKtXr8ZHPvIR7LXXXjjrrLOQSqXwwgsv4KGHHgr29Zvf/AZf//rXcfLJJ+M973kP0uk0Vq1ahUcffRSvf/3rq1ofERERUSUYcCMiIiJqoIGBAXz1q1/FGWecodz/ne98B52dncH3b3/72/HlL38ZV199Nc4+++ySPds2bNiAG2+8Ef39/QCA3XbbDR/72MewYsUKHH/88UWf++yzz+KGG27AzjvvDAA47LDD8G//9m/4y1/+gne9610AgIsuugiO4+Dqq6/G4sWLAQCnnHIKTj311MregIKbb74Z99xzDz71qU/hox/9KADgne98J8466yz84he/wLve9S7svPPOuPPOO5HNZvGTn/wkNrh36623Yo899sBFF11U1VqIiIiIposlpUREREQNlEql8KY3vSlyvxxsGxsbw7Zt23DwwQdjcnISa9asKbnfU089NQi2AcDBBx8MAFi7dm3J5x5xxBFBsA0A9t57b/T29gbPdV0Xd999N1796lcHwTYA2GWXXXD00UeX3L/J7bffDsdx8O53v1u5/wMf+AB83w9KWvv6+gDkA3Se5xn31dfXh40bN0ZKaImIiIhmCjPciIiIiBpo8eLFxmy11atX4/vf/z7uuecejI2NKY+Njo6W3O/222+vfC+CbyMjIxU/VzxfPHfr1q2YmprCLrvsEtnOdF851q9fj0WLFqG3t1e5f/ny5cHjQD6QeO211+Lcc8/Fd77zHRx++OE46aST8NrXvha2nf+35A996EO466678Ja3vAW77LILjjzySJx22mk46KCDqlobERERUaUYcCMiIiJqIDmTTRgZGcG73vUu9Pb24qyzzsLOO++Mjo4OPPnkk/j2t78dm9klcxzHeL8+gKDWz623zs5O/PKXv8S9996LW2+9FXfccQduuOEG/PrXv8bll18Ox3GwfPly/O1vfwsev/HGG/GrX/0KZ555Js4666xGvwQiIiKaBVhSSkRERNRk7rvvPgwNDeH888/He9/7Xhx//PE44ogjlBLRRlqwYAE6OjrwwgsvRB4z3VeOHXbYAZs3b45k84ny2R122CG4z7ZtHH744fjCF76AG264AWeffTbuuece3HvvvcE23d3dOPXUU/HNb34T//znP3Hcccfh0ksvRTqdrmp9RERERJVgwI2IiIioyYjSSDmjLJPJ4Fe/+lWjlqRwHAdHHHEEbr75ZmzatCm4/4UXXsAdd9xR1T6POeYYuK6LX/7yl8r9V1xxBSzLwjHHHAMgP9VVt88++wDIv0cAMDg4qDyeSqWwfPly+L6PbDZb1fqIiIiIKsGSUiIiIqImc+CBB6K/vx/nnHMO3v3ud8OyLFx//fVNUdIpfPzjH8eKFSvw9re/HW9/+9vheR6uuuoq7LHHHli5cmXF+zvhhBNw2GGH4Xvf+x7Wr1+PvfbaC3feeSduvvlmvPe97w2GOFxyySV44IEHcOyxx2KHHXbA1q1b8atf/QpLliwJerT9x3/8BxYuXIhXvvKVWLBgAdasWYOrrroKxx57bKRHHBEREVE9MOBGRERE1GTmzZuHSy+9FN/61rfw/e9/H319fXjDG96Aww8/HP/xH//R6OUBAPbdd1/85Cc/wQUXXIAf/OAH2H777XHWWWdhzZo1ZU1R1dm2jf/7v//DRRddhBtuuAG/+93vsMMOO+Bzn/scPvCBDwTbnXDCCVi/fj2uu+46DA4OYt68eTj00EPxiU98AnPmzAEAvO1tb8Of/vQn/OxnP8PExASWLFmCd7/73fjYxz5Ws9dPREREVIzlN9M/lRIRERFRS/vYxz6GZ555BjfeeGOjl0JERETUMOzhRkRERERVmZqaUr5//vnncfvtt+PQQw9t0IqIiIiImgNLSomIiIioKieeeCLe+MY3YqeddsL69etxzTXXIJlM4oMf/GCjl0ZERETUUAy4EREREVFVjj76aPzlL3/BwMAAUqkUDjjgAHz605/Grrvu2uilERERETUUe7gRERERERERERHVEHu4ERERERERERER1RADbkRERERERERERDXEgBsREREREREREVENcWhCEb7vw/Paq8WdbVtt95qotniOUCk8R6gUniNUCs8RKoXnCJXCc4RK4TlCpVRzjti2BcuyytqWAbciPM/Htm3jjV5GzSQSNubN68HIyARyOa/Ry6EmxHOESuE5QqXwHKFSeI5QKTxHqBSeI1QKzxEqpdpzZP78HjhOeQE3lpQSERERERERERHVEANuRERERERERERENcSAGxERERERERERUQ0x4EZERERERERERFRDDLgRERERERERERHVEKeUEhERERERERFpPM+D6+YavQyqA8+zMDXlIJNJw3V9AIDjJGDbtctLY8CNiIiIiIiIiKjA932MjGzD5ORYo5dCdbRliw3P85T7urp60dc3H5ZlTXv/DLgRERERERERERWIYFtv7zykUh01Cb5Q83EcK8hu830fmUwaY2ODAID+/gXT3j8DbkREREREREREADzPDYJtvb19jV4O1VEiYSOXCzPcUqkOAMDY2CDmzJk37fJSDk0gIiIiIiIiIgLgui6AMPhCs4v43GvRu48BNyIiIiIiIiIiCctIZ6dafu4MuBEREREREREREdUQA25ERERERERERKQ4/fTX47vf/daMPa8c3/jGV/Dud7+1LvuuNQ5NICIiIiIiIiIixXnnXYg5cyofHFHt89oNA25ERERERERERAQASKen0NHRiT333Luq51f7vHbDklIiIiIiIiIiojZ122234H3vewdOOOEI/Nu/vRYXX/xdpNNpAMBDDz2Ao446GHfdtQLnnvs5vOY1x+JLXzoHgLk09A9/uA5vfvNpePWrj8SnPvUxPP30UzjqqINxww1/CrbRnyfKQB966AG8//3vwIknHoUPfeg9eOqplcq+r776Knzwg+/ByScfi9NOOwmf+9yn8OKLL9Trbak7ZrgREREREREREbWhFStuw7nnfh6vfvVr8J//+XG8+OLz+NGPLsGmTRvx9a9fEGx3wQXfwGtecwrOO+902LY5N2vFitvw7W9/E69//b/juONejdWrV+HLX/5CWevYtm0rfvCDb+Od73wfent78aMf/S+++MXP4je/uR6JRD40NTCwCW9+81uxePESTEyM4w9/uA4f/egHcPXVv0NfX//034wZxoAbEREREREREVERvu8jk/UadvxU0oZlWRU/7/LLf4yXv3w/fOUr3wAAvOpVR6CjoxMXXngenn32mWC7o446Bh/72FlF9/Xzn/8UBx10CD7/+XMBAIcddjhyuRwuu+zSkusYGRnBxRf/GMuWLQcAdHZ24qyz/hNPPvkE9t//AADAWWd9JtjedV0ccshhOO201+Cf/7wZ//Zvb6rodTcDBtyIiIiIiIiIiGL4vo9vXvUQnlk/3LA17L5jP77wzldWFHSbmJjA6tVP48wzP6nc/+pXvwYXXngeHnvsEeyyy64AgMMPP6rovlzXxdNPr8KZZ35Kuf/oo48rK+C2cOF2QbANAHbbbRmAfFab8MQTj+Oyy/4PTz+9CiMj4Xu9du2LJfffjBhwIyIiIiIiIiIqpvLksoYbGxuF7/uYP3+Bcn9vby9SqZQS1Jo/f37RfQ0NDcJ1XcydO0+5f968eTHPUPX29irfJxJJAEAmkwEAbNy4EZ/+9Mex99774L/+6wtYuHA7JJNJ/Nd/fQqZTLqsYzQbBtyIiIiIiIiIiGJYloUvvPOVLVdS2ts7B5ZlYXBwm3L/2NgYMpmM0het1L7nzp0Hx3EwNDSo3D84OBjzjMrce+9dmJycwDe+cSHmzJkDAMjlckpQsNVwSikRERERERERURGWZaEj5TTs/9X0b+vu7sYee+yJW2+9Wbn/llv+AQB4xSsOKHtfjuNgzz33wooVtyn333HHrRWvyySdTsOyrGCAAgDccstNcF23JvtvBAbciIiIiIiIiIja0Ac+8GE88cTj+J//+RLuuecu/OY3V+Oii76D4447AcuX717Rvt773v/AQw89gG996+u47757cNVVV+Cvf/0zgNIZcqUcdNAhAIDzzvsqHnjgPlx77TX40Y/+F729c6a130ZiwI2IiIiIiIiIqA0dddSx+NrXzsezzz6DL3zhM/jlL6/AG97wRnzpS1+ral+f/ew5uPfeu3HOOZ/BPffchc9+9hwA0R5tlVq+fHd88Yv/jVWrVuJznzsbN930d3z969+a9n4byfJ932/0IpqV63rYtm280cuomUTCxrx5PRgcHEcu17jac2pePEeoFJ4jVArPESqF5wiVwnOESuE5QqVM5xzJZjPYuvUlLFiwPZLJVJ1W2D7+/Oc/4Pzzv45rr/0jtt9+aaOXU5FEwo6cH6U+//nze+A45eWucWgCETW9h58ewF1PbsT7T9kb3Z3JRi+HiIiIiIho1hkZGcbll/8EBx10MLq7e7By5ZP4xS9+hqOPPrblgm0zgQE3Imp6/3hgLZ56cQiH7bMYB++9qNHLISIiIiIimnUSiQQ2bFiHm276G0ZHRzF37jycfPKp+OhHP9HopTUlBtyIqOm5Xr7y3WMFPBERERERUUN0d/fgggu+3+hltAwOTSCipifibAy4ERERERERUStgwI2Imp6PfKCN8TYiIiIiIiJqBQy4EVHTE4E2DlUmIiIiIiKiVsCAGxE1PRFoY7yNiIiIiIiIWgEDbkTU9Dz2cCMiIiIiIqIWwoAbETW/oKS0scsgIiIiIiIiKgcDbkTU9MKSUkbciIiIiIiIqPkx4EZETc9jhhsRERERERFNw+rVq3DUUQfjoYcemJHjMeBGRE3PBzPciIiIiIiIqHUw4EZEzS8YmtDYZRAREREREVF5XNdFLpdr9DIaJtHoBRARleKxhxsREREREVHFnnjiMVx55c/w1FMrMT4+hh133BlnnPFOvPa1r8Pk5CRe//qT8IEPfATveMe7leede+7nMDAwgB/96GcAgNHRUfzoR5fgjjv+iZGREey223L8539+HIce+qrgOR//+IfR3d2N448/Eb/4xeXYsGE9fvSjn2HhwkX48Y8vwcMPP4StW7dg0aJFOP74E/H+938IqVQqeP7Y2Bi++91v4Y47bkNHRwde//p/R19fPy655PtYsSIsAy1nLQBwxRWX4Xe/uxaTkxM45JBX4d///c31eItjMeBGRE3PZ4YbERERERE1kO/7QC7TuAUkUrAsq+Knbdz4Evbbb3/8+7+/GalUBx5//FGcf/7X4Ps+TjnlNBx55DG4+eYblYDbxMQ47rrrTnzsY58AAGSzWZx99pnYtm0rPvShj2G77RbhxhtvwH/91ydx+eW/xPLluwfPfeqplXjppQ344Af/E3Pm9GHRosUYHBxEX18/PvGJszFnzhysXfsiLr/8x9i6dQu++MX/Dp573nlfxUMP3Y+PfewsLFmyBH/84x+watVK5fWUu5brrvs1LrvsUrz97e/GwQcfivvvvxfnn/+1it+/6WDAjYiaHqeUEhERERFRo/i+j4k/fgPepmcatgZn8R7oesMXKw66nXjiycFt3/ex//4HYvPmTbj++t/hlFNOw0knnYxzzvkM1q59ETvttDMA4Lbb/gnXzeGEE04CANx441+xevUqXHHF1dhtt2UAgMMOOxxr167FFVdchq997fzgGCMjw/jJT36OxYuXBPfNn78AH//4p4Lv99tvf3R2duEb3/hvfPrTn0dnZyeee24Nbr/9nzj33K/ita99XeEYR+Ad7zhdeT3lrMV1XVx55RU4+eRTceaZnwy2GRzchr///YaK3r/pYMCNiJqeCLMx3kZERERERI1gofLssmYwMjKCyy//Ee644zZs2TIA13UBAP39/QDyQa3e3jm4+eYb8b73fRAAcPPNN+LAAw/C/PkLAAD33XcPli/fHTvttLPSk+2QQw7DjTf+VTne8uV7KME2IB/ou/baq/HHP/4eGzZsQCaTDh7bsGEdli3bHU899S8AwFFHHRs8Zts2jjzyaPz6178M7itnLQMDm7FlywCOOeZ4ZR3HH/9qBtyIiGTMcCMiIiIiokaxLAtdb/hiS5aUnnfeV/DEE4/hfe/7IHbbbTl6enrw+9//Frfc8g8AQDKZxHHHnYCbbsoH3IaHh3D//ffic5/7f8E+hoeH8PTTq3Dcca+K7N9xHOX7+fPnR7b5zW9+hUsu+QHe8Y734JWvPBhz5szBypX/wne/+y1kMvn3dMuWLUgkEujt7VWeO2/ePOX7ctayZcsW43PnzVtgfpPqhAE3Imp6YQ83BtyIiIiIiGjmWZYFJDsavYyKpNNp3HXXCnz842fj9NPPCO7XExlOPPFk/PnP1+OZZ1bjiSceg+M4OPbYE4LH+/r6sXz5HvjCF75U8pimoOA//3kzjjzyGPznf348uO/5559Ttlm4cCFyuRzGxsaUoNvg4KCyXTlrWbhwofG5g4NbS66/lhhwI6KmJ/57wHgbERERERFRebLZLDzPQzKZDO6bmBjHihW3K9sdeOBBWLBgAW666e944onHCmWmYdDr4IMPxd1334mFC7fDwoXbVbyOdHpKWQOASCnqXnvtAwC4445bccoppwEAPM/DnXfeoWxXzlq2224RFixYiNtv/yeOPTYsK/3nP2+ueO3TwYAbETU9HywpJSIiIiIiqkRvby/22edluOqqKzB37lw4TgJXXXUFenp6MTS0LdjOcRwcf/xJ+Otf/4TBwUF85SvnKft57Wtfh+uv/x0+/vGP4O1vfxd22mlnjI2NYfXqVchms0rmmskhhxyGa6+9Btdd92vstNMu+Pvfb8C6deuUbZYtW45jjjkeP/jBt5FOT2Hx4u3xxz/+HplMWsmaK2ctjuPgXe96H37wg29j/vwFOOSQw3Dffffg4YcfrMG7Wj4G3Iio6THDjYiIiIiIqHL//d/fwIUXnodvfOMr6Ovrx+mnn4HJyQlcc81VynYnnngyfvvba9DV1Y0jjzxKeSyVSuGii/4Pl1/+Y/ziF5dj69Yt6O+fiz333AtvfONbSq7hfe/7EIaGhnDZZT8CABx33KvxqU99Fp///NnKdl/4wpfxve9dgEsu+QFSqRRe+9rTsGzZclx33W8qXsvpp78NY2Oj+N3vrsXvf38tDj74UHz+8+fiM5/5RMXvYbUsnykjsVzXw7Zt441eRs0kEjbmzevB4OA4cjmv0cuhJtSs58jZ/7sCw2MZvOHIXfHvRy9r9HJmtWY9R6h58ByhUniOUCk8R6gUniNUynTOkWw2g61bX8KCBdsjmUzVaYVUrjPP/BBs28bFF/+o5vtOJOzI+VHq858/vweOY5e3/5qskoionpjhRkRERERE1NZuvfVmbNq0EcuW7Y50egr/+Mff8OijD+O8877d6KVVhQE3Imp6IhFX9HIjIiIiIiKi9tLV1Y2///0GrF27FrlcFjvvvCu+/OWv4Zhjjmv00qrCgBsRNT2PGW5ERERERERt7bDDDsdhhx3e6GXUTHmFpzPo2Wefxfvf/34ccMABOPLII3HBBRcgk8mUfN7g4CC+/OUv47jjjsMBBxyA0047DVdfffUMrJiI6k1kuHmMuBEREREREVELaKoMt+HhYbz3ve/FrrvuiosvvhibNm3C+eefj6mpKXz5y18u+txPfvKTWLNmDT796U9j++23x+23346vfOUrcBwHb33rW2foFRBRPTHeRkRERERERK2gqQJu11xzDcbHx/G///u/mDt3LgDAdV189atfxUc+8hEsXrzY+LyBgQHce++9+OY3v4k3velNAIDDDz8cjz/+OP7yl78w4EbU4sKSUkbciIiIiIio/njtMTvV8nNvqpLS22+/HYcffngQbAOAU045BZ7n4c4774x9Xi6XAwDMmTNHub+3t5c/JERtIBiawB9nIiIiIiKqI8dxAACZTLrBK6FGEJ+740w/P62pMtzWrFmDN7/5zcp9fX192G677bBmzZrY522//fY46qijcOmll2K33XbDkiVLcPvtt+POO+/Et7/dmuNjiSgkAm3s4UZERERERPVk2w66unoxNjYIAEilOmBZVoNXRfXgeRZcVyR3+Mhk0hgbG0RXVy9se/r5aU0VcBsZGUFfX1/k/v7+fgwPDxd97sUXX4yzzz4br3vd6wDko9LnnnsuTj755GmtKZFoqiTAaXEcW/lKpGvWc8RH/pegZVlt9TPZipr1HKHmwXOESuE5QqXwHKFSeI5QKdM9R+bPX4ihISsIulE7smDbFjzPBxAmdvT0zMHcuQtqEmRtqoBbtXzfxxe+8AU8//zz+M53voPtttsOd911F8477zz09/cHQbhK2baFefN6arzaxuvr62r0EqjJNd05Uvj9l0ol2vJnshU13TlCTYfnCJXCc4RK4TlCpfAcoVKmc47Mn98L13WRzWZruCJqZslkMigproWmCrj19fVhdHQ0cv/w8DD6+/tjn3frrbfib3/7G/74xz9ir732AgAcdthh2Lp1K84///yqA26e52NkZKKq5zYjx7HR19eFkZFJuK7X6OVQE2rWc0SUkk5OZTE4ON7g1cxuzXqOUPPgOUKl8ByhUniOUCk8R6gUniNUiukcmZx0Sz6vr6+r7MzJpgq4LVu2LNKrbXR0FAMDA1i2bFns85555hk4joM999xTuX+fffbBtddei8nJSXR1VRfZzuXa74fTdb22fF1UO812jgQ93JpsXbNZs50j1Hx4jlApPEeoFJ4jVArPESqF5wiVUs9zpKmK3o855hjcddddGBkZCe7729/+Btu2ceSRR8Y+b4cddoDruli1apVy/5NPPokFCxZUHWwjouYQDk1o7DqIiIiIiIiIytFUAbczzjgDPT09OPPMM7FixQpcd911uOCCC3DGGWdg8eLFwXbvfe97cdJJJwXfH3PMMVi6dCnOOussXH/99bj77rtx4YUX4ve//z3e9a53NeKlEFEN+b6vfCUiIiIiIiJqZk1VUtrf34+f//zn+NrXvoYzzzwTPT09OP3003H22Wcr23meB9cNa2t7e3txxRVX4Hvf+x6+/e1vY3R0FDvuuCPOOeccBtyIWpzv+8HMGMbbiIiIiIiIqBU0VcANAJYvX44rrrii6DZXXnll5L5ddtkF3//+9+uzKCJqGDnGxgw3IiIiIiIiagVNVVJKRBQhxdjYw42IiIiIiIhaAQNuRNTUPCmrzQcjbkRERERERNT8GHAjoqYmV5GyopSIiIiIiIhaAQNuRNTU5L5t7OFGRERERERErYABNyJqanKIzWMTNyIiIiIiImoBDLgRUVNTM9wauBAiIiIiIiKiMjHgRkRNzVemlDLiRkRERERERM2PATciamrMcCMiIiIiIqJWw4AbETU1OcbGoQlERERERETUChhwI6KmJsfYGG4jIiIiIiKiVsCAGxE1NblvG3u4ERERERERUStgwI2ImpqS4cZ4GxEREREREbUABtyIqLkpQxMYcSMiIiIiIqLmx4AbETU1jxluRERERERE1GIYcCOipuYzw42IiIiIiIhaDANuRNTU5Bibx3gbERERERERtQAG3IioqflghhsRERERERG1FgbciKipcUopERERERERtRoG3IioqbGHGxEREREREbUaBtyIqKmxhxsRERERERG1GgbciKipyTE2ZrgRERERERFRK2DAjYiamlpS2sCFEBEREREREZWJATciamqeMjSBETciIiIiIiJqfgy4EVFTk4Ns7OFGRERERERErYABNyKq2o33vYiv/Ow+jE1m63cQOcMNjLgRERERERFR82PAjYiqdve/NuHFTWNYs2G4bsfw2MONiIiIiIiIWgwDbkRUNVHuWc9ST5893IiIiIiIiKjFMOBGRNUrxL/8Okbc5DJS9nAjIiIiIiKiVsCAGxFVTQTAmOFGREREREREFGLAjYimIR8Aq2cgjAE3IiIiIiIiajUMuBFR1UT8q55hMJ9DE4iIiIiIiKjFMOBGRFUT8a+6ZrjJtxlxIyIiIiIiohbAgBsRVS2cUlrPklIOTSAiIiIiIqLWwoDbLPePB9biM5fciY3bJhq9FGpBQUnpDA1NqGdgj4iIiIiIiKhWGHCb5R5ZvQWDo2k8s2640UuhFiSyz+o7NIE93IiIiIiIiKi1MOA2y2WyLgAg53kNXgm1orCHWx2PwSmlRERERERE1GIYcJvlMrl8oM11Gcigys10DzfG24iIiIiIiKgVMOA2y4mAW85lhhtVbiZ6uMlnJjPciIiIiIiIqBUw4DbLZXOFklIG3KgKIv7FKaVEREREREREIQbcZrlMliWlNB1iaELdD1E4Ds9TIiIiIiIian4MuM1ymRyHJlD1vKCktH6BME8JuNXtMEREREREREQ1w4DbLOb7PrJZ0cONkQyqXn2nlPrG20RERERERETNigG3WSzn+kG1Xi7HDDeqnDcjU0rl49XtMEREREREREQ1w4DbLCbKSQEgx0gGVWMGppT6YIYbERERERERtRYG3GYxMTAB4JRSqo4IgNUzEOazhxsRERERERG1GAbcZrGslOHmMuBGVRDxL/ZwIyIiIiIiIgox4DaLZXJyhhsDGVQ5fwamlCoZbnU+FhEREREREVEtMOA2i7GklKbLn4mhCSW+JyIiIiIiImo2DLjNYkpJKYcmUBX8mRiaoO2cGW5ERERERETU7Bhwm8XkktJsjhluVDkR+qpnhpu+b8bbiIiIiIiIqNkx4DaLySWlHJpA1QinlNbzGOZjEhERERERETUrBtxmMbmkNMeSUqpCOKW0nhE39VueqkRERERERNTsGHCbxdQppcxwo8qFQxPqd4xoSSkjbkRERERERNTcGHCbxTJZaWiCyyAGVSEYmlDHKaWRktK6HYqIiIiIiIioJhhwm8WyzHCjafI4pZSIiIiIiIgoggG3WUwtKWUQg6ohhibUMcNN+5493IiIiIiIiKjZMeA2i8klpTmPGW5UOZ8ZbkREREREREQRDLjNYkqGW44BN6qciH3pgw3qcYy474mIiIiIiIiaDQNus1g2J2e4MYpBlRPZZsxwq95vb30W37nmYbjMMiUiIiIiImobiUYvgBpHznBzOTSBqiBCX+zhVr3bHlmP8akcNm2bxNKFPY1eDhEREREREdUAM9xmsUxWHZrQbplDVF/y+TKzJaXtdZ7ORFkuERERERERzSwG3GaxjFRSCgBuu6UOUV3JZ0s9Y0V6IKrdAlM+6l+WS0RERERERDOLAbdZyPN9vLBxFJPpnHK/6/KKnyognS51LSlt86EJIs7dbpl7REREREREsxl7uM1Cdz+xET+6/snI/TnPQwecBqyIWpGnlJTW8UBtPjQBLCklIiIiIiJqO8xwm4We3zhqvD+X4+AEqk49g2B6MK/d4lIzMemViIiIiIiIZhYDbrPQtuEp4/05lpRSBeQgWz2DRT7au4ebxww3IiIiIiKitsOA2yy0dSQm4OYxw43K57OHW00ww42IiIiIiKj9MOA2C8UG3EpkuPm+Hxm0QLOXHCCqZw83PZjXdj3cCjxOCSYiIiIiImobDLjNMtmci+GxjPEx1y2e4farm1bjrB/cgXUDY/VYGrUYudRTL/us6XHaPMPNCzLc2uyFERERERERzWIMuM0yWw3921LJ/GlQKsPthY2jcD0fazcz4EZ6SWk9j9PePdzEy2mzl0VERERERDSrMeA2ywwMTkbu6+pIAAByJTLcxONZTjMlaCWldSyHbOcMNzmY2G6BRCIiIiIiotmMAbdZZmAoGnDrlgJurudh/cCYsbzNLQRV0lm3vouklqCUlNZzaEKR47Y6+ZUw3kZERERERNQ+GHCbZQaGJgAAh71sMRbN68LypX1IJRwA+ZLSv9z9Ar700/twz5ObIs9lhhvJGlVS2k6BKfm1sYcbERERERFR+0g0egE0s7YM5Xu4LZ7XhQ+etg8sWPjmVQ8CyA9NWDcwDgDYsHU88ly30OMtwww3wsyVQ+rVqu1UejlTk16JiIiIiIhoZjHDbZYZGMxnuM3v64Rj27BtCwmnMDTB8zE+mQUATKRzkee6Xj6zLcMMN0JtyyHvf2ozbnlonfk4syTDrZ0CiURERERERLMdM9xmGTGldP6cjuC+hGMByJeMjhUCbpOGgFuOGW4kUUtKpxcs+r8/PAEAeNmu87FkfneJ47ZPYKqW7yERERERERE1D2a4zTIj4xkAwJzuVHCfIzLcpIDbxJQp4MYMN5LI/cdqtMvhsXTkPj3zq53iUjPVB4+IiIiIiIhmFgNus8zYRD7g1tMVJjeKklLXDUtKTRluYkopM9wIUHuO1aocUmRRyvRdt1MmmPy+eWziRkRERERE1DYYcJtFMlk3yE7r6UwG94uS0sl0Lni8eEkpM9xIVasYmMiiVPet7ryd4lJKhlvjlkFEREREREQ1xoDbLCLKRR3bQmfKCe537PxpMDSWCe4rNjQhm2OGG6mBsFplnZkDbvHHbX21fw+JiIiIiIio8Rhwm0XGC33ZerqSsCwruF9kuA1J/bP0DDfP84PAR5o93Aj16T9WXklpbY7VDOpRlktERERERESNx4DbLCL6s/V0qsNpRQ+34fEww20q7SoBADnzKMuSUoKakTWd/mN+zHlmetz0fStTsgT5Y0VERERERNQ2GHCbRURJaW9XUrk/CLhJGW4+gCkpy82VAiqZNiwpffK5bbj1kfWNXkZLkcNe0wmCyc80Bty079u1hxsz3IiIiIiIiNpHovQm1C6CDLdIwK1QUipluAH5Pm7dheEKciCkHYcmXH7DSgyOprHvrvOxoL9TKbklMyXDbVo7Cm+aS0rbOMNNvt0+L4uIiIiIiGjWY4bbLDI2JUpK1YCbU8hwS2fUzLXJdPi9HAhpxwy3qUw+m29oPIMv/vgeXH7DygavqPnVLsOtVElp8e9bmRK0bKcXRkRERERENMsx4DaLjE+KoQl6DzdzNtdEIUAHhBNKASBT5tCEdZvH8Ln/uwt3Pv5S2Wt8cdMoXto6Xvb2tSJe3rqBMWwanMSjz2yZ8TW0mloNTfCVDLfZ1sNNvt0+r4uIiIiIiGi2Y8BtFhElpb2d5h5uOjnDzZUz3LJuWcGBlS8OYsvwFB5ZXV7wKp11cd5VD+L8Xz4048EH0aMuU8jycw2ljaRSGv5PJ8OtVEmp9n179XCT38MGLoSIiIiIiIhqij3cZpGgpFTv4WabM9wmpaEJOU8NDLieH5sZFzynkK1UbqncVMZFJushk/Xg+8BMtlETUzbT2XzALee1X5+6WlMb/k9rT8EtZrgRERERERFRO2CG2ywSNzTB0TLcnEIAbkKeUqoFQjLZ0n3ccoXSU7fMaIwnbTeT/ax83w+Oly4MhGCGW2k16+FWoqRUP33a6ZNRe7g1cCFERERERERUUwy4zSJjoqS0RA+3hf2dANSAm17qV04fN/Ecr8xIghJ8mMHogxzwERlurucz46iEWpVDyk8tZ0rpTJ4b9Sb/FHFoAhERERERUftgwG0WCYYmlOjhtt3cLgBqSanrVZHh5laY4dagiY3y+tLS6yp33bNWrcohS2S46Slt7RQIZQ83IiIiIiKi9sSA2ywyPiUy3NSAm8hoA4BkwsbShT0AtB5uVWS4ZUUPt7IDbtLtGWyhJq9PDiQagz8U8GqW4Va8h1ukpLSdAlPKOd9OL4yIiIiIiGh249CEWSLnepgqTODUe7jtudNcnPuegzEwNIntF3Rj1dohAMDEVLEMt/JLSt0yIyR+M2S4ZeSAGwMg5ZrO5yU/1dQ7z9dS3Nqp9FIJWrZVdzoiIiIiIqLZjQG3WWK8EDyzLKC7I6Fk01iWhWVL+7BsaR8AYO3mMQD5DLdN2ybw29uexY7b9Sr7y+bKH5pQdoZbg4YmyMdiSWn5ajWlVN7P2GQWX/v5/dh/+UK84ajdIo+bvm9l6pTSxq2DiIiIiIiIaosBt1kimFDamYRtW0WDYF0d+dNiMp3D9659FJsHJ/HgqgFlm3Q5GW5epT3cwtv+DAa7PKWHW/i69MmspJIzsqbXVy187hPPbQMAPPfSqBRwU/fdvj3c2ud1ERERERERzXbs4TZLzOlOIpmwsXzH/pLbdhcCbmNTOWwenDRuU0mGW7nBM7WktKyn1IQ7gz3cfN/HfSs34ZLfPY4XN43WfP8zSc3OmkZJaQXHKWf7ViK/FvZwIyIiIiIiah/McJsl5nSn8P2zjsL2i/sxNmoOogliiMLW4fjt6tHDTSkpbViGW31LSi//y0rc+cRGAMC8vg68Y/Gcmh9jptSqHLLUc/VgXjv1cGNJKRERERERUXtihtssMqc7hWSi9Ec+v68TCccuOjQgU0aGW6VTStWeYI3v4VaPoQn/emEwuG0aENDMxiazymc5U+WQ7d3DrTF9C4mIiIiIiKi+GHCjCNu2sHh+V9Ftyspwy1Xaw61BQxNiMtzqUVLaqMEQ07V5aBJnX7wCl/3lX8F9SjnktDLcij9Zf7Sdep0xw42IiIiIiKg9MeBGRkvmdRd9vJwMNzE0oewppUrGVFlPqQm1h5s8NKH2i/BmKCus1jZuHYfr+Vg/MB7cV6sMt0pLSlvobStJHjzRSgFYIiIiIiIiKo4BNzJasqBEwK2sDLdCD7dyS0qlXTaqh5vM9eqc4dZCQ1DFWv2YoOi0eriVelzboJ0CU8xwIyIiIiIiak8MuJHR4hIZbtlcOUMTqs9wKyeo8scVz+H2RzeUte9yjyurRw83N6YHWrMT75G84pr1cCvxXP3zaaG3raRWzXgkIiIiIiKi4hhwI6NSGW5praT0D3eswYVXP6z0PRNDE8rOcJMDbiWeMzSWxh9WPIerb15d1r6LiVtfXXq4tWiTfPF5xC15Wj3cKt2+hd63Uho1KISIiIiIiIjqiwE3Mloyv0SGm1ZSeuvD67HyhUGlx1fFGW5K9lfxbUWGXSZbupdcJceVlRsorPZYrRRfCTLclIBh+Hg9e7i1c4YblPewccsgIiIiIiKi2mLAjYx6u5Lo7UpG7k84FoDo0IR0IQCWkxqTiZJMt8xIghzCK5XtEwaApp8ZNKMZbnKfuhaKsIi1Km9VTPCt1sRhbMsqfN8671sprZrxSLXheT5WvTioTEcmIiIiIqL2wIAbxXrd4btg2dI+5b7ujgQAIJ1RLxBzhYCbPNlT3FduhpuvDBQoEXCrYNtSYjPcatzDzfd9LcBS093XlW8YmiCHI6eX4Vb8ueJx284H3NopMBU3hIJmh/tWbsK3fvUwrl/xXKOXQkRERERENcaAG8U6+dCd8V9vP1C5b05PCgAwns4F97meF2SJua6c4Va/oQnyLqdb+hk/NKG2GW76YfwWiriZSkprVQ5Z6rnicce2lO/bAXu4zW5DY5nC13SDV0JERERERLXGgBsVlUyop8hcEXCbzAb3yRNLc1IQKVtxwE26XeI5lWTDlTzuDPVw0/fXSgEW09AEX4q4TSvDrcTYBD3DrZ1KSmMqdGmW8P3ozxUREREREbUHBtyoKNuylKBbf28HAGBMCrhlctGsNtfzgotIH+UFl5QgWgWN9KcbGJupHm6t3PzfMwQG1Oysaey8zAy3Qrytpd63UtSS0jZ6YVQW8YnzsyciIiIiaj8MuFFJKSXgls9wG5vMBkGYnBRwE33Pclr/s3Ky0Ewlpb7vG59by4Bb3Nr01zBd+nFaKsMtCJ6ae45NL8OtxOOFfTtt2cMtvD3dTE1qPeLc5kdPRERERNR+GHCjklJJJ7g9tyef4eb7wGShj5spw03PDisnKKYEcArbf+83j+Lcy+6N7E+Z9lmnHm6uV9sMt7YrKa1Rw/+SAbfCV7ste7hxaMJsFmQB88MnImpJrfS3HBERzTwG3KgkuaS0I+WgI5UPwImyUqWHm8hwy+kBsuoy3P71/CA2bpvA4Gg6dtvpBsbigoG1nlIaKSltobQWL8jEkQJE0uPTChiUnFKa/xoMTSgZomsdNXsPqSWxhxsRUeu64Z4X8Mkf3IGXto43eilERNSkGHCjklKJMMPNsS3M6UoCAMYm8gG3TM4NHs8Vgl/ZKjLc1IBbPkgn7otkh3lywG16mWOxJaU1znCLlpTWdPd15Yc1peF9WvCtkoDR8xtHsH5gTN+lQp+MalntneHWSucD1QYz3IiIWtfK57dhfCqH514aafRSiIioSTHgRiWlkuFp4jgWekTArZDhVqsebr4n3/aVMlJXC+ApgQpp37c/ugEf/97teHrtUMnjBftuUA+3VrrI9kyBAW355b6adMbFN696CBdc/XBhn+bt9P5W7djDzYsJYNLsEA5NaOgyiIioCvwdTkREpTDgRiXJQxMSto1eLeCWyUUDY9X0cNNLSpWAW5kZblf89SlMZVxcev0TJY9nOq6y5noPTWihlCZPC37pt4HyX89kJodszsPoRBa+78cGmsK78zfavYdbOwUSqTxhUJmfPRFRqwmzlBu7DiIial4MuFFJ8tCEhGOHJaWmHm6eyHCbbg83NcMsWjYa3jYFxkRwphwzVlKq/UVW273XVzg0Qek6pmxT7h+cRZLktO3MGW5tlQmmZLg1bhnUGLxYIyJqfe3UW5aIiGqLATcqSc5wM5WUKj3cRIZbTv3jwy3jilLexNNLSov0aTNlhzg1CLjpZazTpb+GVhya4BcJEJUbCFMnc/qxwQa9jNVuwx5uasZgG70wKou4SGurIDIR0SzBwTdERFQKA25UUlIampCwrUhJaTYbnVKqD00oJ7gkB74iJaVFMuZM5aq2Xf6pPXNTSot/38yCDDfpX3H15Zf7B6f82fl+kaEJnvqHrMhabKVS3FLU4GMDF0INwaEJREStj7/DiYgoDgNuVFKHMjQh2sMtawiMVdPDTR+EkC1SUir/bWPKRKsowy1mabkaB3aiU0pb5w+0MNssvE//A7Pc1yN/Wr6P2EiTXm7ntGMPN/l2O70wKov4yNsohkxENGsEf6c0dhlERNTEGHCjkuQebo4TZriNi5JSQ4ZbdT3c5Nu+EkgrWlJqynCzatDDrcYlpa08pdRUNhEtKa1sX+J27JRSUW6nDU3w2uhPW2a4zW7hzxU/fCKiViN+c/NXOBERxWHAjUpKxkwpHTVluHkiw03r4VZhSanv65lzfuy2pv5wjlN+wM2NGY5Q+5JS/TXUdPd1ZRqaoAcJym0arA9NiHuWnuHWjj3clL6F7fTCqCz8xImIWhj/0YSIiEpouoDbs88+i/e///044IADcOSRR+KCCy5AJpMp67mbNm3C5z//ebzqVa/CK17xCpxyyin44x//WOcVt7+4DLdwSqk8NKGQ4ZbTMtzKGpqgZq25Sklp/P5MgTG5pNT3fdz68Ho8vmar8bgzNaU0Whab/35sMourblyF514aqenxakm8354WLJNV18PNj/1D1dP+kLXbcEqpcs630eui8uiTeImIqHUww42IiEpJNHoBsuHhYbz3ve/FrrvuiosvvhibNm3C+eefj6mpKXz5y18u+tzNmzfjbW97G3bbbTd87WtfQ29vL1avXl12sI7iyVNKE46NrlT++/HJLHzfRzYX7eGmD01wPR+u5+HG+9Zi713mYbft+yLH0UtKs9MpKZUCbnc9sRG/+PsqAMDl55xQ9LjKmmud4RbzGn5767O4/dENuOWh9cb1NQMReyyW4VZuwKhYGeWBeyzEw6u3KI8FPdycdgy4mW/T7MChCURErSsMuPF3OBERmTVVwO2aa67B+Pg4/vd//xdz584FALiui69+9av4yEc+gsWLF8c+98ILL8SSJUtw2WWXwXHyGVmHH374TCy77ckZbvKU0pzrYyrjIiMF3MSgAVMPtz/c8Rz+cvcLSCVtXPqZ4yLH0YNobpGSUl/avalc1ZF6uP3u9jXFXl5suWu9e7iJbzdtm6jpcerBFEyrvoebfDvs4Ta3N4VPvPkV+I9v3QLfj5axis+0nbKB5DLcdpq+SuXRg8pERNRCODSBiIhKaKqS0ttvvx2HH354EGwDgFNOOQWe5+HOO++Mfd7Y2Bj++te/4h3veEcQbKPakTPcHMdGKmkHJZuT6ZyS4ZZz43u43fTgOgDqkAWZWl4HZHPh93p5p1JSWiTDbc2GEQyOpou8uvhARzl95yqhB63E6+1INf85G5aUxmenlfsvvMo+pPutQkAt7NWmDmpoz5JS+Xb7vC4qD4cmEBG1Pv4KJyKiOE0VcFuzZg2WLVum3NfX14ftttsOa9bEZyk9+eSTyGazSCQSeNe73oWXv/zlOPLII3HhhRcim83We9ltT+/hZlkWujryyZETWsDNjZlSOjSWRjoT9nozXWDqvb3kvm2RklLpe1PATAQEH3p6ILgvETNIodZTSh95Zgsu+d3jQY+7uOOI7ztbIODme2rwC4gOSdBf35/veh4/+dOThkCjelvsRyQlWtpwBPH8MOBW/etoNsUCmNT+xEfO5EYiotYTTFPnf8CJiChGU5WUjoyMoK8v2turv78fw8PDsc/bsiXf8+ncc8/FW9/6Vnz84x/HY489hosuugi2beMzn/lM1WtKJJoqJjktjmMrX8vV2REGhDpTCSQSNro7ExibzCKT85TAlOv5SCTsSPDlgVWble9zno+uDi3QJJWBwopmhCmfhbat/jk5jo1EwsbIRNjDz/PMn6cfM9BUvJZK3fzgOjz53DYc9vLFeNXLl4TLtKMHSiTsIHgpvm+kuHPEV7bJB11tS309duE9F/567wuYTLt407HLsXh+d3C//D7YthUE0ixYSCRsiIdtx1L2l5DW1Oj3qVb097AVXle1v0coSv74W+GzLxfPESqF5wiV0hrnSCEz37ba6nd4q2iNc4QaiecIlTIT50hTBdyq5RUyoY444gicc845AIBXvepVGB8fx+WXX44zzzwTnZ2dFe/Xti3Mm9dT07U2g76+roq2XzAv7DG2YEEPOlMJzOlJYfPgJJxkAr501WgV3jMnqQbTnnxuUPneSiQi721HR1K5nepIBd+nOpLK9l1d0rad+cfkIF9XZ37/E+kwq87zfcyd2x1kUAnJpDnDzPdR3edf2L9YV7jm/BTShGMFJbfz5vWgf054bvbO6UQy0fiMN/0cSSbDXxX9c3vg2Ba6ujsiz5k3LwysiY+jp7dTeR96R8IS377+LqQL8VrHyZ87IgCX319PEKDr6kwGa2mXn0v5PbQdu6VeV6W/Rygqmcr/XNkO/1tDsxPPESqlmc8R8Q+BndrfezSzmvkcoebAc4RKqec50lQBt76+PoyOjkbuHx4eRn9/f9HnAfkgm+zwww/HpZdeihdeeAF77bVXxevxPB8jI83f0L5cjmOjr68LIyOTykCCUtJTYZbY2OgkJm0bqcIfGZu3jGFSKp2cSucwODiOsXG1b1om6yrfr90whE4trjQxkZZuZ8LRmADGxtIYHBwPv5f2P1p4TD6G63oYHBzHliH189u2bVyZYAoAE5PmsuNM1lWOWa5MJgcAGBmZUp4/PDoFAHBsGznXRa6wRtcN173upWHM7VUDWTMp7hyZnArfo23bxpBwbIyPTynPHRoaR8qSSn0LQcWhoQn0psJ/NRgemZSeM4GRkfx+PM9X3q+hoQl02IBbKFnOFj7fdDpb1efSjOT3sNrzbaZV+3uEotKFn6tsi3z25eI5QqXwHKFSWuEcyebyf5eMT2Ta6nd4q2iFc4Qai+cIlVLtOdLX11V2VlxTBdyWLVsW6dU2OjqKgYGBSG832e677150v+l08ab5xeRy7ffD6bpeRa9LnvjpuT58zwv6jo1NZpGWAl3ZXH7fcYMRhMHRdGQN8qCFXM5DJiPv11W2l/vGZbP5x6bSueA+q7CP4fEwWAjkgxoJ7Ycj7r3IVfg+CaLfnHgv9OMkHAvpbD4DLJfz4ErDIUbGMujtTKLR9HNE7qeXy3mAH50cq79eURKcybrG9wEAstnoeyQyEMXzxH7Eaeh6ftv8XMrnvNdir6vS3yOtyvd9TKZz6K7Dz6X4XeF5/G8NzU48R6iUZj5HRO+2Zl7jbMD3n0rhOUKl1PMcaaqC5mOOOQZ33XUXRkZGgvv+9re/wbZtHHnkkbHP22GHHbDnnnvirrvuUu6/66670NnZWTIgR8V1FEouE4XeXQDQ3VkYmjCV1YYmiCmlxU9YubeaoE4p9ZGVe8NpwR1fKh8NAlzSNrZlwfN9jI6r2WumyaPxQxOqa4IrjqEfSwStRDRcHFd+ryamcmhG+kAL+Wt4v/Ycbcpo3L7EdyKgJhIQxfPE405bTimNvq/UXH5102p88qIVWLd5rOb7Dn6WwM+eiKjVBH+n8Fc4ERHFaKqA2xlnnIGenh6ceeaZWLFiBa677jpccMEFOOOMM7B48eJgu/e+97046aSTlOeeffbZuOWWW/CNb3wDd955Jy699FJcfvnleN/73ofu7m79UFSB+X0dWNDXgd13CMt6RaP/ybSLjJyhJIJIMRHi/t58X7bR8WjAzdMCbnKQLadP+JS+9QzH9Hwf45PZyOAFU3BN30YwBefK4cUE3PzC8sS01OBfRqXtJtLNOVVXeb+1QJigB4/0KaPhY/oT81+sQvPhcEqpGrBrxymlvvK+ttELayNrN43C9Xys31L7ciFerBERtS5f+0pERKRrqpLS/v5+/PznP8fXvvY1nHnmmejp6cHpp5+Os88+W9nO8zyl7xUAnHDCCfjud7+LH/7wh7j66quxaNEifOITn8CHP/zhmXwJbSmZcPDNjxyu9D7rDgJuOeRy4WchsrWyMRlu8+d0Yngsg5HxaGBJqlqE5wFZX8pw89T9ycEJ15Ap5nk+RgpBvc6Ug6lCeaopi0gPwllW/gK42lp/sTZ9v2KdoqRVPCy/tvEmzXDzjRlu6jbyy/WV+/WAmxpYFdk9sRluhRtiomc7BabUIGUDF0Kx3JiMzlrQz3EiImoh/B1OREQlNFXADQCWL1+OK664oug2V155pfH+U089FaeeemodVkV637MuKeCWMZaUmv/4WNDXgedeKq+kFFK8Sy8p9YwlpXKGG4KA27w5HXhp64SyrUy/ryOZD9BVW1IaZriZg4TivQx7f0gZbk0acPMMgaFoSanajyy4X4tbKoE5Xwo0WWqGm16S6rR5hhv/YG9O4lyuR6BXBJurTKYlIqIGEr/D+Z9vIiKK01QlpdQ6RMBtIp1TeriJIFVcD7f5fZ0AgFFDwM3TAjZKDze9PNOQ4Savw/N8DBeO0d+Tko4RXZOeiSZ61nm+X9VFdlxJqbg/YasBJXm78akmLSn1TAE3dZu44FGxDLd86Wkhw61wnxWX4Wa3d4Ybgy7NScTN63HaMcONiKiF8Xc4ERGVwIAbVUUuKVWGJhjKO2Ui4DYyYSgp1fpZuUUCbsYebq7aw21kLB9w6+tJBdlR5fRwEwE3IJpZV45w8qC+5vz34dCE/P1yf7rmzXALbwf/oqttExc8ir4P8r5CItAWl+Emet+1U8BNzfZrn9fVTuJ+nmshbgAJERE1v6CHG3+FExFRDAbcqCoiw21sMqsEw0TQSwwwcKS+b0C+pBQIyz1lSuaTB21KqVaeqZSUqscE8kEZkeHW150KgzjllJSmwoBbqWmrJqZhCPL3kaEJrtzDrUkz3MooKdUzFE33689TSkoLbEstHRUBPsdWp7u2mzZ9WS0v6MlYl5LSwld+9kRELYuTpomIKA4DblQVEXDTA2eipDRb+JqSssWAMMMtH6jLB5ompnJYNzAWCdLI2WXRDDdTDzc5YBcOTejrSaEQqzFeNMeVlJqOWw7xnNiS0mBoQnS7ps1wMwTQqi0pVYN34Z+pVtDDTd2H3sOtnQJuenktNR/x88mSUiIiknHSNBERldJ0QxOoNXR15INS+lRN1/Xg+z7S2fxU0J7OBCbT4TZzezuCKaBjE1n093bgCz++G6MTWSxd2BNs5/vFe7iZsqlykaEJ+Wyxvp5U0QmX+r6TCRsW8tkn1Uwq9WJK0MKSUjWDS+3h1pwBN9M0Tf1fdJXPRCkp1fel3dZ6uEUy3IKS0nygspogaLOKywqk5uEVTuC6ZLgF2XM13zUREdVd/f5BhoiI2gMz3Kgqooebzkf+wlQE2bo71e1SSTt4rggujRb6uW3YMh5sF8lw0wJf8uRLU984T8pw6y/Rw03PLkk4dtBnrZpJpeIQcZNVE7Ytbav2qpto1pJSZWhCEHFTyG+jGnwrVlIqZ7ipX8NMOjVQ2U493CLBR2o6ImBcnx5u4is/fCKiVhO2BeDvcCIiMmPAjarSpQXcRFYSkA9STWVEhltS2S7h2EgmRDArPnvM03u4lVNSqvVwG53MB9zmVNjDzbGtoM9aTk/PKkNQUqqXUmo93ID8H2nK0IR0c2a4eYbAUKnebMHtYkMTlB5uoqRU7XEntk+0Y0mpcrt9Xlc7iSuhrgW9bJqIiFqI+d8fiYiIAgy4UVWSCVsJHIkSUyAfSJsqBI56tAy3pBRwkwNkupJTSuWeYjFTSkV2WiphwxbBGsNfRXoAJ+FYQUZcdRluoqRUfX3B0ISElOHmqZlwzVpSqvddM1Ey3MocmuD5fhBoEjHb6GclMtzar6RUeS/a6HW1k2BKaT2HJtR8z9SMmAVD1F6Y4UZERKUw4EZVsSxLyXLrTIW3J6ZywR8h3VKGm2NbsG0LyUQ+OJfNebFBN0/v4aZPKTVkuMnBMc8LAxi2bRUtKRXPTxUCYY5jh/3CptHDLVJSGmRqaSWlUmAunXGrmoxab2pJaeG+SEmpOSinbxcJXBS+FeHbuKEJIsDbToEplpQ2P6+eATeWlM4anu/jvKsexA+ufbTRSyGiGmGWMhERlcKhCVS1ro5E0H8tlbTh2BZcz8fYZP4+y1Iz30QQK1n4mnU9TGXMGV2e5ysBtGhJKSKP6SWlrhRws7W+YOq+8vclEzYyOQ8JqaS0mmyqIOBWZkmpfoxM1g3eq3r4813PY2Q8g3ectGfZzzFmuEWmj5q31wNkcv8935eye0QPN6hDE8S+2nFoQjNMKfV9Pyjjpaj6TinlxdpsMTaRxbPrRwDkf6fZ/Jkjahv8HU5ERHGY4UZVkzPc+rpTQUBEBNy6Ugk4UjaXCDQlEvmv2ZwX9HrTeb5aIlppSanv+UqGW7EebuK+VDIfHHQcK1h3NdlmpaeUxpeU5rer+JAVuX7Fc7jpwXUYGkuX/Ry5OlbcjCSqxWS16YEkfaCC+FYE2uyYDLdiWYqtSh00MfPHXzcwhk9fcidufXj9zB+8RYQl4sxwo+opnzE/bqK2wN/hRERUCgNuVDVb+gf641+5QxBQGytkvXV1OEE/LgBB77akEwazJmOGBPglM9yiAbe4DDfHCktKTdlR4r6kVFIqJmJW2sPNk6Zuxk4plTPcoJaUytvVi2mqaynqxWIhEBbZRrpdtIebflvt4RYER331uM3cw23d5jGs2TBS8fPkQQlxf7CvfH4bLr3+CYxMZKpeX5xf/H0Vhscy+MXfV9V83+2iviWlYt813zU1mbgMYCJqXezDSUREpTDgRlXbsGUiuH3wXouCoNZoIcOtM5UI7gOkklKph1t8hpuPXE7u4aaXJYbfi0mi6tAEtYebCPyZghpBhlthXQnbDrL3to1MGdcXRw6WxWXlJZQMt2hJaT0DStU26VdLSqP7iuxbOU6RfcEPLkTDgFu4nXyEoIdbk12s+r6PC65+GN/61UNIx5zP8c8Nb8d9HDc9uA73rdyMx57ZOo1VxhyfkZ6SxM9JXUpKxdcmO6ep9uKmOBNRCwsy8flDTUREZgy4UdX+/ejdYFsWznzjvvnBBEFJaT4TpzMuw02aUlq0h5snl5TGD00IMtzkgJvnhyWcthX0yzGWlPqipFRkuFl42a7zAQAPr95S5B0wrztcsxZIk9Yj+H58Jlw9mIZNlPU8Q8aa/velWipqvj//PO3CM/i2UFIqBUflbcWwiWbLcMvmPIxNZpHNeZiIydiMU87012oyEstl2ewjVYzcY7G+JaU13zU1GTWzlx84UTsI/9GkocsgIqImxqEJVLWTD90Zxx6wNJhQGpSUTuaDDl0xGW5iu5I93HJFerjJAR3DlFI5OCFnuJmumcXzD9l7EXI5D6/cYzskEzb+fNfzeGLNVqQzLjpSTvSJxnXLgUBzqWi+p1z+DzS59NW0j1rzDe9bOYwZboj/TMovKfWD/egZbr6vbus06ZRSZZquns5XShllZuL+egQa2bi9OL+Mz2da+wezI2YLZrgRtS/+SBMRURwG3GhaRLANQGRoQmfKUS7o9Qy3Yj3cPN9HTs4WK5IFJraTA3RywE3OcCvWw22fXebh5EN3BpC/OFrY34ktw1N4fM1WHLz3IuM6I+suo6TUtvLrcQsDA6bTwy3nerjx/rV4+a7zscuSOSW3ly/6Kstwi+6j+NAE6eJSn1Iak+EmzhTRw82XBioA4fnVbAG3TDY+MFyKoTVe7Db1eN1McCvOFGiupXASb+33Tc1F/i3fbGXxRFSlmBYbREREAktKqWbEZM+xCVFSWrqH22TanOHm6z3ctKCUqReZHGSTs93yGW6FbYv0cJPLXy3Lwiv33A4A8MRz24xrNHHLCLg52tRUfTBDJUGbmx9ch9/e+iy+esX9ZW1fbeNucw83dZu44JH+cvQJplpFafBLKZ/hFm5cbPBFI2Vz4TmsB4ZLKaekNGysX4eAGyNuRblFMjVrIQxeN9c5TbXHDDei9hNmKTd4IURE1LSY4UY1YyopVXq4FR4XU0qzrhdfRqcNE8jpwSvpW7GdXNon37YtaWiCsYdbuJ1sYX8nAMRm4RnXXaRkU7zWIADoFkpK9ey9Cv5yW7t5rOxtgWlkuCmDDsTX+Mw1U489476kslGrEHELp5SqGW5Ok2a4ZWMyK8vR+Aw3BtyKUXoXsocbTYPys84CNKK2EDdEioiISGCGG9VMQhua0KUNTQh6uCVK93CTgxhA8ZJS8ZhSUpqrvKTU0bJ9xHorCaIUHZoglZTKQSV5uIO+j1IqzVCqtoebHKiMLymV9h0TfNO386WaUtOUUvm5iSbNcMsU6TVYinzhHfd5iPe7Lj3cYs6fzYMTWL1uqObHazWuct7Xfv/McJs9mOFG1L74M01ERHEYcKOaCTPcRA83taQ06OEmZbjFTSlNZ7WAW5EsKXE755oDH5YVZvKUW1IKhE36q53mGTfowZYCgHJgMJGofAqnHiQsxVSKWw61DFTc0LeRLig98/36cX3IGW554ZRSdf9NOzRhOgE3JevFHHgRu5zJDLeLr3sc5//yIQyNpWt+zFZims5bD3GfPbWPeg/gIKKZFzdEioiISGDAjWpGBH9ET7LODnVoQkIbmlCsh5vcFwswDBYwlEZmDf2zRL+0cEpp5RlubgUZbm6xUkopsCcOJZe+pgrvSyUXY5VmuJlKcct6niHwUCxzrVhJqfyHqe9LcTtLLSnND02QMtwKn4dvOHYjKQG3iktK9ffGuBGA+rzmuIrS4fEMfB8Ym8jW/JitpN493JRAds33Ts2EGW5E7cic8U9ERCQw4EY1I3psCV2p4kMTckVKSjMlSkrlEkcR5DCVfoqAlF2kXFNcCFlWXElpjTLcDEMTcrlwGxGIrCSTyamwB1exQFi5z4vvNRYtO80/V99OfU7w/hfuEy/J99XnJqTzq5my3DJScFjvNViK/l6aXpc4q+tRUhqXISnW0UyBzUaod5Ak7meG2k+0lJ6IWl2Q8M+faSIiisGAG9VMQgu4daYcbWiCKCkNe7hNxpSUZrJ6hpsfG8QRQQG97xsgBdyCqaDq477vx2e4iYw9/UlFqAE3c1ZevsQVhTWHr1MEImeqh5scwBmdyOAvdz+PbSNTxueZpmkW7eFm6Plmekx+qSLQZitDE8IN5M+nmQJuaoZbhQE3/XvD04MppTPYw222B9oEJcOtHkMT5Nt8y9taOf9oQUStJSwpJSIiMmPAjWpG9HATujrMPdxEaWnW9TAVW1IaDXLFZWeJi2JThpvIAHNiSkrlb6M93NQMN9fzcMtD67Bhy7hxzfq69At0ObBnFY4lymAtKwzwVZThVqMebiseewnX3bYGN96/1vg8OXYY9y+6yuejPFd/z5UwQ+Ti0wq2U/+IlV9rMw1OUHu4TbOk1HAlHkwprUtJafGA22wPDNS7hxsz3GYPZrgRtS/+SBMRURwG3KhmHLt4hltYUhr2cIsbmiBKSsW2QPzFr8gqKpbhFky+jAmC5dcfMzShEMi7+YF1uOrGp3HuZfca16yvSy8vDHq4WeHQBJHh5th2sFa3gr/c5Pe3nIu4uAy3iXT+c5hMmz8PU2BAP5o6NKG8klLPD3u6ieCP3G9PHqjgSAHdRmRg/fWeF/CtXz6EtJZ9mZlOhluRALC+TV2mlMbEa+sZ5CvXpm0TWF8kuD0T3CKZmjWh/SxQ+1ImEvPqnKgtcNI0ERGVwoAb1Ywpw00NuOVvJ5186WR+Sqk5w03oSDrBbbmXminbrawebkXKG/WJjUFJaeG4q9YOFV0rULwEzTg0oRCscRxpsEMFSVJykLCcXnNqWW70dlx2nakcqliwSJ1qGp8J50tpbOLtD4cmSM+11M+nERlutz26AavWDuHFTaPK/XKgt5LyYyAaZDFO0RXBrzqXlBbLzpxpnu/jvKsexDd+8YAxkD5j61Dekzrsn1lPs4aa4da4dRBR7YQZ/w1dBhERNTEG3KhmTD3cTCWlyYTUwy0mo0qQA25uzMWvyAgzBZzE8Z2Yck05wKGXlIZDEzzjc02KBS3EseShCWJKacK2pD5z1WW4lROYiBvqUKxJvu/7xnIofcvYYF7kfZCfBCWLDZCHJoTHta3CtNkq3qNaEdlr+rHlPnyVZrjpb6K5pLR4MHQ65CCmHLCOm0Q7UzzPx+hEFlMZN5JROKPrqHPJJydXzh71Ppem44nntuKS3z+OkfFMo5dC1JKa7WeaiIiaR6LRC6D24WgZbp0pPcNNDE3If51M50pmKnWkYgJuppJSU4abKFOMCdQUKykV6xXblJNVVWlJaS7IcLOD41eSvSUHTEyvP7I+w3rkY5qyeCKTNH3z/UpQrkjvK334ha+luJky3IKBCrYFz/UbEnCLywLMZOUebtMrKTU93VTeOTKRQV93qqJjmdhahmQqqQVYG3QN0Sz9ruJ+59SKEnvmBVtba+YMt+/++lEA+f/mfeQNL2/waohaiK98ISIiimCGG9WMnOHm2BaSCTsYWgDIGW75INroRLaMfVphIEoKKPmG7KycIcPLsdUgTqSET7pD7x+v93Azlazqyslwsw1DExw7LCmt5MJbCfCVkeEm79uU4WY6diTQENaUxu5bmSIbmQyrPkfPcBMxIKWHmzb8ohElpWEWoHq/HOisdF3R/nbxGW5i3zc/uA6fumgF7lu5qaJjmchDE0Q5bDMEBpTMr8YsAUD8RN1aaZbXSfUXlwHcTAZH041eAlFLYUkpERGVwoAb1czeO88Lbm+/oAcAig5NKFVOKp5jCrLo/cc83zcGO2y9pFT7q8iVss70iY0JbUrpdEtKg2MpPdzE0ITwvkqCNvIxyslwU/qsmUpKDceOBA7F15jMt/xx4i8uvbggg97DzfODIGekF18jSkpjgpJZKcOtnKCszIf+3hi2ERluhQfXD4wVvtZgoIAhU9TU22+mqZlfDVkCAG1oQl0ibtJNXrC1tWYIZJdS4dBrIuLQBCIiKoElpVQzr1i+AJecfQxe2DiKxfO7AagBN1FKqg9XKCZhW/lMs5wecFO3i8vucoJATf57PZgl/kjS+7eJYwNh5k85gTB5wqjr+fB9P8yuKyzRlvq1iWCeXFJaSZCjZhluRXp2xZeEFstwiw/a6BNPwww3Uf4rngcMjeUzLvp78uWTzZHhppWU1rmHW/jZqE/Rg3XVUEuzRYZbE1w4xARvZ1rcZOSa7V8OgDfD+05VeWnrOB5cNYATD94RnSnzn1WmSc/NRv9HJyIqjhluRERUCgNuVFNdHQnsvUuY6Sb3RUsk1Ay3ciQTNhzbBuAqJaWRxvUxmUVBZpSUNSUTgRu9fxuQD4IBYRBF78lmopdPTqZz8AH0dCbDklLLCspXxaCDhFRmWkn2lny8snq4xWS4uTHBJP0YgNxTzHy/vh/9PdczPUTgKDKlFD6GxvJNvOf2dgBocIZb0MNNvV8tKa10Smn8e6Pfp2fY1WJqprwPcX7L9zUqMCAHExt5IWOazltLzfI6aXr+30/uBZDvrfiOE/c0bsMMN6L2E3bYaNIfaiIiajiWlFJdyU39k47aw60cyYRjzGrS/7iJy+4Sx7disseCQQbGgFt4XM/3I9lL5ZRk/vfl9+OLP74H2ZynBPfEukTAzbGtoN9d1SWlNejhZgrixGaoFcnO8qX9xL3nwXOCDLfC12BKadhTaN6cfMCtkRlufkxQMjutoQnq96ZAoj6lVGxSi4woJUNSTOOtc5CpHM0yNKHeGW71zuR7fuMIBoYmy95+y9AkHl49wIvHKj23YST2sVbo4cYMN6LqNOdPNBERNQMG3Kiu1Ay3/O2KM9ykwNfEVBYbtoxHgx5xATfRw80QzMqtfRzJO/8Pi+xh47/sJ+xwna7rK9lL9zy5EWd+/3Y88dxW/PxvT+HT/7sCoxOZSMBl68gURieyGJvMBgEb2wqz2USQw3HCoQnVlpSWleEWN+m1WIZbpAdb/muxCZtKSWmxoQkI/1C1IlNK/aCkdJ7IcJMGKsw0NyaomsnJPdwqDbjFBDOV+6Aet4b/oq4EYA093BqW4dYk2UD1nlJaz+Dm6EQG3/jFg/jurx8p+zk/++tTuPi6x/H8xtHaLmaWKPbfNvnXYJPG2xhwI6qQ+G9ks/5MExFR47GklOqqnB5unSkHUxkXJvmSUjEt1Md//d9dmExHt40LNoU93NRg1h0PPoeXPfYjpLJj+PCc5/GT7L9Fniuv0/U85eJ71dohpDMuVq8dxm2PbAAA/PPh9VhaGBahc10vZmiCyHCzjeWSm4cm8Y/71uLkQ3fCwrld0f1WnOFmfm6xoQmRZvHmBDelPK5YDzcPakBHD+oEQTUvDLjN7c33cLObsIdbVu7hVmGdp/4qTM/W++vVtKRUWoBpSmkNDlGlxgf9AC0bs87nXK1f5+hEFq4XlmWX95xM8FyqXKJIwE2dSNucV+eMtxFVh1nBREQUhxluVFdKhptj7uHW152KfX4q6OGWD2aYgm2AGmySy1ijPdyATNbF+juuRyqbn/a4nTOK01O3Rv5gEusF8plLckmpuBCXAz/5LDjzH12iLBXQSkpdqaTUEEz64e8fx80PrcOF1zxs3G/FQxMQfQ35/UT3pz8W7CNmKpdaKhrdPvhe2y7McBNfreCxoUJJ6dw5ooebHTnWTPB8P7Y5snzuVTo0Qd9XsQy3MAsxXNN0edr5q9/XqLhAEywBQPFBLbVQz6EJxQahlFpPs5Y8NrtUkXYJzZK1WYzNiBtRRWI6bBAREQUYcKO6UjLcCoE2x7aVP+zn9CRjn5+QSkqLDS0QQQ/LCieS5o+lZri5no+piXG8uutJAMC9zkHI+jb2tNchu+r2yNrFMvMZatGhDfJ9Oc+LvVDNeX7wHMsKg0pBhptUUioHpF7clA8KDgxNGfer9HAro6S0dIZb8WMA0WmZpn2rGW7a/vTttMfFueH5PgaDDDe1h9uMB9yKlBZmYgJuOdfD02uHgrJhk2JBS2kr5TER+qt1Sam5h1vjLyMamuFW5/dCnVxZ230Xy1ottZ56Z/O1q2Ilpa3Rw63RKyBqLeE/xDXnzzQRETUeA25UV6YMN0C9MCmW4ZZM2GH/tSLZQ/LwAWOGW+Fwnu/Dfe4BdFpZbHbn4OqBl+EvkwcCANJ3Xw1vfFDZr1hzTsteExMr5TW5rh97ceu6npbhhsJ+veA4Yt2u9IdbT2fxqm/5eOVkuKm91aS1e/FBnLihCcWys3xDMM+0HZQMN9HDTRwXQTmcGJpgeo9mgmlAhqBkuEkRy9se2YDzf/kQbrx/bex+o++h4dhahpt4w2oRE5H3YepR16i4Sz0DUZUo9rnXRJFM0GnvuopsNX0wB5Umf25Jp0gPtxbIcGMPN6JKmf8eIiIiEhhwo7qylaEJ4ekm90fr6ylWUuoEGW7FLnhF4EoeSABIGW5S1pS15m4AwH3p3eHDwq1T+2C9vwjITiF9/3XKfhNBdp1nLCmVs+5yrle8pFTq4RbJcLMtYw+33q747D9920oz3NRgghe5L3hMD7gF+9IDafJz4p+vZA1JTwynlOZvjU9mg/en0RluxZrnyz3c5PNh22g+K3FwJB273/KGJoggiPa1Bu+Bp52/8v4LR5/2MaqhD9ZolPqXlNYxw00KjJcbzNP7BFJp6Wz4819uhluzvr+MtxFVp1l/pomIqPEYcKO6Mg1NACrMcJN6uMURgRlbz3Cz1JLSrswgnC2r4fnA/ZllAAAfNm6yjgQA5J5eAXfzs8HzxbH1DLegpFQKcuVcPzabxJUes6XgmhxwMwWT5hR5b4DKe7iZstrk28YebjEZavqmcYMSos9XnyMeDnu45b8OFvq39XYlg/OlUUMTigVG4kpKxe1i2Xj6I6aXFWQqeer7Xos/8JVJtW70c21Yhpt8u1mGJtSlpFQ6Vo33X82EVfErtllLHpuRPPBHzujWtUIPN2a4EVUm/O9xY9dBRETNiwE3qis5+CUH2ZSAW5EMN2VKabEeblKGm3zNow9N2G3kQQDA6twSDHnhRNE1mQVI7H44AGDy7z+AN/QSAATZdXoPN7EWdWiCF19SKk05ldcYDE2QS0pjMtxMvcCUKaVlZbiZA2GVDU0ofI3sW7odM0BBX4PymKV+VttG8hliIrsNaJIMtzJLSsvpoRVXrmu6Lyj7jXluNeRdGDPcGnURUaQH4ExylXXUYyF1zHBTztkyn1PFoIXZTg64FQ2uKwG35nx/GW4jqkxcxj8REZHAgBvVlVw6qma4hdPc5nTHl00mpaEJ5fRwk7PHxPfia681iWXjjwAA/jn1cixdGAbchsYy6DzyXbAX7Ax/cgTj130JU3f9Eh12/pj6lFLxt5UcBJMHI+jkxxyppDRnKimVdtHVEfZwG53IRvYrb5stZ0qptL1rCL6ZLsz1Bur6lFIRBFMmoBbJ3FErFv1gP+JTCwJuwYTSMCBrKrudCcWGJsRNKXXLCF5U0sNNfA5BiWmZQZRilAxJw5TSRl1EeNo50ih+FUGrSqh9vWr7Oqtp0h+UlNbhtbarqUwuuF3sv1HN0pewGCa4EVUo5h8giYiIBAbcqK46UwmcfOhOeO1hO6MjFQbZ5D/si5aUOmFJac5wxetopZl6Sancw+2EzieR8LOYmrMjVmaXIpWw8YrlC8I1dfSg69TPwlmyJ+DmkH3iHzjBeQBAPnNJ/oNKZBtlsnKwpUiGm+sHF+yWJZWUulLAzYoGk+Qg1vB4tBdY5T3c5ABCNGPPnOEWEzArfA2mq8YED6JTTtXAnPhOLykdm8wHGE0ZbjNeUhqTsSdnLua/lzMeRfCiyFqL9LcLNylkuGmlvH4N/sRXS4xFhpu8nmkfYtoaGZxwZzD4WN8Mt/J27hf5PUBmU2kpw61IVFaNITfn+2sz4kZUEZ9DE4iIqITiIxCJauBtJ+wRuS8jNZouNhgglXSKBlkSjg3Xc5VeaDJxAdE/8QIO71wJANiy84nACx5SCRsfPO1l+PGfnsShey/Ob9/Vh67XfwG5Z+7G1D9/jFdZj+K+xJIg+0cQF1Zyw+x8Dzfz63A9dUqpWGWwbsc2lkvKt0fGM5H9KgG3cnq4KWsyZbiVDrjpZWfyQArTc6LPD2/7vh/5p2G9j1CHlA3ZFBluRd7znKGktFiZmf4yzAE3dX9hhtv03wP5wj9nDBA25iqimuyseiiW2ViT/dfxdRbLMi31nOmeW+sGxjAwmsF2c4r3oGwHk3KGW5H3TTmn67qi6jHeRlShGv4DGBERtSdmuFFDyJlhiSKT3ZJO8ZLSYIpo0MMNSg83x7bgZ6ewx/PXwrZ8rOl8GQb798rvO+mgtyuJT7/1ABz1iu2D51iWheQeRyCx59GwALyl+164ufCiKn+8QoabMqHSi81wkAMzcUMTwpJSc3BneMwQcDMETNIZN/YCOy7zrPjQBH0f6vemDDflYj+mJBXI/60aZrhZha/m/QONy3CL6+WV0QJuSklpGT3cik16De4rvENBDzcRFKnBWyDvwzX0cGtUrKtZGsyrn3vt91/P11ms72CcIKg7zWOff9VDOOeSFZhM50pv3OKUHm5FSkrVn6vmvDjn0ASiyoif5Cb9kSYioibAgBs1hByoKjbZrdTQBDF8QS4plS8abNtCduWt6MiOYIvbi3t6Xx0ESVJFAn0A0PmqtyGNFJYmhpBa/6DymAjwpTNSD7dcfEmpEnCzwjUqJaWF5ajTBcN9jEyUynBzMTqRwacvWYFLfve4cR1qOWT0ArCcDDe9hEJ8fEogLeY16Mfw/XBHYUmpej44Uh9AUzbdTIjLdMpm9YBbdIBCBRWlxgtxPetI76E3HUrAVgvoAQ2cmdAk2QJ172enBJ9rneFWebDQK/J7oJLjjoxnkM15sy/gVjS4br7dTBhvI6pM0OKhWX+oiYio4Rhwo4aQM9xKB9zyp6lr6FGWKAxiUKaUSvtLWB4yj/8dAPCPqf2Q8ZPBsZMlAm5WZy8eSh4EAFiw5m/oQBjwEgE0uTQ2k/NiL2zlTKh8v7b87WBogmPu4VYqw02+wMu5PjZum8Bk2sWaDSPGdcTtO8xwK/4cIPoHZlgKKz2nSKmc3utN7D4cmqAe32mCDLfYklLtnDRlFRXr4aY/Ygp0BMFQEWgrsm2l5LWZM9waleIW3myaktI6nHNqeXVt9+1XsfZaTCk1TT9uZ+rQhCI93Jrh58pA/qyZ4UZUqeg/VBEREcnYw40aQg5M2KUCbo5afqk/Lj9m25byh89OEyvhjw8im5yD+9PLsK/nI1vIrktJvcHiPNlxIPacegwLMkP4yJxb0GVlsCa3CPfnjgQApKVMvXTWjQ0EqSWl4YWN2D5hSz3cYoJVIxMZ+L6vXBTJF27ZnBcGAqV1yeIy3IoFh6Jlj2rgxwpKSs0X2nFTTvX1iJCb3rhbDrg1qodbXNahHHAFwiwx+TnFp5TGByP1+/SS0kr+wM+5njIdV5Bfi2lKaaOCXfJRm2VoQr3fi9r3cKsi4Fb4NTWdpczkoIlmoA5NKC/DrZkCkfK5waEJRJWp5r/HREQ0uzDDjRquWIZbKmEjUXhc75cF5Hu8AdqUUml/u4w9CgDYuuRwuHDg+WF2XTJZ+vT3Eyn8YvwY+LCwPLkZSxNDOKrzaXzA/w0W2KNKpl4648ZeYGalAJi+RqCQ4WbI3pJv37dyMz77w7swNJY2Pp5zw4BbOuMZ11JdD7e4DLfC2ktNKdV2qQTjCv8DolNKBdsQcJvxDLeYctlIhptSUuorX03KKSkNApz60IQy/8IfGkvjzO/djsv+/K/IY2pJaTTDbSYrO5/dMIyXto7nD1vHUstK1LufXXzwefqqCRbWYiBHvbMCm025QxOaInPUQPnHL8bbiKrSTD/TRETUXBhwo4bTA27y98mEHWRQ5UwlpVqGm2OF5Zrz7DEsmHoRADC86JUAAM8Lg1KlergB+cyz53Pb4YlFp+LF3AL8ZeIADLhz0G+N42Nz/oFF3uZg20yRDDc5MGdLa5RfczB8oMgF6+BoGs+sGw4fj8lw83w/Mlk1f3942zQIwNzDTf1e7yEWlMLCvO5oSakWZCh8K96SSA83OeBmKLt9Zv0w7n5iY2TdtRQXvIj0cDN8dpVkuHmF++TMuUiGm2Edxdz2yAZkcx7ufnJT9PhKSamaQaffrqexySzOv+ohfPfX+QD5bMlwq+dA2GomoNaipHQmswKbgTo0oVhJqfl2o8m/S1lSSlSZ4B8gG7sMIiJqYgy4UUOIqaDHv3KHSLaXrQTcHDhWkYBbIcNNPGbZYS+0g1LPAQCc7fdGrmsugPwFrii3TJZRUiqmoD7T9Qp8Z+R1uHHqFbho5GRs9eZgoTOGT8/5M97ZswKAj3S29NAEy8pf1ESDSnawbiUQZtjf8HjG+Hg25ykZV6ay0qoy3CJDE9Sv5gw36XbRklIpfykmw0308JOPJQYS+L6PS37/OH7y53/hmfXDqJe4vlTlTCmtpIeb7/n4+d9W4ZMXrcDW4anC8dTPJgx4lrf2YiXb6pTbQrBWLgmcocuIiaksXM/HqBgMEpMtOdPqn61Vv+CUL/dULGPtvu/XpDxKLSmtfj+tovyhCc2f4cZ4G1F1mulnmoiImgsDbtQQ737NnvjsGQfgjBP2UAIqtqX2YEsm7CBgYAq46T3cHNuCZVtw4OKwjmcAAIk9Dg+O4Xl+2VNKgTCgNyVN2xvxu/HjydfigfRucH0Lh3aswdEdTxXPcCsEv0RQLdKnTCopNWWHveHIXXHgHgvzx1cCbuE+slJJKZAvcdXJqzMFE6oZmhBk5sVk1OiBBL1RvHieFdPDzVRSKta0bSQdDJN47Nmt0cXXSNy0SvF+i/PE9aIlpcWnlEbfm9XrhpDOuli/Zaywjbo/8X25AaBiZWKmnn71LqM0ES8l/NocQRv556se61B/Fmp7gHJ7uG0ZnsSvb1kdBHj151Z83FmX4Rb+tyFXZnC9md6W2VD2S1Qv+tR2IiIiHQNu1BDJhIOX7Tq/MIVUDqioQQs14Bb9iyZpmlJqWTih819Y5Iwi43QjuezQIOjg+n5FJaViYMOEFHADgIFsN64cPxp/mDgYAHB6z/34ytzfYungQ8b9yAFBIJpJkLAtadpn9IJ1l8VzsPPiOQDUDDelh1tOC7hlowE3U1abfL+5pFQPCql/YBoDbkUmFcZleoQ93OJLSsPBEvnvX9g0Gjz25HMzE3BTswrz73FXRz5bUj5HxXbF+zqp3/u+H3xu2ZyvvafhNvLXUuSAdvT4hgy3KkoRp6vYa2qaDLe6NHGTbtZ49+VOC73tkQ34+31r8c9H1hufWym5rHI2BHPkoQnFXq86NKF53hclI7GB6yBqSb7yhYiIKIIBN2o4Ob5iGTLcnJgMNwthAEYemtCPEbym6zEAwLPbnwwr1RVkTfle2B8rmSynpDSa4QaEFym3p/fGPendAQBz7QkcPPQ3vLn7Xsyzx5Tt5fXJXwXHkUpKDcEdy7bQ35MCoGa4KdlWWoZbJhvNCIwtKS3Su8nTdhPJcLPUIJi8jX4c03bie3EemPrbCfrQhBc2hgG3518axchEBvVg6ncHAFOFc6m7I6GsS75dUQ833w8yE3OuZ8xIDDLcyvwLv2hJqaGHm/J5z3CGm6mksaE93MrMEqtWPcsMy127ON/k0shp9XBrkuzEmTJV5tCEeg7ImA41e7eBCyFqQeJHhiWlREQUhwE3ajjLCrO7IuWEVtiTLav1y5KnfQYBLQs4wH0cKcvFM9nF2DJv/2BbIH8hWenQBACYNJRnFlaPq8ePwOcHz8BfJ18BADimcxXO7f8D9ky8FGwVrk9kuEWzuIwlpV74eJ8IuE2YM9zyQxPCdZoy3EwlhPIxTRfm+h+S+veVlpRGtgu+j39v9NtinXKGmw/gyee2RdZfC6bPBAAmp/IX23MKn41aUlroM1e0plT71gfShUBpzvUi75Xvh1lv5QZFik0BNmW4qRNCZ4ae4dYs/a486fOsd0lpfLv96ijDV4osXvweyOVq81pnX0lpNUMTmud9cZvkZ42olfFHh4iI4jDgRk0hCLgZzsi4klLLsoKSzyCIZmXxstyTAICbp14Ou7BDOTMq6OFWRoab2P+kluGmm/JT+NvkAfhD4nV4LrsdEpaHd/TciU4rHxzL6BluhiwuvVxSrDe/vRRwk3u4aQETZWiCqaQ0ruyzkqEJWoZVkD3oA3c8tgGfv/QurN8ybjyOcX+Fr2FJqXr8Yj3cRIbb3jvPBQDceP/aumQiqY3gw9ui1HhOVzK/naGktFjQQV+q6/lB4CvrepE/4n1f+hf1cnu4FQm4lerhNnMlpYWvUL/qt2da/Sdu1ifY4fu+Gswrcq4EATfDuVsN089AOyt3aEKz9CXUxfWnJKLimuUfhoiIqLkx4EZNQQS2RON8WdzQBNtGZILpXrmn0IEMBtw5WJndQQpwiUBN2HcrWUEPt1IBN+FfuZ3ww9ETMeDOwTxnAm/rvgeAHxxTrCeSxSWVlKpZNSLgBiXgFmQ5aRluchlpyQw3Q/DNNyRoRIYmBE1L8l8dKXvw4ae3YGBoCk+vHYq8BtMaPB9BzEG8I9H3Jprh5no+hsbSGB7PwLKAD5y6D7o6Enhh4yhue3RD9EVMk5zV5pkCbt35gFvOMKVUL8mV6VNA5dLlXM6LvHeu50cCnqXIGW6mEtbgeA0sKY1cuCjZQDOzBpO4z71W6lE6e8VfV+Lzl96t9J0sGvQNAm5S77XplJTOshLF8ktKw9vNlPmnBpUbuBCiFqP8wxB/doiIKAYDbtQUgumdhmycoE+b3sPNUktKbXh4RTo/tOC2qb3hQy5VzT/H9/0gKFVJSelUbEmpajKdQwZJ/HL8SLi+hVd2PI/P9N2Ad479DC9ProstnU1IJaWmrBrbttDfnQ+4ZXJesB75wi2b0zPcyuvh5vlh2KeiDLfC9+F7a54kW2poQvCdpX5Wgj7FVqz9pUIW3eJ53Vg4twtvPHo3AMBf73khsobpUrO+wvuDktLCZyPKPoHwcyz3IhxQz7Oc60feO8+rvKRUPtf0tcjBVGNJ6QxdRejZP16N15BzPSUztNp11Vo9ygwfe3YrtgxPYf1A2EeyvAy3GpWUNiBDslGyOU8NshctKW3OQCQz3IiqJP/+5tgEIiKKwYAbNQU9MCYTAYOc3sPNsuBIU0pfmXoefd4wJq0u3FsYZKAPKciXlOaDGqlEOUMTokGwYkQm3HO5RfjNxKsAADsntqIPo3hf723YxdpYWI/6vGTSLl5SalvoSDnoKJTBiuCB3qRfLiM1ZrhJt8MMrOIlYNGhCWr9n1zmaQy4RYI88r7C/QUZbvpACUMPN9cPS4PFhNBXLF8AABidzEbWMF1ybzb59YQZbilpW/V9LXYRqw+emJSyZbJuTIabeG6Z56T8/rlaWbaS8WiYUjpTlxDFsn9qsYYf/fFJfOaSO7FlaLKi55n6HNaS2qOvNvsU65R7XhYPuHmFr7UJlNX7PWsm+u+7coPrzRTY4tAEour44M8OERGVlmj0AogABIEzvZwQKFJSakklpTkXJ3U9DgB4ouOVyCBf4udoATdPCtSUU1IqppSWS77IvSe9BzzfwnxnDHt0DWJ3ay3e7NwCP3da5HWmEg7SmUKGkesi88Q/4E8M41h/HbZ22nByewOYi/6eFDYPTWJ4PIPF87sjQZfJdPGAmym4ppSAoXjZYf77wraF+xOF9zEfcCsnQ04+no9wWEL+vsjgDGMPNy9Yt8iAE5+VHpithbhG8HpJKZA/TxOOXeaU0vxX27bgub6a4ZaL9nCTM+jKjWVY0imc8zx0IAw0y2szrXemLiL0Y9Y6OLFhyzhcz8emwUksnNtV/rrq3MNNLUmqzf6NPdmK7LrSAF3J4yuZcu19Faq/vFy5U0rrtaAqxPWnJKLimjWITkREzYUBN2oK5ZSU6sEceUrpnngOS5xhZKwOrOo8AMCoul+pFDErSkqT5fRwqy4JNJmwkc15uC+Tz7R7OGnjI9a1WOCMI/PwnzE3vRhv7L4feyU2oMvOwBrqw0TnrgCAg3L3I33XfQCAo2wA3UD23i3wd/x/6OtOYvPQpDHDDVB7zZmGJvimAEuRMkMgPmAm7k1KWYZ62a95f/K+wu9F/z79DDBmuEnZdCILUQTc3ELZpSl4Wy3lolS6HZSUdiUj28a9vzLxXjq2hZyrl5RGM9w8z48EPEuRA5j6z5BaUlr4XOvct8xEv3CRMwdqkSQl9u8Wa6hnUM/sn2K9DafDVCJazpRSt1YlpbOoJ5heRqZnkMqatdTWrfMk3pkymc7h97evwaH7LMbuO/Y3ejk0y7Twjw4REdUZA27UFEwlpWHGU/5rNMNNTCn1cULyUQDA092vhJvohAi4TT/DrbqgTdKxlYyR8ayDP7mvxPt670Dm4T/hcADoDLf37/0RvF2Ow9EdQzg092D+2LsfjhWrRrCv9Qx6h1/E2BUfw5meh639vUg/sx7+8rfC8XPYxRnAqN+Fca8D1uRwsM+0oYebaXJhNINNCwREmrAVvhS2E9Nec65nLCnVL+KiPcKCiFv+iz40IWZKqbi4FUFR+bNyPb/qz84kruRRZLj1ShlubjB8oLIMN0BtwJ51PeMU07geblOZHBzbLnpe6z2m5P3nvGhJaWOGJmjnTA3WIF5TsYBIsefJ3+sZmNUq9nMxHSKAJge/iwV9g6EJtSopNfSJbFf621RuQLeZAlv1zuKcKX+44znc9OA63PTgOlx+zgmNXg7NAuo/FDVuHURE1NwYcKOmEEwpteRspnzgIBiMEJlSmh+KsHdyA3ZMbEPaT+Dp3oNge+o2QJjlI2dGldfDrboMNz1TL5118XBuVxxrvYDd/BfhWkk8OrUUD2d2xaEdz2K/1DrMe+4fOL2ncNxlh6Dz+A/jL0+swL2ZHXHW3JtheTnYALZzRoENN2PsZzfjq91a37sc8EDPbvj1+KtippRGM9z0LLlIY31DWWN+X/nvk1IpZzklpXHlg+GUUvX5poCbkuFWuE/ORszmvKo/O5O4yYsThQy37o4EHNuC6/nS+1oIYBXLcEOY4QYAU2l1aIIpw00EoOTdZrIuzvzu7ejtTuIHZx2tHkMJqpmzFcXx9PXO2NCEIhf9tViDPsiiXPr2vu9HT9Bq1wR93zXZbRhAK7uHW2UZcaXIQc12byRuylKMC8qqmb3N8760y1TZDVvHG70EmsWa6WeaiIiaCwNu1BT0wBgQBuGCHm6RoQn57Y/peAoAcHd6D+QS3bCl7fShCWmpZK+cDDfHUOJaDv2Pr3y2m4U/dbweX3zHK3D9Xevwx7vy0zSfyO6EC19rIfPCY3h+7QCGOpbgNcd8AJZlwfOBNbnFGDv5q1gyx8HfH3oJzz3yAN7U/wR63GHYFjDqdaLbSsOx8sc8uOM5LHUGsXr0ZGT+tR7Owl1gb7cbLMtSM7XKLSmNBB3Ur+J9zLq+sX9a3JRT/baIuOkXq3FTSoMeboXAWlIKsGVyHp56cQB77zwPXR3T/zVnCgi5nhcENbs7k3AcSwkEhj3R4vdbLMMtrodbUFIq7filrRPwAYxOZOF5vhLwVYKskQy36GM1Ti4ri35OxE2FrZZIPKo04GYa+FGrOK7ps53+Pn1zhlsZJaVysLxmJaW1b6fYVExvk+v6sBPR/25wSml9tfLaqVU15880ERE1FwbcqCmI4QfyhMqEFoTTs6csy0JvbhD7JNfD84E7pvbCy2wLrhSw0XvDyQG38nq41a4sMX/MBKxEB2zpqt2DjeReR2Pz/FfiRysfxvYd3Tg5lW/sLi6G7J55sOd2I9GXxQOZ5bDmvwr/eeoyfPqi2zDsdqLT8QAvhx2cQbyv9zYsTQxh6ZZfI70ifwx70XJ0veYsNfgiShPLzGgTRNaK+CoCbjnXC8oSledrd6kZbr6U4SbOAXV7OXhUrIebbVuwrPwfvvet3ISrb1qNns4ELvrk0dPu52aavCgPqOjqcAqBQS/Su63cHm4AMFlGDzfxvsvvo3wup7MuhsbS2G5uFxKOrU0ijQaQ9NfYiKmFkUEaynFrEIiCmnVYrmi2Z+3ekHr0cJPXp2S4Fdl3kBFXZglqKbWadtoKTC/P9TwkDQPg48rSG61dMtxaee3Umjg0gYiIylG7miuiaQiy2Sz5vvzpGQ5NUC+WfR/YcfB+2BawMrsDtnh9sC1LK0tV9+tL98uZU3ESZWxTCRGc0rO4ko6tlEsKIigm1i+CkJ4PWB09GHHzjeBSnZ2Y8lN4NrcY3x4+DWuy28GFA2fJnoCTgrf5WUz89lwc8K/v443d9yOFrHFKKVDO0AT1qxJwM2S4RQML6gWeCIbETSmN6+EmArDy5yjKSJ9/aQQAMD6Vw91PboysqVKmRvATU1kAQEcqH2wLgoEiw02UaBb5Q1zsS7zmqXTpHm56Dz1ALae9+8mN+H8/uRffv/bRyPH1gKhaUhrt4TZjJaXKmvTpnTXYfzAYYHoZbrV8P+rRw01+ffLvy2KBxpqXlFaRMbXy+W34/rWPYsvQZNXHbQjD64vLomyFDLdmCgRWigEPmmmNyAYnIqLWw4AbNQVTSWlCKynVL2QSfgZLBh8BANyR3jvYVo6R6SWlQjnZbfk1VPcjEve3f6oQnNITrpIJWwkmBfsRGW6W2qfM9Xx4ftghqaczTFYd9rvxg9HX4qe9H0X3G76IntP/B9ac7eBPjaIrsw3Hda7E5/r/jP7CYIlIj7UyA3DGgJvhYjOuJBVQs5nEe1JsaEIQ1PL9IIggZyGKz0v+vK+99dlpN29XShwL+xIDE7oLJavifNU/m3KOHfRwkzPccoYMN98P1hLXE+ovd+dLlf/1/GDkOJEMt1I93EquvDYigzRqnA0kdjHdHm61LJGMBtymv095vVm5RLTIuo0lpdP4eVFLSsvbz4XXPILHnt2Kn/31qaqP2wh6wByID+qyh1t9tfLaqUUpP9ONWwYRETU3BtyoKQQlpXLAzTZngwn7YjUS3hQG3Dl4Krs02NY2ZLg5ekZZGQMTgPKnlMoBLyA+UCGOq5dJ2na4bqWvlgi4GYY/yBez3Z16dbiFQj9/2P1L0PPm/0HXKZ/Bv3Y6HdvcHmznjOLMnr/BHd1SMosncs0sMqwKN8TwiVxMDzdf22f80ITCOaA9Xw6oiffBl6aUykFR8XnJgavhsQy2jU5F1lUJU5nc5JQacBOZdjnXLztrRDxmmwJurqGHmxeW4MYFNsYms8ZjiH0KcjkvEGbmNSIwUKyHWy1LLSvu4WYIeNaKPlCgFvuWX59aUlrkHDQNWZjGUqYTwBkaS1d/4AayLLXc3aRpM9xifje3mtZdObUq+Xd4MwXRiYiouTDgRk1BZG6pJaWFYJlxcIGPw5wnAeR7t/kIM9lsQwliJMOtjIEJ8rqEub0p43a93fr95j++RGadJYWVRIaY6YJND8g4QRaVpwRZejqTkWPJU0qtVBcSO+2Hgf598f2RU7DZnYP5zjimbroEbi4+QANEs12Ch7UMt2zOi73YjAug+H7Yk0y8JXqGW2wPN0+dUgqEwTe5NBMABoamF3AzBdBEhltXIdgpfzZylkuxrCjxXojXJX9mWcOUUtcL/8RXg5jhNtlctPRayBUJhojPLm6/9VSscXstJl2GJaWVpajNbEnp9Pcprzdr6Ml26fVP4JLfP26cViyXG0/ndcrlq5UGcGo5WXgmiPdJCbjFnGPN2u+pfTLcWnjx1JL0fygiIiIyaa2/bqltiaCKpQRXouWBwu6JTVhsD8G1U7gvs7uyH1OGmx7EKWdCKaBmuDm2hUVzu4zbzelSA15xf3wFPdyk15TS+rr5UuBD7CcIuAUXdb5yMRvNcFODN+G6fAz73fjh6EkY91LwBp7DnL9/BZ+c81ccknoWSeRKNooPSkq11yRP2NRNZVypFFK6wIOc4SZeq/pcxzAEQ+7hZspwk4cPAJh2byjTRelEJMMt/GzKbRwvLhJN53jO9SKhpnyGm3gfo/spdgyxtrh1iVJYrwFXEfJhPL/22UBBSWmFOys1UGQ6ivU2rFZchpvr+5iYyuG+lZvx4KoBDI9npOd4he1rk+lUTUmp0HoBt/xXy7KkgHvpDLdmyiRrnymljV4BzWa1+IchIiJqT6311y21LUcrmQSkQQqGYMQxnfleP9sWHoBJP8wuc7SAmx6oElJll5SGPyIL+juRiAnU9eoBt5j9iePK8T89CBdMi5SuIIIeblIPMyXDrSOa4ZbJmgYY5L8Oer345fiRACzYU0NYlhzAu3rvxDfnXYPJGy9BbsuLcLc8D9/NFhma4Cvr16fIyj7x/Tvw7asfVp4v7wNAbIabnGUov35RHmnq4TalBdwGhqeX4aZcLMf2cFP76+nbm/eb/2oMuMX0cAsCbmUGNkxlo/prCh/3tQvw2N3WlN7DrdbZQEFJaYVDE0oNFKmG7/v4y93P45Fntqj3T3vPanaZvD89S9V07qilhdNZQ/XnT7kl/M0iyHCDVFIeG3Az3260aoZcNCMGPGim6f9QREREZBJNiyFqAH2aKBCWCurBiHn2GPZLrgUAbNv+COCpbcFjlmXBkocmWOZ9JMscmiAH6hbN64q9KtYDbnH0bDYASBSCcOJY4g83uRQx6EVXuKjLZ7iFj5eb4SZfVD+Z3Qn2G76KrQNbsOLmO3BEx2oscMbgPnMPRp+5J3+8nQ+A13Gasg9xUSZ2VW557lMvDhVel3phr/dw02NPphJhzwuzyOTPKAy4hcGwiXQOW4ZrmeGWvz2pl5RK03RdQznfyHgGv77lGRx7wFLsudNcZV+msulsiR5uav+Y+LXLD+WUQEt025w2GXWmriE8LRihBItqmeFWaQ+3OpSUvrR1AtfdtgZdHWrQvyaBxdiS7uigFsH0ntRsaEKbl5SKHyHLskqWlDZi+m85TBOYW1ETvaU0azTgP5ZERNRyWuuvW2pbppLSub0dAKIDD47oWA3b8rE6twTZ3iXKY3qGmymQB1TXw23x3G5jJhIQDbgtXdBj3E4E+uTdBJNLtSml8oWQHjiUA05AfMCt1AAEv397pOctw01T++F/ht+Ibw+fCmuHlwO2A1gW3BcfwQ7DD6rPiclwK1ckm6nwl2pFU0o9P7iwNZaUpvPBxu0XdAMAttSyh5vIcNNLSqWSMiVAh/zrvOaW1bj7yY04/5cPhY8Vy3BzPWPZp7hLDpiVU7YKqMEA03N831eCLTM3NEE7Zo1LSsOhCRX2cIspp54OEQjXszBr8TpjeygWKRM3vabpvE7X8LNSLqfFMtzEh2ZZKFlSanhaU2ibDLcWXju1JvUfhnj+ERGRGQNu1BTkktIz37gv9tllHt5x0p75++QMJrg4ouNpAMDtU3tHMoNsC8aS0ujQhMqnlC6a1xU7MbW3Ww24venYZXj1QTviPSfvZTyuHFgMhiZY6gWbUlJa+Ek1DU2wLQtdHdGAm++rUynz90UDOOFFsYW17kI4r/0s5n7kcnQcdgYAYJ+Bf2BZYlO4j8KfmeJZyQqzUpQlyBlulvpVcGIy3Ew93Bwtw237QuBzoIY93MRNvaQ0yD7UJsjmn+Mb1yDeSz2oDORLdCMZblKAstzpgvJDctmv6QLB82tXWlgJ7ZSAfNbW4kJG7GPaJaU1DP7pL6vWPdz0++P64pnek+ksxfSzUq6E3sCxycm/u2yreMBN713ZLBpRQl4Prbx2ak1KmXjjlkFERE2utf66pbYlZ6IdtNci/NfbD8S8OfkMNzlYdmDqefTaaQy63Xgis2M04GZrJaWG3nAA0JkqM+AmXQAumtcVm+HW1ZFQjtHTmcA7T9oTe+08V9kuaSgpTWk93MKm+HLArVBSKl3UBQE321Jej/yepAt93LYMTeKOxzZEAnB6plz+uPkss+R+J8HZeX84fg4f7r0FuzgDhfVBWWdcX7s4kYBO8K15wEVshpuhpFQE/8Qhtl+Yz3AbHs8gYyixLcfYZNY8pXTKXFLqutFprZ5nDvIWy3DLmnq4ySWl8gV8kcQt+f1WJ0iat1Xvr+4yYmBoEj/8/eN4dsNwWdtHGrfX+EJGvOxmKCmN+6xqEcyLCyj62ucqb2V6T2o1NKHS96vlergVvlqwgmB/a08pbZ51VaqFl05toJV/doiIqL7Yw42aQlBSasj0kQMqR3WuAgCsSO8FD3YkUBE3pVTfrqezvJ5rjp7hFhNwc2wLXR0OxgtBmGDIgZb9FZSPyr3qDEMTfF8NhIX7kwJuvgi4AZ2p8Ee5M+VgKuPC9fx8kKkric//6G74frRXmJwpJ4jvLctG14ln4vlffh0L0y/i43034k8Tr0Rf2oG7tRuL/K0YQRK2ne9fVG4wQ/1XYamkVHutwWuPzXATJaXRQRvC3J6O4P3YMjyFpQvNpb5xbnpgLX5102qlZFj8YS2y6ESwU2Ta5VxDENPzjWXM4r0w9XDLGXq4yZlK5ZaUytEVOcNN/tytwmZ+kUyoSjzw1GY8sGoAXR0JLF/aX3J7/Zhqf7rpX8iEJaXTzHCrQVQs7rOq5es03R8p2xWPmQJu03idOUNwulyt1sMtGJpghT1Hy5tSWv+1lUv5B5AGrmO6GPCgRuLpR0REcRhwo6YgyvFMAS0RgFlsD2HXxBa4voV70rsrz5O3Laek1NTzzKQjGWYlLezvivSCC9efL+sMAm6FDRPaE5KFLCd5jSIrSw66+H7YuNyywkCkMjRByvCSM9wSCRsdfr7kUfSLimsa72kTNcV9gpVI4e5Fb8HyZ6/By1Lr8eae+4GN92PiOuDDDpCbZ8N9YCV2TO6Kl9trkPMd3DS1L7wiybPR4AqC15l/b9TtTSWl+R5uhdcvXaTr5a2JhI2F/V1YNzCGLcOTWLqwBznXw7qBMey8aE5sAFVYu3kMQD7LLXx/xNdChp+tfn6uZ8hw830kk6YMtzBLUWfq4SZnuJXbhL1UDzdRDpcP4tamxCxbOE6xybXqGsPb+eCQ+bFqKK9/mhlutQiUxH1WNenhFvN+e56v9RuSnlPjHm6VDk2Q349W6+EWlpRaSvZtsW3zt5vn6rxtMtwavQCadWrxj1NERNT+GHCjpuAEGW7Rx0Qw4pCONQCAf2V3wJjfpTxP3lYOXogSTD1rqqfMgFtXRwL/dcYBSCYcJBO2MRMJyGdmyFlm4VRRrXdc0lBSmowG4Twpw82UsZcv/Qsfl3u4pRI2bMvCRDqHTLZ4zoLe4F/sW5a1kvjJ2PE4rmsV9ks8j6Ud4+jqSGBsIoMeawqJjY/i0z2PBtvvndyAhzO7YK27EGtz8+HCid2/Xj4IqFmOtmUp38uv35zhpgbcko6Nhf2dWDcwhm0jaQDAr295Bjc/uA6nH7ccp75ql6LvjylgFGRL+WHAM3/saLmv/Bw5wy3nekg4dhDAMWe4mXq4RRs1W5YVm5GklxK6hmBa/j2Wt5/+BbgI/PhlXgZ72oVLLYMTSkltTLlfOc+txVqA+Oyx2vRwM78+ediGvoZa93BTB4yU3l4uc6+0H2SjmYKFxcp6w9v1XVcl2qeHWwsvnlqS/t9iIiIiEwbcqCnE9VoTj1nwcXAqH3C7P7088rzge8tSMqSUckTLCi6ge7rKKykFgH12na/sw0SUlOrHjS0ple4WF5lysp5aMmroYSb1CdN7uCUTDmwrfxGbLtG3zDMFh0xZcLBxp7svbpncB0fttj0+cOo++O9LVqBrYiM+vWwlklufxTa3B912BsuTm7E8uRkAkPEdvJhbgBGvG49kdoG79UV8oPtmbMjNxYDbh5eNPYueySyedRbCsnbLvzfSW6xnvMiNycMebtEppcH3CSvomycu7G9+cB0A4PoVz5UMuJkCGEHAzVU/n/CzMZeUytNcJ9M5zOlOFc1wA/J93PT1qKVpPhzLii0Fk4csAGpwIywdFj8zvpJBB1R/AS7eo3JLE6MBNikIUN0SjPuedoZbTUpKK7u/on3HNuzXSxrloJghqDytktLwHCvnIlQ+x/Xfl81OvDrbUoemmHiRc7w5uBV+Xs2qhZdOrco33iQiIlIw4EZNwSkWcLOAlyXXY54zgQkviSezO0aeJ39v6vklbnuFIEm5JaU6KyYw4jhqllnQc62cktJktKRUDoSZXo8yNEHLcEs6dlDKWirgZspwi8t4E9mC4UWZhQ3ufIwecRb+8IdbsHK4G/32JF7VsRqLnWHslhhAr53G7oXg2ys7nsfEH+/Fy5NTeHkyH/TCeP7LJ/oc/Gt8AYDd1Aw3QwajeH9MGW56D6ikYyuZZ7KF/Z1F3xsgJsNNTJHVhjYknTCwpwfq9FLNial8wE2Y29NhPH4mp35+ekDM8wDHDsuPjeuPCTjJPQCtQgc9D1rGS5WXEUGGW5lP17N/1OBEVUsIKNlc0+zhNp21PPz0ADYPTcb2Eaz2vZYV6x9mynDTMxqDx2ewpDQjBdzi/kGjWYW/Ci2lpNy8bXNmkk1nqmwzaeGlU4vSzzmRcU5ERCRjwI2aQrGSUscCXtuVL1m8O70ncjBP5ATihybkHwNQiF+UOzQhbp3R+20l6CW20zOuTCWlIlBjaSWl4uJHeT3GoQl6hpsdTCAoNZnT883lj8r3nnpsvYeYZdvY5GyPDCYw4CXxp8mDCs/0scgewc6JrViW2IQjO1cD2Smsy83DZrcfXVYGib75mOsPY7v0Wuz34tXwRvaDZYXBJ0c7IRwl4FYIeDlyhlu0h5vYh+f5GJ8Ke7Et6CsdcDOVIIq3y5XefyAsDc7kzIMostK+JtK5wr7y2x36skW4+aF1kWNltAw3z9Mv3H1lP6b1y48pQxOkkuSgpNTTS0qNuy1JZDmVG7hRJ9eqQcLpBH+A2mS4JRwLOdccnCrXL/6+CsPjGbzzpD1LrrNasdlV2jAMr8R5M5MlpXKGW6tlWMlDE+IC++G24e3pntO1NJ2pss2klddOLSrScsD8NywREc1uDLhRU4gbbgAAiU3/ws6JrUj7Cdwy9TLj84LvtZ5fdsztcnu4RdYZ89dUwrHQJQW99CEHQjilVAq4aVNKATWDTQ7yOVJJpbiYtS0LCcdGwrGRcz0kE3ZQVpvOukoZoc71ig9NAMILGbGO4MLGD1+rebqghc1ePzZn+vFAZjdscOfh7fsn8MP7d8S4nw92vXLpdujrBPZ77irsntyEqdt+in6rB2/vGcbd6T2x1Vmq7FEdmlDIcJPen8iQCinDLef5WFcYglBYHv7xwFo8uGoAnzz9FUrAVMgZLp5FNpn++YhgajrrGktKc1JgYaIwXEO8lYvmdWNBXwe2FvrMiamvekmpPlAgDJxElplfv9YHTj4X5B5u8v5qkV0WZlCVt71exurXsFan2h5u+XLcPMexkXPdaQVKpgrBbzHdVlebHm4xgVdDZiRQZMjCNNaSqzCAk8lFz8laEz0Ta02s14I60Ma8bf0z3NZvGcfF1z2G1x+xK47cb/uynmPq69iKWjk7j1pTJMMNPsJ560RERHmt1TCF2laY4ab+seL7HhKP/xEAcOfUnsGwBP15gm2be57p+66kh5uy/yI93DoNGW75/nOhsKQ0vE8E4SKZRkHJqHScwkWjZwjIiSy3ZMIOsq3SWQ9TmfgsN880NCGupLRwQRnE20R2B4BkotQfmRZWpPdG6rgPBsE2sQ8XCfxm/DB4sOG+tAodGx7CqzqexSfn/A27ORuVvcjZakEPNznDLaFluDk2bDt8z9YNjAePTWVc/POh9Xh67RCeenHQuGpzhlv+uHIPPQBIFT7bjCng5vtKdtn4VFa5ALcAHL7vEmXdYl/Kejy1J5sInMSXlKo935TysaCHm1Sq69cm48XVgpKlRI7jF3msQtVOKZXXLgK5fmUzF9R1eOp5EzleDQIG8T3ctAy3Umsp3H/XEy/hyz+9D5sHJ6paQzmBOzkQ7dWhMHDd5jF85MJb8dtbn635vgWrnJJS+XadIltPvTCIzYOTeOjpgbKf0y4Zbi0dLaSWFPnPFk9BIiIyYMCNmkLYw029P/fMPbCG1mLSS+KmqX1jnyfkS0rV7wU5eFF1hltsDzcbHcno0IT8Y+FtkQUl94ITQThAHQpQdGiC5wcXdmJfYmhDMmGjoxB8S2dcpEsE3EqVlIqLchHMEo+LrSwrWsoZfzz1e1E9uMmbixcXHQsAyCw9ECszS2FbPk5J3AtfinKEgaG4Hm760ARbuRBeNxBmuE2l3aC0c2Q8Y1yvqYdbUMapDW0Qn20m6xkDbnpJqbyFZQGve9WueMXyBfj3o3cLXkckw00faoDipYH5AJ30vTw0QTq/5CmltcjECQJuZZeUyrd97fvq1mB6ftUBN+3cr24d+eeazimgNsGOXFywx1MDPuWWlF7255VYNzCGX9/yTNlrUEtKy8lwC38/+YXfa3FZgNX47W3Pwgdwwz0v1GyfQlBWX1ZJaf0zycQxKtl/+0wpbfQKaLZr6YA1ERHVDQNu1BRMJaW+5yL9wO8BADdP7atkRunPC763rNgMN/lCSA5yVbZO8/2ObakBN6WPXPikMJstfK48vVLuUaZnUOm3xYW7uKszlQj21xH0E3OLXry6poBbzPd6uabcMLzcgJue/eFL/bpeXHwset9/KSYO/Q9cNX4kpvwkllpbMPmn85F+4PfwhjbC8XPBusXrTxTp4ZZ0bCVIqQTcMjlMlgi4maeUisfUDMOU9J4be7hpJaVKhptloSPl4FNv2R9vOHK3IMBTKuBWqnQzn+Emfx+9uM5P9g3PO6WHW4OGJtSyBboyNKGCklLl94UjsjurX5fYX9waanGtVrMMt5igeznkktJyniaf454PfP83j+Kzl9wVlF1PVz2vgcOSUinDLTagGt6uRyaffIxKAsOmQSqtqJXXTq1J/+8BT0EiIjJhDzdqCn09+YmNc7rCyY25Fx+BPzoAdPTi1m37GJ9nnFIqBbtq3cA2voebjY5kNHAm37YQBoRsQw83QM3gkpvam/YrLlTFfaKHXNKxg/LGdNadfkmpFlgSD/vB+srPcItMfUQY1LEsC1ayE5Y1hjG/CzdMHIA39dwPd+PTcDc+jcxD18MG8Ik5i/FAZjds8ZZiK3qU9yQScJMz3Fwfm7ZNBo+NTWaD93C4ggw3fUqp+MyCIKcpw83zlf5p+YBb+LieOCkCPPqUUjfS/F58jclwc9Xt5QCiXFIqyq19X81CrLqHW4kMKp3aw82PfD8dpkBTOeS1y6Xc1a5B7C4bG3Cb/tVaXLBH7+EmBn6U28PN1N8wTqUlihltaMILm8Ywkc5h28gUujt7yz5unHpmnYS/u6QebmUEMeud4VbRed4mGW5EjcafHyIiMmHAjZrCq162BF2pBPbeZV5wX/bJWwAA1h5HIfuS+VTVhxLIGW76AIVaiC0pta0gwym/XfiYKA9MJuxgPaahCYBaUioqKeMy9sSFu3iO6CGXLyktBGwyXtCs3cSY4aZnt4geblqWj7yZXsoZezzXcCyRJVLYhXg9t6X3wWjvLvjwUb3IrbkP7oZVgO9i9+Qm7J7cBAAY7O9G7/2PIb1kVyT3PiaShZdwwvNBzzKTA5HxJaWV9HCThyboww6gDU3IaoEAfd0xGW6+PtSg+AV2zvOU7Y1TSqX3TM+EqrqHW+F9K/f5ejDCj3msGtWWlMrbivO72hZuSrArNshV5c4lbsx7JQ+AAKKDPyLba/fLA2FKmVYPN+n8q1XGUj2vgYMMN6WktHQGY72CgHr2bTncGvy8N4NWXju1B2ZZEhGRCQNu1BSSCRsH770o+N4begnu+icBWEjufTxw+5PG50VKSqV+VMWCY9WKHZrgWEV6uOWDJ2pgLXxuypThJvVoUzLcpMBWtpD9JJ4jD00Qa0nnXEylS/Rw8/X7otsAYdBB/E0pnmZblvLaiolkuPnhRaIYLyG/xVucRUjtcyhS+xwH3/cxNbgZf/zFr7BHciN2TmzFPGcC2PAoMhseRebhP2HnJcfigKSLJYkh3D61t5rhJr2nurgMN1NwRM9wK7ukVO/hJm2in1bB0AQt4JZ//6IZW/Elper2pvIx+fzKfx7SBbh5tyVVPjQhvK0H/aZL3pdp6mzs86QMQDGsI244RSny+x4fkKlfhpsfyYwsBI2L9HCTPztRrl7WGpQebqW3V3q4SedfrU6BugZigoCbFQT7y5tSWp81hf8YMvsy3GoRsCaqRCv/vBAR0cxhwI2aUmblrQAAZ+dXwOnfTnns5bvNRzbn4Y1H7xYzNCF/X1xgrZLyKF1cEC9h22qGm6EMVH48NsNNnhbpq8/X9yuyn8RzuoIMN0eZmJnOFu/hFsnGiuvhFslwCyJlsSWlFhDbtL+wE+hhHfk1yu+3ZVlI9C3E36f2x9+n9kcCLpYnNuHDxy5Ax8ZH4b70FHZ46Z94/5z89kd1PA3vuYVwrIWF1+rFXgxX1cNNyxBTSkoNmXxyttp4pKRUPa/E1NdsVut5p/dwK5EN5EZ6uMnle+Gx5eELpgy6SrklAoG6YsGIaQ9NUHq4VZ7h5thhpmy1GQzy8+KHJlS1a/U4RcoZTZl+xbYXA0WAMJhfDvlnppzzJ6tluAWTd2uUm1bPi+JgaALCbOu4oK76c1vf9VRSUtouPdyIZpr+O4pZlkREZMKAGzUd380i9/SdAIDUPsdFglw7LerFW4/fHQAwPpVVHrNtyziAQVbJxaMufkqppfRwswwBN1NgLX+/E9lWnh4q78uy8s25Xak8Uuzr8Jcvwfot4zhoz+3wwqZRAPkppUV7uPnRklI960UfDqBnuFlFhiY4jqUEGPR9e7467VT+Kh9TUIZGwMGq3FJY+xyJ7kNOQfbpOzFx+xWYzFkY9zuwyBnF1M0/xEFdOyDV3YVtU8djB2crDkw9jx2cQdwy9TI8nVuKTiuDvdOr4U3sA7t7LtIZF9fd9iwO2mu7olNKRfBGZD+JKaXprBt9nYYebvLFbXyGW7SHm6kXVGxJqatur0wplXu4QXy2vpLFVXUPNxHQqbKk1CsSgKt4LdLtuOwy4/NEybBlBSXi1QZK5M/HVKYM1CjDLWaBkd5/hSXEDXDwPB8T8u/WCpKCKy0pVXu4VTdps5iZuAi2LKtkSWktz+k4we+DCnbfPhluLbx4ak1+0W+JiIgAMOBGTSj3/EPw02OweubB2ekV+Wb6UEsYYbgtvq9rhlvMhadjW9hpUT61Su9nJkpKU4ZebYC5h5syNEGLZQUBN62H2547zcUX33UQAOClbeMA8hez6SIBN7eKoQl6hpuFsMm/znFs5Nzw+HqGkTylVLwjpmClID5f+eJKBKeSex6J1VNL8ZMbVsODhdf1PolXdzyOOZPrcUQn4A6swWn94cXwXskNuHlqXyxPbMKy5AAm/roBPW/8bzzx3Dbc9OA6bNg6XrSHmz40Qc4qNPXFk4N3+R5u4eNxATdTDzf5r/qg/C6yyjx9SqnrRS/6bdtSAne1aO4uZ7hNpnNYv2Ucy5f2xfZUjPS38s2PVUMOIFbS2yrIXpKyZqstKVWDnvXLcIsP9kB7TwtB4yLZWOPSlNBqM6bEa1o3MIZN2yZx0F7bRbbPaUMTKh24UUpdK0rFOWIBlUwprdeaSn2uJsrn1cIhA8bbaKbppxzPQSIiMimv8RLRDMo+dRsAILnX0bDsfBBDzmyKGyIgvi+V4VaPklLHttHdmcAPzjoKPzjraOWxRJDhJpeUho+rPdzyX+VAWFyWlyg3NAUWO6QppZMlppTqF7ZxQxSCklLxgAiUWUAiEVdqq95vuhAM7gkGSoSP6e+3ZVmRDEX59VsdvcgiARcObvMPRs/bvonVu74FT2eXwIEH17fwUHoXPOYuh20BJ3U9gWXJgfw6tr6A7MpbkCkMmZjKuMbyMM9TAwNhyXAhK81UUmro4Sb/ua4HokQQ1tTDTd6z3k9Ol3PV4JUyNEHJ4AqzFyudMmkSlCz6Pn71j6dx3pUP4qkXBmO3V0pKoV7ITDvDzY++5nKEJbf5oJu+r4rWUE6GWw2CHXGvz9d+zuXPx7gf31eyh6sN4Ij1fPmn9+GS3z+OZ9YNR7aXz/F8Zm9hzS2Q4RZU1SsZbnEBt5nMcKsgsNwmGW6tvXhqRfoZxyxLIiIyYYYbNRVvZDPc9f8CYCG51zHB/XYhqwtQs8wcLZssnwFVeCwu4DaNklInJkNHZLXN6U5Fn+OoUywBvaRUvj9/2/PC0j49i0+8rjDDLbqeVCoMuE1livdwiwxJiCspddSggzzsIL6kVL0/GsxTM+Xyryc6cELWkXKU/lJyRmFSCvwlHBt23yIML9wfVz3UiVcvHcFDGx1s83qxw3Y9uH9oJU7pegRz7Qk8ktkFR3SuRvqe36B790Ivppy555scbAMMPdxybjRr0NenlOaUsi/9tErGlZRGMgTF/s1/6Luep/UPk4IbwbHD/NHINEvjXksTmVa+72PbaBoAgq8mat84PThR5SIM+64mw822rOBfpipZi/i560wl1EmxZfT4qlbc68sPolC/L7X9+OT0M9z083LD1nHsvmO/cl9WKykNhybUKMOtJnuJ2behh1tswE15Xn3WE7x30wyQtqIWXjq1Kv0HmecgEREZMOBGTSX71O0AAGfHl8OeszC4Py7DTQ9GWXZ4X9xE0elkuFlxGW6O+X4gvBBLKj3ewsflckylh5tU8qfurxBwC3q4GYJSYkppxi1aUir3ipPvM30fDk0Qj4TlVLElpdrac1p0T76oDnu4xWcwAtEefI70+uUAXaIQyLRtCz4srMFO2OaNAAC6OxJ4LLszHsvuDBsefAD7L3XQs+0pLFv1C3ypvxcP5fbHWncZ9AZW+numD8XIuWo2G1AY2KCVNo5NhhlEeoabWLs+NCEy4MLQ76q3K4mOpIOtI1PFS0qlALYf9HCrTYZbmHkX7qPYv/7r2T9K+d00r2KUktKY7DITuYeiXWGGm+f5+NJl9wEAvvWfh2uDG0r3+KpWsR5u+vrya4kP/lWb4VYsY8r08ywHlWtRzqyra0lp4ataUhrXoy+8Xa9MGH2gS1nPqcHPezNo5bVTa9LPOJ6DRERkMq2S0g0bNuCBBx5Q7nvqqafwuc99Dp/61Kdw0003TWtxNLv4Xg7ZVXcAAJJ7H6s8Fte3zZJ6tgGFiYJBSam6/0P3WQQAOPnQnateo3wsObMqLrgn1gSEPb6AsEk9ACSV6ab5r67vSxl95p5wQcDNcOgw28orOjTB2MMtJsNNvF69qbllWUGASKf3szNlaHnSfvTXYyyX1abBygFJuYRVBAFFQC4jleB2psKgqwcbPmw8tds7kNznePiwsNAZw2twJ07vvheWPokMamlm+PmG78FUWs0qzEiBs/6efBakXF6nv0rxvuklpfoQB72k9NB9FuH7Zx2FHbfrCbaXLwKUDDepR5k4xeTegeK1VkN8zr4fBieLXYt4vvl2qeeVw1RKWQ6lpFT0Vizz+emsi60jU9g6MoW01tOvURluptLa2Cmlnl+THm6eNqzB9PMsZ36aegxOV9x+brjnBVx49cPI5uJ/P5bet7hVaUlp1YcssZ7in6uJHJxr5SwxxjpoxmnnXCv//BARUf1MK8Pt61//OiYmJnDFFVcAALZs2YL3vOc9yGaz6Onpwd///nf84Ac/wGte85parJXaXO7FR+FPDsPq6kNilwOVx+QLtUjfNseClwuDU0GGmxZx+/AbXo53n7wXejqTVa9RPnYy4SDn5vJBvmIBN0NJqXzxK2eH2VVluEWPLU/MTGdrk+EmAldi6WHALdqrTbC0UJJ+MerDj1wpye+l6bXJGW56QE8O/InyUvF+iUwax4n2gQOA4UkXnUe/F3cnD8f6e/6G13c9hKM6n8akn8KjmZ0x5aewxZsDH5YSuBJrTCbsYLiH3jdP/gxetus83P3kJqxaO2h8zUB4TujBAD3DTS8ptQsN/kU2ot7zTQ2GFNZvhSFFOUAm779Sco8wsbtiQQA9w62WmU7y8+OCXSbq0ITK1iKfH/rric+Amv7VWrEebsaS0phj+r6PcSkDs5KMKb2kVP7eVHouB5XV963sQxYV95H/86H12DoyhRc3jWH5Dv1V7TsYPGKVUVI6oz3cyn+O/I8grZyh07orp1bFc46IiMoxrYDbY489hve85z3B93/4wx8wNTWFP//5z9hxxx3xwQ9+EJdffjkDblSW7MrCsIQ9j4LlqKemHHjRgxN6uamIs5kmXE4n2KYfK5WwMZk2X0TKgpJSKRgkX+SkkjElpSLDLW5oghsfcAsy3DJuJNtK5np+5GJav2jXe7iZppTGZbiVGsjg+2pZlvwVMGcOytlpeilvQgqyis9FbCMClI5tKwG3/t4UhscyGB7P5LezO3HL1L4Y9zvxjp67cFLXEzip6wkAwJSfwPrcfHgPvIQdnRTWuQuC99+yLKSSTn5QRSTDLQyc7bPL/HzA7cWhyOvV124amiDTS0qDCb2F15wvKTUHe+RggQdx3un91Kq7pJCnlJYzdVIpIfWhXMk0amiC3MOt0qEJynAKXx+aUMcMt5h9e75amluqpNTz830G9e3L4XnqOSZnd5pK7+UebvUJ/pj3I8rbK8l6jNuzZVklS0r1PoX1EGa4VV46nX9+zZc0Y1o5WEitST/neA4SEZHJtEpKh4eHsWDBguD7W2+9FYcccgh23nln2LaNk046CWvWrJn2Iqn9eWNb4a57HACQ3PuYyONyTCmS8aWVm+6wsBcdKQfLtu+r+TqV3msJUbIYn90GhFlYckmpnMkhP9+25ICbep++fRhAig+4+QBGpUwV/Tiu58VOJRXEH5EJPcOt8LhlxQ9N0P8AjWZohRE38SrkgKopGNUhBcscLYtRzngTaxKvVQS99JLSRXO7AAAThZ5VIgB5b3p3/H1yPwDAqNeJjO+g08pheXIz7Kf+gbP7/oq9kxuUz0cET/WAW7oQdEgmbOy5Uz6bZsvwlLI+5XUk1LJhIVJSqgWzxK6CDDdXzWxSA0FSBlfhbcz3T6tFhpsXHKOcMjc1o602gxtM+44LMJnIQUz557IcctBFnwQcO6W0Fj3cYvbhRjLcwrWZ1G5KqdqjzZQJnI0pKS0/ZFRc3NLlsudqBc+1UFFJaf16uImftfKfo5TxtnDODmMd1GicUkpERCbTynCbP38+NmzYAAAYGRnBI488gs9+9rPB467rIpeLz64hEjKP3wj4Ppyl+8DuXxJ5XA1KaY9JQRbHtjBvTgd+8ImjlIyyWpHXIZrkFxuYID9HHpqgDguIllDKPZciJbR6SanhIlbOmhspZG4p+yiU4erZN0B5GW7KRWqRoQn6taeph1twj2HYhekCXe7hVrykVM1wE0EvvaR0bm9H/vFCGai8xhsmD8Q/JvdDFgnY8LDYGcaOzjacsWwrEpufwgd6b4W75Sg4C3cFAHQnfMx3BuBNdSjrEsG+hGNju7ldQVZdnCDDLatPKY0pKdX6/SXiMtyUcj8Ez/GC+/RyzuouIIIeYX548V8sZqMGI+Ifq4ZeSun7ftES8GDbYGhC+L6Wu5Kc8j6rZZXxfdbK3HkRxQYyKO+xyHArUoIql5ROZ0qpnKVpmp4pl027XjQDc9riAm7SOVr1roOfofD38ubBSby4aRQ7L55j3Fa/XUtyifnQWBpPPrcNh+6zCMlE/GRur8jPXitp5WAhtQmegkREZDCtgNsRRxyBK6+8Er29vbj33nvh+z5e/epXB48/88wz2H777ae9SGpv3ugWZJ+8GQCQ2v8U4zZxU0r170XpVyoZf4ExHXIwqNwMNzHkQO7htsdOc7Hb9nOww3a9xv27UkmpHhsQWV3iQtVUUurYNhKOhZyrNj8PH7eQRf4CWL/ojptoKIJAHtS/K+0iQxPigneC70ulqcaS0ug+1R5uWoablPEWDk0Ig0/5bSx0doT7mDenEHArBLf0NWcLvyY92HjJnYeX3Hl43WGnY+PvLsA+yZcw+Y9LYPfMg7v1RZyTSMPu97FhchGewMkQeXti30kn3+9v2fZ9eHj1lsLrjb7IpFYGK8R9NkF5qC1KSu3gNcvP0HuLAeI9FsFUNTum2sCACDj5UnZX8R5uync17eFmOgf1QK3xedJ7GgyVqDbDTQ64NUEPN7nHnnE/vo/xdLUlpWrANpuVA2rR/WRiS0rLPmRRce+rnIVZ/b7FrbCkdP2WcXz9Fw/gW/95RPC7RV9HvUrP5J+1P9yxBrc/+hJs28LhL4/+I5ZQj0EVjdDCS6cWpZ9ztcrKJSKi9jKtgNtnPvMZPPfcc/jWt76FZDKJz33uc9hpp50AAJlMBn/961/x+te/viYLpfaVfvAPgJeDs3QfODvuZ9zGNmSBCcpAhTIyV6ZDPrbItCrVw62jkG0mlzEmHBtfeu8hsfuXy9BMQyIAqYdbzGvuSOaHOpg4hkw6IW5KabAOP3phFhfAiNuXkM+Wy98We6gkw01/b+TAXyIIiKqfT76HW/hZBBlu2fJ7OuV8B78YOwaf6/8L5o0OwB0dyK+98PhSbMbyxGY8m1sMIJxSKtY0pzvsJWgKKortIj3cIhluapaOeL8SUgP32Ay3IKBrwUYYgKnFlFLPi+6v2MV8JMDmmx+rRqSs2fVRJOFHXQfUSbjV9XCLL+s1HW864kpK9Qw3cTs++Ad1aEKVATc9w830/sWVlNYq+FOypHRaPdzCoLX8eybn+nhh46gScPOU59WHnOE2OpH//MYMLQVkas+9Oi1sBrRysJBaU+SM4zlIREQG0wq4LVy4ENdccw1GR0fR0dGBVCoVPOZ5Hn7+859jyZL4f1kl8kY2I7f6LgBAx6Gnx5Z6KRluMT3N9O3qQT72su370NedxD67zCv6nBMP2gmOY+NVL19ccv9yIExcfMYOTcjGD00A8ll+puw2QMpW86MZbnr/H3GRLJ7jawEEu1hJaSS7SN25/LD47EsOTegokuEmBf7EmiIBWr2kdE7+95Yo3ywnuJDNuZjwO/CrzPH4xJIHYC9ahtQrTsUP//wM9hhagSM7V+PYzpV4dqwQcMuJDLdo8NV0zids8/sZHZpQ+OqFF/6AWlLqKcGeaPDDti2p7NNXAhBVD02Q+mN5JbKp8tuFtz2th9t0oxORsmbPA1A64iZnmIrPqNy3I+fJ77P6udW1h1tMMC/aw80P7jfxPL/qoQlKOa2nlkWbjpeV3g+1FLfsQxZlKjX0pd97tSgphRV9j9ZvGcMBeyxUjimYfhYeeGoztl/Ygx0W9lS9HjnDLch+LfEC9YzEVtXCS6dWpZ10PAeJiMhkWgE3Yc6cOZH7Ojs7sffee9di99TGMo/8GfA9ODvtB2fR8tjtTIMFgu+l4ETdA27S/pMJGx97ozkjT7bjol68+zV7VbR/1wsDH/rrTZQxpRQoXlabcKLHsZCPbZTq4eb5+h+W8UMTSvVwA/zIRV6poQmdcoZbsSmlMSW/+aEJUklpb/GSUhMRGNiIReh56zeD+7MdA7g9vQ+O7FyN/ZJrscgexmavP9i3WJN8fBheY9xnmtPWFmSPIcxWA+SS0ugQBM/zlSCbbVmAJS7OazNNUWRaeb4UFCyyL32NtRjcIJTKsiz1PNu2gkBm+SWl0vr1oQl17OEWOwTBU9/TINgUV4IKrdRzOiWlOc/4mJDNyiWlM9PDzSsR/NJt3DaBwZEp7LPrfHXXhadaloWdF6vtATZsGTduq98GgPUDY/jhH57Arkvm4Mvvi2Y+l0vOcJN/BotRswqrPnTDtfLaZzvf9/HUC4PYcVEv5nSnSj+hSeinHIcmEBGRybS6yt9999247LLLlPt++9vf4rjjjsMRRxyB8847D67rxjybZjtvbCuyT98JAOg48A1Ft1VLStXHig1UqLViveRqsn9pGqIrXfCb1hBMKY0tKY3/8RblT74XXnCJYFCkxLRwDSwCfb5W82dZiO3hpme0GXu4if0Uvsqfr7GktNiU0kS4vQgqRgNuYUlpMmGjpzNf3pmuIMMtlzMHO1NJBxvduXgisyNsy8dbe+6BBT8YyJAwZLiZTqO4cytSUhoETsS+REmpFWyvXwO4nofRiUzwem0r7H0YV3pYKRFwkvdXLNNGDfJp2VjTTHGLTsotb3/TKylVg1Vl9XCrQaFhsQmZ8iPB0IQyX890SkrT2RIBNzeupLTsQxZfj2FHOS0gWsolv38cF17zCLYWJgsHz/XDf6zYYbteXPDRw/HRf98XQL6Xm7pt9HlCueWfpYQTgaP9HePon1ermokeeVQf963cjAuveQRfuuzeRi+lMjzNiIioDNPKcLv44ouxdOnS4PtVq1bhv//7v7HXXnth5513xpVXXomFCxfiwx/+8LQXSu0n88hfAM/N925bskfRbYsFupQebjNYUlqPgFtYUiqXCUYDRkAYcLNi4modRTLcwmy1MPsm4djI5rzYqaVOUFKql4KqJaW2ZYUla1pGW7QkUt6R2F/xAGpHUu6FpwUjLSvI1AuGJmjbOI6Fns78Pno6E0gVAngVZbgVggR6wE9Mh71u4hDskdyIPZKbcMG8X2Hb0CJMJl+GnPMyAECXVBZrGVLc4s5j/f0Ms8dEcDZ8jfl1+pHAxdhkDv/vJ/dgqhAEzPdwC/dTyx5uvnQeFy8pLRJomW6Gmxbfiiu7jDxPBFOs8DMqdR1/68PrcdcTG3HCK3dQ9iOfU3Xt4RabPaeXlBa2L/e90N/EGHKpZv552hRSw4uMKzmtZ9DE1XrslSImPY9MZLCgvzPyuPidtbC/K3gNL22dCLJJgeLneK7IAIeRiQx+9Y+ncfT+S/FyLcNOF/Z0LK+UG2ijDDftdp3/7Y1q6OHV+R6oIxPTCzjPtGiGW0OWQURETW5aGW7PPvss9t133+D766+/Hr29vfjlL3+J73//+3jLW96C66+/ftqLpPbjjQ8iu+p2AEDqlcWz24BSJaXFm+zXkhxfqUdwT7wWufdWXIAxyHAro6Q0pWW7BYE9L7xAFpMx9ZKwMCAnXTgqATdL7Z0mHavUBNR8+WBhP4VLJPnVWIbXVmxKqWVZQWBQTJE19fzbcVEvXnPITnjL8bsHgclM1iv0tCsdXMi65vde7GubNwd/mjgQAJCyXCxxX8JH59yMI3N3wfd9rYdbdP9xgzDiApbhpNdChpsoKfW8SObUwNBkEGwDRMlkGFDypnkBLp8znjS0odyAWyToN80oQDTDrbzgkRzwFj/3pYIXdzy2Ac+sH8a/XhhU9lNOUKcmPdxiXps+PCMIxpRbIlthGa7g+9rQhFIZbkpJaVmHLGNN0fvcCgcFBBmBMT9/8k/rdv1dSCby/3gxMDxpPI5pkIdp/wBw3a3P4r6Vm/Gdax4pvU4RgJd+r5f6jE2fWbObmMpFMggVzf8SSBL337tSnnxuG75x5QPFz4U60n9WWuFnh4iIZt60Am6Tk5Po7Q37ltxxxx046qij0NXVBQDYb7/9sGHDhumtkNpS9smbADcHZ/EecLYv3evPKhJwm8kMN8eKX0ctiOmVI+OZ8II/LuBWxpRSYadFan8hRxqaoGewxfU3CspQtfstqIGvVEx5KRANCPiQ+48V9ie/x4Y8BTngpmevAUAyoQadHCcabPz/7P13mBzHeS0Onw4zs3mRE0kkAgQYQII5UxIpUqKCZWXLlhWcJCtcBV/H+/k6y75ykC2Jtn+SLUtWsK1sU5kUKYpizgEECRIEQCJnbJzQ4fujp7rfSh0mbMDWeR48uzvTXVXdXd2YOnPOe2zLwi9ctx6Xn72Ms942GkEqucDOveepr02ZxF/eWTsTf3jsTfiL46/Dw/a5AIALGg+h/sDXeYWb4vrp5nEjr6W0ecy+QuFWrfNBGraVnPtOkF2iSikhAfT7SHXjFGqsVtFqDbfYUkoIySzyotGcF9Vaco4jRWh2n92t4RZy7WeFJuRtN2u7IAxTQxPCMORquPGhCZ1ZvKrmsF+wH7a9zg7MBb3YFpYv7AMA7D2UEAGpCreUxNTjY/XM8cXtEpItUbil76P6EmSm45++/QT+8F/uw4FjE8r3Z7M1di6i1S9K731qP7bvGcHjzx3u8IhahJl2BgYGBgYKtEW4LV++HE888QQAYNeuXXj22Wdx1VVXxe+fOHGCSy41MACAMAzQePYeAEBp0w25PmxxRFeKpXQqQxO60dei4YisPnyimhBhIsHo8Ao33TgokXTaEj7YhNX4otZVZsHkavqQ3zmFG0GkcMtJuPnygjtWuCkOQ2WXpTXcVGmejBiMCTcppVS0gSbt1Rp+KrnAatV5GoWbqCQcCftwMBjGD4Mr8B/jlwMA6o99D/MPPowrK8+gBE+tcBPajQkxidBgPxkByI4xUUqK12uyxtfVtCxe4cYpceShZYInM2RL6UTVw0PPHOSshmL9JWGWtDCKBJKltKBai08pTd+XzQuqIBQtpTp0Qh2hC2QQ6y7mtRsy5K31Jtplg4APTRAJJT/grzUXNtGhxauScPPlc5EGNmd0oSXi/2EsaZQqb8Q6hXz7AdcPRdrzVATbPSRjzVS4pdn8ZygOj9QAAMeaP0XMgkMwINCEcmeCpmtPB8RuZ8O9Y2BgYGAw9WirhttrX/ta3HTTTThw4ACee+45DA8P47rrrovf37JlC1avXt3uGA1OMvgHnkM4fhQo9cJdeV6ufeycCrduE250YdUNNd2iZn2gw8cn499F0kkKUdAQlpQE0yrcgiBeTMehCbTAO/md1nCjC0YxNKHk6mvHiYu7kDA8qlpmqtfSUkqj/nlLqSqllMK2LJRLNuqNALWGn0rIuLaFGvQJsWIyLKsnV2v4uLe2HpcvPIbV1acx74mv4C39wJmlPfhaeAMAIPRqsNyKZsw2PF9W38WBBMI5ZESkH4RwsxRutkWKrbevcBMtybRtAPjn/3kSTz5/FNddcCp+6YYzmtuRYxL6bVf5pbPvZYG3lCYEdRpiwo2ouiK1UZ5x5hpWKrQKt5Afe2yR1Ci28rYr9yOrpbi00wy1IW/17JTCTX6N9pNLfRifL7UaTHwEs6TFiZqHkfE6Dh6b5Kzd4lmnISMiSgUIN9oHm4tFargBs4OsEp97ii2mbjAGbaNVhRub73mfTwYGBgYGBtOBthRu733ve/Ebv/Eb2L9/P5YvX46bbroJQ0NDAIDjx4/j/vvvx7XXXtuRgRqcPPCeuxcA4K65AJabTwGZpixLI+M6jW4noi6a1yTciMItjWBU/c0wSgoQL53fq9yHptkxBRtdFFOiwCVBC/TjrWXxKow0RYaoEOHKwakUbqrQBKJwU11vdmx5CTcgsd9mEW5sYcAWyOJcrAjHzohIZqt7dPg6WL3DCC0bXmhjU3k33ujegcnb/hljn3sv6k/dzvUTj5ldG40aRaz35xZQuNkWuMLu7dZwE+16ogrvyeePAgB+/PBu6TjYGNLqXRVFy5bS5k/bsuJ7PWthx9qu1gSF21TVcNOQiVINt4KW0la3Ey2l4vnTEVji72nYtX8UN33rCew7oq7jpCbc8s9xGgQhEZQx4cbfr+zZ43kBPnPzFnzsSw9hj8ZeCiTkmOo8FyLcyO5MWZg298QwDdXYZiJiwk3zvuFfZhda/SzFpup0TVlJi23mnYGBgYGBAm0p3FzXxUc+8hF85CMfkd6bN28e7rrrrnaaNzgJEQYevOcfAACUTr8s9368ik18T02sdANTZSk9MV6PVTJZhJEqWAAAV7BbDBegKaVJaILCUqqq4RbyHywtWOituLjxspVwbBtPv3BMe3xSDTfSluooVOeY1nDzFAoddqyMdMqylAIR4TaKRqallI1HF5ogKtxKzeRXpvIJKoPof8vHMDZRx5f+7Zt418CdOM/ZDu+57QCA2v1fRWntxVK7TFmns3+xBSjbLQ5NyFXDzUIQ13BLt77lASUlKKEbpoip0oiWdhcx4v5FQxM4S2mGciaxlCbnmNbTKjLOVqBNKQ1CqOri5bVA5Q5XkFJ0+dCE1JRisc+cY/uzLzyIIAzx4oEx/NV7L5feV12zIpZSOow8oQkAvf8CHFHYHqUabin2z3KKYlhuV1a4pd13qv5mA2kgEi2meP3sRqtflOYJ5JlKzJRxGBgYGBjMLLSlcKMYHx/H9u3bsX37doyPT09ikMHMh7/nKYTVUVg9g3BOOSv3fvQDmU7x1e2EUmkcXSDc+nvcmFA6dGxS2Y8jMI46ovGM0+YBAOYPVqQ2mOVQGZqgs5QSFZRoKQWAN790Hd5wzdrUD8+SpZSLO5W3VzVFyUOxZhR9n/2Uj12vcKvX0xVubFdPUz9PrOHG1ClMbeI6NqxKP3oGh/FIfQ3+YeQV2OkvhjW0FNbwUqA+ieod/4qBw09gpXMYjCVh/Uj2L1bDJiaHmiQjU8T5gbQImKjxhJtFFFydVrhxiaUpjUk13ML2xkAhKdzyWkrD5NwnoQnp+6hruOUNTWh/saZrg4ZXAJGVHOi8wk22jCNd4ZbSbt7TwY754PFJ5ftZCrcilksVwQ/I//ckCtMwflbwYxLnZJOQVzRPU591/TPQ8+vlUbgpzv9sIA1Eoq3TJL3B1EL3pWEWki8OOjiYAjDzzMDAwMAgD9pSuAHA448/jr/+67/Gww8/HH+It20bF154IX77t38bmzZtanuQBicPGsxOuvYSWHb+b+7TbKPsvSlXuHWB4LMsC4uGe7H70BgOMsItw1KqG8cbr1mLRcM9uPTMpTgxzifdxQo3UrOrRFRvDDEZZ1sx+RVCULiJ14P8eelZS3HfUwfivxnZwWqbRQo39pp8HKpjo/2pFqCVcrRAZcRlHoKyHFtK01NKJYWbMD5RjSLawZiKkL3+vLcUf3/iRvzrb14L78UnMPn9v4W36xEsxSP4rWHg3trp+I/xK+Mxi+oskcxKLKWJwk3ERFWs4QYEIbELU7JLcx7SIFtK+TH2lB2OkIre43+n/WapyrIgF6jP116iGrRiVa1IRtz71H68sH8Mb37Z6bAsKz7frYQmdAK6mmySpTRg23dY4SacHzE0QSY/9QRS52q4ye14XK249P11X0AAfLAGRYko3FTPKPF0eqSGWxiG3DOOWvRrDV9SK1NwltKYxNMfoOpemA0kQly7qznW2ViHziCBKo08D7Jr+U0tZgNZbWBgYGAw9WiLcHvsscfwy7/8yyiVSnjTm96E008/HQCwfft2fPe738Xb3/52fPGLX8S5557bkcEazG6EXh3ezocBAKV1+e2kQLqVk5ERrSZdFRoH6bpbBN+i4Z6IcDuuVrhl/c3Q11PCjZeuAsDXcwNIDbeQ1nBTKdwSJRdNamRbqHqmi8V337gRV527HP/142ex+9B4vDCybUsiAZQppRmkpmrB/ror1+CRZw9j48r53LEyqIIWWKJrZCnVkwCMANQp3Gh9OUC28rqu3Dc7A+5pm9D7yg+j8fyDGD/wItzjL+CyynZsrZ+CF+2NANIspfz4mIrPCwJp8Tk+yc8Fm1O4tW8pFRVygaDCG+gtSYRbVxVuraaUNvezLEubUvqZ/3kKAHDW6vk4Z+3CmFyhJEsYhLn67MRiTWspDXnaMiZBu6xwy7SUpinccvWYQPc8VircqKW0gMJNOg/NPyVLKVO2+gFHOCZjEklgnpQUiXyGas1Hf09JO1Z6LA1Prf7i+1UQbrMgcEBUuElhHbPgGAwSqNLI84Bd9pmSUmr4NgMDAwMDFdoi3D7xiU9g6dKl+MpXvoLFixdz733wgx/E2972NnziE5/Av/3bv7U1SIOTA97Oh4FGFdbAQthL1xXaNy2JNCbcpsJSOgWJqCw4Ie5H6EYkjPIMQ2dLpWRAklKabBcQgswipEy8YFT0TfsqlxycvXpBnFzKFpZOTLglBI+KXMs6toZCoXPO2oU4Z+3C5Fgd9bFT5A1NiAk3TQ23hUP8tdMp3HRwV26Gu3IzXnjhGJ741ufwit4n8Ob++/AvWIUjsLRKDlFp4xCFm7gYGRctpbYFi9SQCnKQXT+8dye+8sOn8ZG3bMYpi/q598RgjLiGW/Pl/p4SDp+oKo9D1WfnQxNy1nCLFW7ItJRO1Dz4CnKTtZMvNCHXsFKhr+HGn8c4dTOjU5bem3dBKxLgmZbSNLtjwROiI+dVrfB1BtP7oeMQ1WrxFw+SpTQJTVAp3MRDE2vK0ccE7V+sv5jWbp6U0tmqcIu/aGB/G4XbrEa7NdzS6hR2ExKxa+adgYGBgYECbWmCHnvsMbz1rW+VyDYAWLRoEd7ylrfg0UcfbacLg5MIja23AwBKZ1xVuN4a5TV0ltJuEWCqvlTj6BRYcIKqTyB/SinXhrCJS1Iv2WIlDk2gC/Pmr46V1LGiKZIqG6jqtLD+qcKNtcUay1LLqZBV04j2xaBMKS3nTSmNfupCE5Yv7MMSkggrEm5uzsRBx7bxw8lz8aK3AAN2Da+xfwpADkAICFEGJHOS1nDLVLjBis9REIYIqUJNs4L49Ncew9GRGj7//a3SezoVHvs50Jt8z8PIGF4VFwoqO+UQckOul5WvwdhSaqstpfT3kmMr7bsAHxxRZJytQNePmPyaV+FWjony1pRwQZCucEu7FkVPh+4xqDqvvO05vV1O4SalqvJENwNNCW4oCTe+HWpxTVNkVhu8MjSrXSCDcPNZbcnkAGaDLS5T4TYLjsEgQeuEW/Rz2uas+P+xmXcGBgYGBgq0RbjZtg3f138ADIIA9lT4/AxmPPxje+DvewawbJTOfGnh/XllGf/elCrcSB/dtJRyfWaEJuQpOCy1Qcg1tqCjdd0YRIIs2ke/0AQ0ddeEov9xAAPSvxTOOrRchJtlceNUWUrjGm71fCmlbOEtnlfLsnDBGckXEJKlNEPhRvvx4eDL41fCC22swy5cVn5O2k4sGh7XcLOTGlIiaSbWcLNsksIZIpfCjaHekM+/TkHG2q2UE8JtrEn+SXXjBItpOxAvZ257JFFeMmKZjqVGbLEl19bWIwsEAlGHbijcLPK6UuGWQT6yEJC81lNxwRmEIRqeXuGWaikteEJ0X7iomvGC/POLCyJQpCyrwO7zmqdWPYqvUbI2zXYrWrGlsSr6SjvHjZhwS55Ls4IzEJ57RuE2u9GqpTRPIE83YaaZgYGBgUEetMWGnX/++fjyl7+MPXv2SO/t3bsXX/nKV3DBBRe004XBSYLGU7cBANxV58Pun194fydFWeZMpcKtyymlQFTjikKs5yMSfcwOmQZdUie1uykVboRwUwcYKPpSWUObP0WiKgypLUtuK7uGW76PvPScFbWUUpUaOzadwg0AR7iJ71JLadp1Y+3u8+fju5ObAQCv738Ai+wRbrskpY0nQGlKoqRwE0MTSA23IOC3zyIjVOSV3tbIFsnJ+6y2IN2DzgnxvVaQVi8rDYlqEEQBmLxPyQ/LtlIUbvlCE4oQTMdGa3jg6YOZqZ8OmW/0vmbbZZGPTOGWu9abcA6CkCdlu5FSyqD7wkWpcCtSw40QqZLCTdM3u88na2oLaFpyrmyBJoRbrbMKNzZnXccmJQNmPo3ATkmicOPfn/lHYEDR6pelYg3TKYc472bBvWNgYGBgMPVoq4bbRz/6UfzSL/0SbrzxRlx//fVYvXo1AGDHjh348Y9/DNu28Vu/9VudGKfBLEZQHUXj6TsBAKWzr2upjTSiy55KhdsU1HDr7+FvS1HBJpI8vZXs21gi7ZqETEjIAFVogiqlNKCW0rwkHCMsRIUbx67ka4tihVA/TAfHtuE11bhKSykh3ERS4CWbV+CF/aPYdPpC3PfUQQD60AQAWLtiKP59/lCFe4+Sd5Wyg5rGIkbbvb16Fi7q34dTsA//Z/i/8VTjFHxh7GrUUdJaStm1pMomVjdPVAXatgUrYIpDnhzKWj+oVF06EjRZJCevjU7Um+/xiqO0mm5FUYTkoeAspYSQZKDXzvfl8xr3H+Yj3HIOCwDwlVu34aFnDuGjbzmPq1cokokl1wITmNHrkteKxRRuYl0+HaQag0GIuhAIkLY9RfEaburXVc1wIQUZx0brzEk13BJvPQdmHa9qCDdJ4Rbobbf8nMuq4aYg3BTTcvehMezYN4KVSwYBRP8f2JYFP+dcnW6Iyl5Z4Tbzj8EgAb13xZTeNEy3pVRUj8+CW8fAwMDAYBrQFuF21lln4Wtf+xo+8YlP4LbbbsPkZJSq2Nvbi6uvvhof+MAHMH9+cTWTwcmFxpO3An4d9qLVcFac2VIbabXT2Hvdsnhqx9Gl/vqEFLqsmm19OQg3nS01CJPFClskqlL5bC6pkVhKVX0pSTjeUkoVQ+xDa161HAD88bsvxk8e3YvXXbla+b7UDlW4paSU1hUKt76Ki997+4UAgAeebhJuKQo327Lwsd+4DEdGqti++wT3HrVu9ZQcjIg7x20kv4ewcWvlelw79h2c5h7FOeXd+Pm+B/HVicu1llJVDbeesiOp24DovNvk+ohqszSoCBNtHbE0hRvZJSJ0eQKuHYi7t2QpVaSU0gL2gYLIpO/lC03If5zsvI00CUvaF0U03yLGTXVfZyrcSsUUbqr6fbSGWaGU0oKXXZtSqtA7FanhprLYx21rvnhg97nOAirXFdQTgDpVpXKsimNRzasv/vAZPLv7BN728vXReG2qcEvtYkYgruHW/NtYSmc36P/zfhByNQXTIP7/N9WQ+jUTz8DAwMBAgbYINwBYt24dbrrpJgRBgKNHjwIAFixYANu28U//9E/45Cc/ia1b5cLaBnMDod9AfcutAIDy5lcVDktgSCO6WL2qPLXM2gXtQlSNdQoigaYjGBnyKNx0wQFBQFJKUyylVOEWhiGxgeZTpbHXmJIjOaZE4VbEUrpy6SDe8YoNyvdU4C2laQq3INWWl1hKeeJQxLIFfVi2oA879vKUGiXcWFCDCmK74848/M3Ia7DB3Yv3Dt6KK3uexTZvOYIwSvsNBALUJSmlbFFSLqkJt4hMbRIwkmUuQ/1TxFLKFkfkNaZw4wk2fr+2FW4p9r3U/ZSWUkK4EXufHwR6S2nY+ZRSNjaxT3buS66Nhhdw840nmdj1TrfXVlxZ9ZoGiVALwwxLafSeBdkGWJRo1T3/RYu0ZVmC2i//HJcJN/UXD4mlVEe4CX0IKaUUAZGoZRFueS2lrHbi8bEagOjLlujZFrZNcE8F2HPJhCacHKCfcYIgBLKrZADQKxynC9MUlmpgYGBgMMPRsUQD27axaNEiLFq0qK2ghO3bt+Pd7343Nm/ejCuvvBIf//jHUa/Xs3ck+PznP48NGzbgPe95T8vjMOgM/D1bgNo4rL55cFdf1HI7nKVUWN1MpcLNmQKFW7lkp/bjCIX3e1OIG30bTUVTSC2lvO0TSBYytq1WuKkkbiqSLFZQNReWSWgDURIpGlt36nDmseVBVg23clkfmkC/bWfnMU3hRiGe9x5yrfLUcBPbecZbgR9XzwEA/FL/Xegbj+pn0usUjVkOxdD1Z1tJSqlOwaODaqGTVcONLo5Hmwv/9JTS6VG4sUW9TRJ6qT2PJkaqrLoM3UgpVSnUqNWbET50HqlUVJkppaUkpTTP+Nh4Yjo9BBeaIKWUCupais7VcCO/x/3mt5RyoQmSpTT6KaWUujJBy7UpvE4tu36oPkdA50ITWJss+MN1kuf7bCANRCuhUbjNbtD7J+/zGaAKt+m54GK/hug1MDAwMFChbYVbJ3HixAm8853vxOrVq/GpT30KBw4cwF/91V+hWq3i//7f/5urjUOHDuGmm27CwoULszc26Dq8HQ8BANzVF8Jqg4hNC01Iari13HxuUDKpW4SbZVno63Fj25guJIKhtyeHwk1jeQoDRWiCylJqW2QRHZJi4Yq+FC/GizlVDbdY4pZs//H3Xo5Dxyex7pQOEW6ENFNbSmloAr/kpARdrNSLa7ilz2nxvPdUCOFWQOFGx/y9yc04xTmKs8p7ccaL30QYXpZYSi2ZfGYkgY5wEy2lFK2FJuhqmbE2k9dUltLod0LApY4gG3LdsGKhCRZJuaWKP2opjWq4pSjcUhaRloVmOmyuYcVtAjwBRPsolWygBr3CjRF2YUK2q8ZfJnMmDLNrKlJ7esML4Pm88k+XUuo60fYUqrn3zAvHYFkWzjhtnvRertCEEIBVzFKaqnDT9J2VRizVcEuzlAbqOaduV6Vwk7djX3wwAo+3lM580iAeokC8Je/P/GMwSEA/VxUh3ALN9Z82zJBhGBgYGBjMLMwowu0///M/MT4+jk9/+tOYN28eAMD3ffzJn/wJ3vOe92Dp0qWZbfz1X/81rr32Wuzdu7fLozXIQhj48HY9CgBw11zYVlvpllJL+Xo3wNUC62J/fRVCuAlrN4lwK+cITUhJKc1jKbUp6RDSBWM+SynrntaEE9uiuy2a14tF83ozjysv6IJYtRhmZJSqhhuncBNTSjMYCHGK9JBr1ZNCuIkqPJf8HcDGv49fjT8tfR39tUMIjrxAyCE25mR7RmToCL4oNKFJwIgKHu0II6jIKx25lCTKEYWbwlJKlVp0v1Yh2RjzWkoZiWmDKNySfWv1nAo3QbEnghWrL0ISxIQZORb6OyPP6TzwAv4c03ZKbhIqQlF2ecIu6xnL5oPrWGh4kEJBxPMQW2AdC5NCW+J1b3g+/u6rj8G2LXz6w1dL94iO+w6EuWSDJxezzjv3BUTe0IQswg36OalTAQJ5LKXya2qFW3QcLEWVKtxmCneRhszQhKkekEFboP+NFrGHTncNNxEzxNlqYGBgYDDD0DFLaSfw05/+FJdffnlMtgHAjTfeiCAIcNddd2Xu/+CDD+LWW281yagzBP7+bQiro0ClH87y/PW2VJgpKaVpSrtOoo+o1nT114CIRMlDNOpsqZFVLHrNVdRrYos9x05sdSGp86NUuKWGJvBWzDAEqQeXeRgtg9pwi6aUuooaboxcyTr3Yl2p3pyWUp1tmmEyrGBr45RoLNvv4xI1AV4Rx+rNpVpK4+MqZs1SkVdZllJO4cYspUKfXL9tLmJEQiXvgi4k5DAN+WCo1vkabrp6aCGpk6gCvRfyIqnhpg4kYMo0hyhTOUtpXMONJ9tFUIVbnvOW1JBjBDZ/TnSJsaJNXoVaI0DDC1Cr+0o1nv55TMk11q8+OVUEp3DT3B+iHT6r6LukcCPjCQP9fK21UMNN9Ro7JjaHHceOnzmzQR0mKpuKKnMNZi6KWUqjn9OWUhqKf5t5Z2BgYGAgo7DCbcuWLbm3PXjwYKG2n3/+ebzxjW/kXhsaGsLixYvx/PPPp+7r+z7+7M/+DO9973uxZMmSQv0adAexnXTVBbDsnFVwNUgjuth7U5JSOgWWUoBPKk0LTciTUKpqg50runBV1nCjltJmE4FIiAh46eZTcPeT+3EGqb8m1gizY5KBMG7KzNPOIH9ogqxwU9XTY+cta86J71OF2wVnLMbdT+5XKt3SSFaGh2urcV75BTSevx9BcHq0n5WQz8yqyOyvLIlV1Re7tqJirSVLqUZBFhc4J/uMTza494BoOoQcSdKmwk0iN/Iq3Jhq0FLa7aqCwq2htZSmHwN3L+SEqoYbvXZM4WbbUfu+QPqJltKSooYaICvcsiDWg9SNW9y+pCDcxO5UylsK3fNYDE0A+DkaZjiMuRpukpKKzRF+H9XxcG2KNucUhZuO5M3Trri/2F9VVcNtFnAGorJJJj6meEAGufGdu3fivq0H8Lu/eAEGeqPPOXTO5bX8A9OvcBO7NdPOwMDAwECFwoTbG9/4xtxJkywRLC9GRkYwNDQkvT48PIwTJ06k7vuVr3wFk5OTeNe73pW7vzxQFXOerWAqgjxqgnYRhgG8nRHhVll3Udvnke5fKtnS30C04Or29aKL4rIwjk6ivzch3Eou3w9VnfRW3FxjEBej7JxRhQwjnYIwTOZIbFG0YtVKGIaxgsqy5HO+cfV8/P3/ugpD/eVYOUNTUVl7UVukD7d7148SAOWSI/XT1xs9CuuKlFK6fUJURudNvDZyv/x7A32l+FpcfOYS/M4vno9TlwxIbZQFEk5FiGxpnIpa6KIyehhn2I9jG1bBIeNhVkW2CO/RkLOOY8ENmzX9FCsGcWyOUBdMOn7NIz9UtBU096f90ppy0X7tzQvxv6AQijGn7Og4Fncd2b51UnNMJAn5dtK7iQk35P//hqYzsn2YmtKyknZs244JN35/NM87r0gTQeeMZWePjxF4OjVlGArnvnluVPObHkd0LDzxLY5F9/ync8txovuDE1BaGcdF7W7C+GnNRPq67l5LOo36vPXBF3F8tMZdH/E80/9zag0/dayqGaia76y/etPyW3KTGm7isXQL7XweiWtWNsdqCU3YztQcg0FxPPD0Qew5NI4XDo7h3NOjWsv0GU0/U2TNkZD8nI7rrQo3MvNuajGV6xqD2QkzRwyyMBVzpDDh9pd/+ZfdGEdbOHLkCD75yU/i//2//4dyudyxdm3bwvz5/R1rb6ZgaKhztbF0qO55FsfHj8Eq92Dxpktgu+1dl/7+Svz7wgUDHCE10N8DAKhU3Cm5XrZtIQhCzJvX17X+5g/1xL8PDfVy/QyT6zfYX841BlE9MzQYtUHVG/OG+wAA45MeDo/WsWbFEPr6ovNeLrsYntfXbAzoH4jG57q2sn/xtUpzARo2V6/lWOmV1IUaHOzt2vmkJOXwkNzPZFPxUfd8SeExPJxsX24eB1O49WWc/4GB5Dr2lB0sXDjAvX/1ggFxl2jbGl8cvYcoHhkacPHjybPxqr7HcJ3/U5T7NmB+cArmz18DIFoMUMvw8GCP1AYADPRX4lpbtvCfjWVlPwOla60YKxCRP/Pn9/N9NNunr1UqJY6A0M2xvChX+PGUSvmeE2zO9vWW4+vouk68b0hWiZVKCT296mdcT08JpZpemeTGarT8/9+wvl1yLB4YKWzH9foqZQeObaHR3JbBYn012+nVEERDgz2xUnJwqBfzNXOIwW4SdwN9ZeDIhPy+Y+N/7t6FZQv78IrLVqPSU26OU+6/p1LizkdAirQNDvVieKDCbV8i14aCEqFDw73o6ymhRPorl9PnQ2/fWDJ+m5+LbK5XhLH29qeHG8CK7pt//8Ez0RjI86m/v4dri94bnh+mjlUV4uI48v0Tp5Q2SePenlL8QXNgsGdKP/e09nkkGn9vX/T87T9R497t5v8lBu2B/X/f31+Jr1EPeUar5p9ujrB7Q3fvdxsDh/hnHD0mg6nFVKxrDGY3zBwxyEI350hhwu31r399N8YBILKPjo6OSq+fOHECw8PDij0i/MM//AM2bNiAiy66CCMjIwAAz/PgeR5GRkbQ19cH1y2eDxEEIUZG5EXDbIXj2Bga6sXIyKS23lCnMPHYnQAAd+V5ODHaANBoq716Ldl/ZGQC9WpyPWvN9wI/wLFj4231kwe2FdWcGhut4pjGptcu6JekExM17rgmJ5PFRdmxcx+zbVmx2qlWjYrV06Lm7LU9h8bwob/7Cf7wXRdhZLQKAAiDACMjUVnzMASOH4/uCwvI1b/X7KfR/Bk2bSMBsTyOj1W7dv0o3zg5WZP6qTWL91drvqQGrE3W4+395lgbXvN4al7qmKuT9fj3StnJfXx1jydofE9N2Pywei6G7Qlc2fMsXtLzNPCTv8SLuy6EPbgQ61wbT3lL4oAHaKw61WojrrU1WeXvU19xT4nfAInvj47xi9/4mBo+jh0bj88dbd8j83Byss5Z4xrN/VrF5ESd+3t8op6rvYnmtavVvfieq5Lrze4NIDpm3aNgbLwWt6UCm22el//5xc7XOHk2HDsW3Z+2ndQBC/wgVo+MTyTXhV2LetNSqBPhNeqNWCl59Og4oJmHDMeOR2PQ2Zf3HBzD488dRl+Pi0s2LMZo8xxalqzNmpjkr9PRE8n5PnpsHEGDJ7XCMFSeP3rvHz8+gVrFxfh4ci4mJ9PnA3vuAdH9wT+Lo+vaaPDPgax6d77Pj7VO5v/xE5PcezVCvo9ljNVTXJ96Xb5/2P//E837PSR1Ak6cmMSx3u7naak+j+w+OIZPf/MJvOEla3HJmfqQLHZ6x8ai+X/8BB+5ceLEBAbKRs0wE8H+vx8ZTeY5fT4eOzaB/lKiNkj7zMqeg9VaY0o++4kYGeXn3eho9z7DGKgxlesag9kJM0cMstDqHBka6s2tiptRKaVr166VarWNjo7i0KFDWLt2rXa/HTt24IEHHsDFF18svXfxxRfjs5/9LK655pqWxuR5J9/N6ftBV48rDALUn70XAOCsuqAzfZH1S+CHXJtssWhZ1pRcr+H+Mo6P1dFTdrrWXw+1ZIXCPCTnosgYbBsImusxVuSbWkpF693uA2Ox+sZCtHgHIlsVS760C55zVhycWs1p4etunU/KoVmQ7+skEEKuoUS3j8kRUnMpfczJdj1lN/fxBUI9MH1BeAtfnbgMWxqn4ZLKc9hcfgGNZu3E9/QB9ztr8c3G1QBS6kqFiBfbDWF8QZh9TcT36w01KRME0XNHDOWQXvNDjnBrd16I6aENL9/zz/ea9blCwGb3i+fH+05UEyKk4fkxeSX17wVxWyokgQz5j5PN0UYjORZGnjt2Yg+0SCAGvbZB85z6gsUb4Il5C1aslKw3/MzxsdRLXXIye59dA0a+iomjQHSP0f4aZF7V69FY6DxR3dciGg0fJcfmzoXvp593GvzgCf93sudAqLh29DyKCMOQOx5xjHwfye/Vmpc6VmUiqTDmIEg0f9Wm8jKq+cjmeHc/H6SN76ZvPoG9h8fx6W88gc/93mLl9lStzfYVicapPgaD/GD3BL1GtIah6jmj+8zK5nvQxc8OaRDrlZp5N33o9rrGYPbDzBGDLHRzjswowu2aa67BP//zP3O13H7wgx/Atm1ceeWV2v3+4A/+IFa2MXzsYx9DT08PPvrRj2LDhvYSMg2KwX/hMYRjR4BKP9xV53ekTbF+DwUrOq8qPt8NfOQtmzFR9dCvsc51AmmhCbRuiM4KpoJtWwAr9u+wRThbWAOO0M9YtYHBpk3Otu14QRaGfHppHsQppYqwgSTpr3vgQxPkxb2uaLy4r8h7ZR0/vXZF5qcuiVcNC1sap2JL41T83isXYJW/C8HoYdSe+RkuqTyPHcFy3I3TOdsat7dFr48YmpB7yDF06h4msKMLZrb4ortIJEXboQliof6cpCcjnUhNLRqMUK0nhJvvh9owhiBMapupwObIRM3Dc7tP4PRThjJrn8aLVkVKqWMnqao2vbaq0IQ4VZTUqHMs1L3kORETgjmq6TMCR/dcYqSg2L8qZEFKl1XMG7rgVd0jchuQ9stKOKTvS+moJFhDhOtaqDf0c0LXrzhX6Hmvakg62m7Wa6qE1ig0gX9tOjBWzVbCcyEYzZ+qGoUGMxNxwiz3HSL/BUvxtqbngmvrdhoYGBgYGBDMKMLtF37hF/DFL34R73//+/Ge97wHBw4cwMc//nH8wi/8ApYuTewF73znO7F3717ccsstAIAzzzxTamtoaAh9fX249NJLp2z8BhHqT/0YAFDacA2sNmu3MXCEm7C4OW/dIrzxJWuxed2ijvSVhRWLul+jg6aPyomVtnK7LFByyBWK/9tkkc4wNtmISUXHtmKVWBiGXHppHrDN4pRSqnALEtKvW8hKKdWlKgK8hbIYEca/31uEcCMpo0B+YrMxbyUqqzcDAP5nSw2vKt2PGysP46HJlVrCL1JBRb/nWbiqiBB6PXULJhW5xqyPfCop/3e73zXFhG7zfOpSVHXjtS0rvl8oIUnt2EEYSkq6uP8gTF0Qstv5xFgdH/vSQ/jVV5+JKzctTx9bwAg3mURzbCsmzy3biueOKgmTHQ8NhXAcC2hyia5tJ/vnIdyaNs/einqusTZkwi097IDuw++fnHOVClQkj+KU0oBXfKWBbiun+EY/VXdnybE5dZw4Dh3vK46H/llvRGpQfSKrfCziOZBIQ0Tnn6mep5OsynNv0uOh4SG6bQxmFpJkUf6Zz1CEcGP/T0zb1RafUWbeGRgYGBgoMKOKXAwPD+MLX/gCHMfB+9//fvzt3/4t3vSmN+H3fu/3uO2CIIDvp3/TazA9CI7vg7/7SQAWyme9rGPtpqmMKiUHr758NU5ZrC5APxvR30MIN+F46WKrR7OwVYEuSEUCx7EtSaUxPtlICDLyfohkoZ5b4RYv2tkCX7aUShe2g3BEQkEcn2VpVW6UDBAX9ZmEG6dwK/b9BkcSphCCXH/k9/v9s3DQH8SQPYk399+Hiub4fD+Ir4+o0lJ9gy8uiEQbahbhxivcmj8DYRFNSbl2FW4xEWVzfWYhbB4WTc1rUHtfndai0xNuQZhFuPHX5b6nDmSOzVcQTux3Sp47VvI73VYkKujcp4S+69D9s09crZ6ucIv7B0/cq+zOErErWJEBnjxS3YoiqcWa9Lj5ljpUrl+RrGJ/KRVuKXU9wjBNCcq/Lp73qsa6DGgUbhntAdHzhR1Cu/dbO8ijVOIUbgq1lMHMhook5X4vQrhNu8JN+NvwbQYGBgYGCswohRsAnH766fj85z+fus0Xv/jFzHbybGPQedQf+z4AwF21GfbQko61yxYDtNbMyYzenjSFWxuWUtaGsBhUK9w8XslG3qZEXK6+m5s1Yqta0n/cRxcvK082qhfCYm0nBq6+Vcq1UIHOVZ3qRwfOAqwZs3KfJgLbxX+NX473Dd6CiyvPY+S5/8J5pWE81lgJejEbfoByM11SVJioFhDi4qbhBagQu6qu4Cjbj7apeq3TixiqEvT8/DagROGWkCceZylNiA8vCJTKIdZOmvJBnEI9Oe7pWOGlUK05RNVm22r1Ymyt1FhKk9/tYpbSpuqvr4c/hpIr31uUiFQRypLCLZR/5+aaSuEmEchsP/ViXwV63uT7Qy9xS1PNhilzQlK4CX/riF1uPHR/4TXV/ek6dlLHcjoVbrmIE/naSdfZEB8zFuzacNeoVYWb4kucqYRU/cBYTA0MDAwMFJhRCjeD2Y1g/Bgaz94FAChvfnVH204WkB1tdsYi1VJKFnJFLKUc6eTIxJGo3hqbbHA2Nfq+V5hw4y2sLtlvKj4s0+PVkWQ6hRvdPk1tmLVvUYVbmiJRB0rw2ZaF57xl+NZEFCYzdOhR/MrgHfi1gdvRZyUpjZ4XEFJGtMxlK9zEkAQtkRAvtIi6CPKCKQxDrd2oFdA6VUB+NQQbg21b8b6eTuEWhFqi0Q8yCDfh2uaxHitruJH6iEkNN0uqn8jGRF/jLKU2/d0qZCnVKdwqivqBQZDUvVMp3OTae7IKho4pD9mktJRm1XDjlHUiaRj9tBWMW5rCLQj151N8PetvCuU5EKalav+ZUsMtzxzjLOlM4WQspbMGKoUbbynNL1eMFdIz5HKbaWdgYGBgoMIcoS8MpgKNLbcCgQ9n+QY4S9d1tG26gJwLSAtk6ITCzRWYS8uyJDKTs5RavICksKVUuG4uIbfYh+VuKhfz2DMp4Ua3oAtncYxi0IQIek6L2H+B7Lpzyv4Ewg0A7qxtxD+OvBxjq66GF9rYVN6NDw99HwvsUQCRwk1FygDqBYSosKlLiXLqVUdcr41TuMn9CI7SlgnZkYk6fvzQboxNRoXY2TnM21wcmmBZROEWxGMSQxMa2hpu6SSfOIfy3NOxpVJBQtmEJLM0hBnblo2Z1vejyiyHKJ9yKdyahJv4RYCacEvadBVkt6xwk8dP56LquupqEvqK2nc6iAm6wigBqN3wqmNKxpGicMsgj9LuBxVXIapuVOEeLheKM52EWzbZEooPC0yfpdCgOFRfvLRuKZ1ehZukxzbT0MDAwMBAAUO4GXQEYeCjsS1St5XOub7j7bNFX15F1WwHXXSLhbdbJdzSSCetwo2ofCxCQzH7XFGFGwMl/KZisZSHvOLqWDlJTTf6+lTWcLNbINws8kSnQ33GW4Gxs9+IT0+8Bsf8Pix1RvChoR9gvj0GzwuVdb4A9fohS+GWHZqgsISJhdAVKpai+NTXH8eXb9mGB54+CCA5n3kXZ+xU2FaiwGJx4Q0vkKyxOqIxq4abJVzbrDTbIAwJcSQrtcSUUvY7T05FKsI6U6SRuUkJZtexYvt3Wwo3xTH5QZiEJiiky3lSSr0Ma6he4ZZfQUkJKl1ogtpS2loNt7YUboo7VqrhprKUujap4aZtvuvI0zd33xmF26xDrHCjKaWcwq044TZtNdxSvhQwMDAwMDBgMISbQUfg734C4cRxWD2DcFdu7nj7zhxTuFGShyppAJ6IadlSqkjbVBFuVMlG32aL9yyFF4O4GSX82Ifmbl7atPp1DGLh+NdfvRYvv/BUzB+skHb4fbLCDCiZkkWkiOCSeVtRuAn7WLBw2FmMT4y8CgeCeZhnT+L9g7dg2bFHYft1AIrQBJWlVCCWJIVbZmgCeU2legvVttOi2L53hPubWSXzromopdSJLaXRa2Lhej8I9KEJQZhqeRLvRZ21mbbHoCr+b1mJqo0S6WLoQMML4jNLCTIuzdhJUkrbqeFWKakto4zAchxL4qyk+kjk9KosparxyYmfTBnYmqVUCk1o/qn6f0llk03205Owcg03ufadvl1Fe8JrSkspmSfTqXDLA9WzwdRwmz1Iaripn/F5U6RpW9OVmSHpXc28MzAwMDBQYMaFJhjMTjSevhMA4K6/ApbT+WkVKzbmiMINAJYv7MO+IxNYf+o87nVaY6lQSmkK6eTYlqS08YMQkzW/ua/NW0oL1nCTrJhcSmlzG5VMpEPgkhdzKNxs28IrL10pbSMurLPCDOj2vW2klLZEuAljtSyg7No4EvbhS/6r8O7wv7HYGcXiI9/BRPVh9FlXY0V4FL8+dDdGgl48UF+L58L1Uh9SaIJYw01DJKjqLekUbiEZe6cWMTFxlFfhxohgWInCrUmqVRWqvtTQhBSySrxOWcQWXaj6gmoNiK4zSz7largF/HmvkWOgzxEu0ZcQMX6O81aohhs5LywlmbOZCctZet2SlNJ0S6mOiGnZUpqDkGZIDU1I6Vcm3NLf595TjCcUtlcRGo6TPN9neuAnHb2uhpux9s1cZNVwK6ISiy2l02UplqadmXgGBgYGBjIM4WbQNoKxo/B2PQIAKG24qit9xJbSucO34U9/9RLUG4G0eKXr8yIkDl/DTaVwk/c5MR4pnxwhHbZoDTeRl1JaSrt4bXNZSgWiQQWRlMxSXPKhCQUVbgJ5ZltW5mKEDkdSuFkWyk3io+oO4hPHb8QVlWfx8sFn0Te+F384/E1ULA+OFfVxdnkPXvCfRjCykUsc9gQGoCYp3LJSSvmFliokgS/T1JlFDCN589dwi37athXX42I1z6o1XnXq+6Fe4RamLyLF65RlqfI1iitaC5EpT/kabkTVFSAm3FzH5u5HR0gpzatwoyRevhpuIUfc2zYQEB5TsmupQhOyLKW6lNICllIupVRjuVY9B9JquAF6AlN8XUoZTQ1NkF/Ls38UmjBbFG70d1npCBhr30xGUsMteY37EqEAeTbdoQkiwWamnYGBgYGBCsZSatA2GltvB8IgCktYcFpX+qBFwOcKHNtW1mijSqzeIgo3LqXUlt5jajYAGOyLQhtGJiLCTSTkitZwSw9NSJQ53QJfv05nKSUqH81xyQq3/DXcitTbA/hza1n5zg9nQxW2t6xk7pRdGx98+9UoXfA69P/c76NRHkKf3YBjhXikvgo/mDwX1dDFSucQJr77cTR2PozGtrvgH9wO3+PJpkbO0ASVpRSISAtx8cXbjYpDRRoUreEWW0qtpB4Xq70lW0pTCLcgXeEmzqFiqZm8MpCNl5FmNglDEVVdtWZtyErJ5ghxl7tXknpwWQvhWp0q5rJruFHCjSncKPLUcMtKG+10SqlsKdV/WZBmKVW1peoPUJBJaQo3la1WItwUNdycmVHDLQ9UyijpmTLTD2IOIzOltJClVG5rSmHmnYGBgYFBDhiFm0FbCL06Glt/AgAonf3yrvXDFn15FVUnM/p7Snjfz5/TLOxfxFKa/C6eR8e2cNqSASyZ34vTlg7i4NEJjE40MMIUbsKCmKmcWknPBPhFPbXudQt5AghES6mynYKhCTTEoKjCzeEIt4j4yCI9LEEVx7+HWOFWcm2cfsowTj9lGADw2EW/g//5/r2wYGOPPwzLsnBPbT0+OPQjLBo9jOqPPhm301sZxGt6V+FHk5tQR0kOTdAsOlQKN/Y6n1jH8xetrGFEQgwgKaXNv8cmG/jcd7fiyk3LceGGxdrxRimlyYgafiCTjBmhCWnXTZxCxRRusqWSzRWAr80oWkrZdauUHa3dvIjCjanbLESErm1b8T7lXJZS/v1Uwi22lKYr1XKllGZMME7hpqnhpkwpzSDcVOEFgMpSml+9pVrwy6EJ8jbOLFe4mZTS2QMVSUqvXjFLKfs5Pddf7NXMQgMDAwMDFQzhZtAWvF2PIKyOwupfAHf1BV3rJ7GUGsINAC7auCR7IwGxStCSF/m2HaVyfvw3r8CCBf343U9FNfkY4WbZ/KKyuMJN7s8Cq2Wk3qaToDa5XCmlOkup8HIRhZuo+smCqHDLM/fpcETFkAULZZa8KpABllvGXn9B/Ldj2zju9+NfJl+BPzj1boReA/bAQvhHX4RdG8X1vU/iqsoz8GFjfPsFCM98N4Kxw7CHlqYQT/xPhjAUQwVCILS494uCWaEpROJoy46jePS5w5ioeWrCrdmtbVsceeL5gVI15MkcXzR+gVAUYQt+6yyFBz1XuhpuSchMogoWAzGYLbZScri55QrktJ2XcKsnBJ7FLNDNJWguS6lYyy4Ut6fvMcKN2mRV6i7+b2VKaQ6rLP09CEMSMBC9rvqyIJNwy1nDrVBKqeKtfKEJdvzsmOnclWg/B1SW0qkckUERqIIuWrWUqhJPpxKysrLIvskXOgYGBgYGJzcM4WbQFrzt9wEASuuvgGUXU/AUQWyRMgq3lhGrXizZvkUVMZZlYaC3aSnVKNwK13BT9MeKpE/Ft9O8pbR1wk2cf1nzkQ9NKKhwE9RquSylXEop/14UmpAo3Lj3xL5tC54PHA0G0f/mj8Wvh4GHvY/eg/p9/4VFzhgAYODgPRj7wkOAX4fVM4iz7U14EGsRChULEkupqOBR13WjfxfFibGa9JoT20J5smai6knb0u3sJoHFCGLPl+es74ewNOXms0ITJEtpgSL+lESjNdzOWbMA9z11AOeevhC7D4419+PHN9kkyMolR0ompb8nNeDSx8VUhUzJSQ9LHZqQkIuObReylPpBiF37RzE22VC+H7+mIWJ8xXnTQSK8/BC2y9SSCckpIi00gbWjfF2hAAUQz78whVxQFW2XCTydpXQWKtyaP3XWYYOZh6SGm5pwK6JWjNuaNm1Za/MuDEP87X89ilrDx++//ULzRbKBgYHBSQ5DuBm0jLA+Ae+FxwEA7umXdrWv1csGce7pC3H2mgXZGxsowT7UWZaltJRSMMKNfXy0LV7D0a7CzWUWsnCqargRu6imo1YspVmEI10I9hRMKeUUboq+VaA1DiWS07JQLjUVboIVWTzexH7JLyAs28Xk0nPx8RNVLHeOYakzgl8avAe2XwcsC2F1FOfjbgwObsdj9ZW4r7YONTTnUmwp5cccCAq3IAxhk9nWKYUbU27FSrvmL5M1NeFGLaWWZcFxbHh+AM8LJEWFH4aARuEWhOkJn+JlzUoDpYSJ78uLVhvAhpXz8fHfvAIA8IP7XuCOh2FSo3CzBXI6t8Ittqi6UjuqGm5+EMb3h6MIbZHUI6T/x7cfwR2P7hW2j96v1j3cs+UAzl+/SB6zQhmXNb/ENjw/iJ8VqZbSjNCEtJp/3N/NTlzXRsMLtKEk0bbyaypyWB5rQuhPl1ooL1REjahSnKl0W8PzcdO3nsSmtQtx3YWnTvdwpgVJ3bXkNZ1qN3db0yRpbFXh5gchntp5DED0hQ/7vDUb0fD8QqVNDAwMDOYiDOFm0DK8nQ8DgQd73grYC7r74bHkOvjwm8/rah8nO6jNTFJqWWrCje7LKdxYDbecLJlKGSYW6Z6KGm6q4uwMeVJKRdVYFuFI65sVTilV1HDL3IdaSqXUhEThJpIBKssvoK+L5cHBi/4ivOgvwrpVZ+HajQNwVmyEt/0+jN3xBawrHcC60gGcX96JT42+AgHsiFg7cQDLcAgnMBy3F4ghCaFYpynzsCWcGJMJNzE0gRFbWsKt2S+7N0pupPpTWkr9EKGdkEecgioIU0mMthRulDhq/pSsxJbGUsosoCW+hhvdyrWLKNyi89jTVLNxhJtC4RYKltIshRvt//6tB6T22Dm+Z8sBfPGHz2Df4XFcfs4yoc1mW0KARBpSLZ0pz66s0IS8llL2d8mJCLe08arssblSSu3ZqXCLFYuzROF25+P78Pj2I3h8+5E5TLixn2qFW9YXDuq2OjK0tlE0kGe243/u2oGb79qJ3/3FC7Du1OHsHQwMDAzmKAzhZtAyGs9Edb7c0y81dShmASyicMsq/j/QV1K+b1nRh9t2U0qTBfbUfPBk6iadnRTojsLN0iiH8kCu4ZZjn9TQBKJwU6TUUogKHgpRYXPUWQx35fpovw1X4+sPNjB06DG8rOcprC0dwvsGb8Ehfwi7/MUY//pX8L5KAz8MNmG/Pw87vUUKgi3klHWtJNAdH1dYSm3+mBjpMln3uLpcdBxAQrJGVksfDT9QkEEBgiDav7fiSlbHtGMQ50UWsUXf9hQKN4k8jZVLOoWbndzf4BeDrpM8K7KuQ5XUcIvGkQyEzTv+OELOmp6lcKP9R9eSlxSyOTPePPfj1YZWLcanlKYeVirhFqRaSltTuInJs+zvkmsDtfTxqt4TX/M0ltK4Ll3qqKcGaWpeFVEjXueZymfUFGEucw3KZFFKohap4QZFW9OIvKNQ1aOcjfj2nTsAAF/9yXP4g7dfOM2jMTAwMJi5MISbQUvwD++Cv+8ZwLJR2nD1dA/HIAdoaEJW8f/+HlHhFi0ebcuCLyyU80DcTJVK2E3ONlG46RfBfA039XZFCbd1pw7j0rOWYsWi/rxDTdqWarjlsJRy+/Dv2Wk13MQUWUevdhEtaXUhsfOYNQ/3VM/Dfn8efmXwDqwvHcD60gFcgWdjjuQVvU9E+4YOgqfKQFiJ9w9DtL3qVyncHEHhlqSmRgvhXiHUIrE6R/sxAsX3xZAHRpJEL/aUHZ5wC9JruImEWxHFFU8c8eNlYErHVEspqeFIt3OcxH6eZfWqSTXcknH0KBRuPjkvtm1JikxxIUr/VpHXrK2EVJPTYVVF9rMWvGLtO1+TDCtCVcONfWEhjoHrT1O/MJ5/qaEJ8nui6k2XUspO6UxQ36R9OaGahRrn8IyD+WIyuTZ6S2n+i6eqBzeVEHvNOwzdPT5bMdAzey2xBgYGBlOB9K9gDQw0qD/5IwCAu/Zi2AOmrtpsQKJSs5r/5PcYeitCja/m22yfogo3maiyJRtWNxcjTky45VO46bYTrZh5QhPe83Nn47VXrM45UnXblsIGnL2PfH4XDvcAABYMVYT9+HZcJ03hxr/YaPCqDWZdfKyxCv86+lL8z8QFeKS2KurnlLPwzdoV2Oktwl5vHsqWD+uh/8KH+r+DpfZxAE2LKWmPLqZqDR8PbzuUqRRJTSlVHIfKVhqTQTHhFv2kCjeLbMvuCbFWXximkzqiLbuIpTQMeeIwGi+/PRu/eN1oaAKt70iHahMrc6altMETbvQeUocmhLF9zFGklMo13JLfVfenWJsvUKTDspmlqn2ng3jcnDU3pf6kSGqL486jcKO/s/ZSLaVKhZteocdAQxNmguImTYnMFdjXKtym/xhUMHwbCc+hzzGo53wWiqSU7tg3gs99b6vy/4ZWIT1fWrCUztS5WgSzuQadgYGBwVTAKNwMCiOYOAHvuSidtLzphmkejUFesAUtW/MxtRogL2BF0iAhciIbKLMltWopVSrccrXUGlhCZaql1Mm2lA73l/l2u5ia6wjkWZ6u0khUC8BLNq/AsgV9WC/UWxGvDzsXqvQ3cUFUExRudPH7eGMl0BR7fWNiEn/zK6/A/Z+6C3eMrwMQ4srKNrx53hM4BUfxm4O34m9HXi2llNLu/v0Hz+CeLftx0YbFeN/rNynPAaBOKRVruFFiYaLmQfzaICawbF7h5pE6WiXXRt0Lmqq3JuEmkNVZKaWisivTUqoo4l+2HWIpFezbGsKtyoUmNLe1+fNCA1YyQxNITbho3+Q9VWhCGNCUUpWlVK9wU9134nXNrXDLWKxLKZ++bEdV3ZoqS6lNbPR5arjR31l7aYSYOqmV/1tNuMk1Naca9Hqn1gaV+c5ZYyk1fBtVuKlVXkUI37iGWw5J9C0Pvoh7txzAmmWDeNkF3amfl1/hVnyfmQZan3awzxBusxFhGOKeLfuxetlQSy4MAwOD/DAKN4PCaGy9PQpLWLIWzpLTp3s4BjmRWEpltZeoLhFJAxq4APAL5TyQVDeq8IIurkbYON2U8ZaJCkd3XAsGRWVY9wYtKtzyKADTa7hFi/az1yzgjlW1rZtWw01Q5ogKN50laDTsBWCTxYaFu2obUH/VH+GgP4T5zgR+bfB2uEFVuwi5Z8t+AMCDzxxSb9CEUuHmMOKoOc4shZugYosJtyCIx5fY/AI0mudFDMeg1kklhLcyFW7CyWHKOnZcsrJR3e5E85jLJZuzjIvbxQq3gjXc6PwV5xvA6t4lSlk5NIHfnrO6plhKffJTPFcJ4SZbcXWQarhx81tNcgJqws2yE12vPqVU3XfJTSc+dUoZeb7I/TrO9Icm0GNN+2KEJ2pk8hzIR8BMB+a6pVT3RQoXmlDAUlokpbTR/GKoUaD97P6Fv3POO9Ucnm2g/8eqFMwGMx/P7xvBv3xnK774w2emeygGBic9DOFmUAih30DjqdsAAOVzjLptNsESSDOqrJEtpWqFW5x46LencLNtOdevqwq3PDXccqSUzhMIt7wpra2AkmCqoIusfaSQ0pT9xW0pWZCWFgnINdzi5ElFf0EYSjWlwsoQPjN6LcaDMla7h/HK0W+gEoxz+xRFvaEgFcSUUkI8pBFussItIXKYzc8LwnihKKpDAwXxQyEuVrIUbnIR/+g4tKEJGktorHArO7Cal9u2LGm7ogq3HgXhVnJsaVxBCKKwVb2vV7ipRhLXc2peVlXtvOTa04V/QUWhInAhr6XUJsR5LoUbGVspQ+GWdhhBBqHhKlKjpxqUCEz7IoertT/bFG5zm2+TwnFUrxezlMr765BY7ztIuKG1edeqom8m4ThRkRe5ZgYzBxPV6DPAhCap3cDAoHMwhJtBIXjPP4BwcgRW/3y4ay+a7uEYFICocOPImZyWUrYL+4CVW+EmbEcXeDG6SV51KKV0/hQq3DhLKXiCVHfeUy2lKUOVLaXJ3+JHaclSKircmoSE66pVSOJn8yAIcSgYwk2j12MsqGCxfwCvPvrvWOVEKrZW1iOqBYCYUipaSkUkNdGi42DnxPODeN/Y5heEMWHQKyjcwgxLaX+vi99662Zcfe7yeFzfuGM7/vm/n1QuDmVLaXMhCX68DDqidZJYQGmgitinoyHsRFQb0Tlkzw7ab8m1pTkbEJIyTw032n3DkwlVlaVUtFOymneh8FoaUhVuMeEmn2PVPWohee7plDxUSchZSt300IRUq6kmaCNum6SU0nZ27BvpaM2rNNDE3XTCTSZqZCXjzCQA5rrCTWcjDTVzPm97eUirIuRcbogKtxZquM1QMWYmaDCRIdxmJ9g8nKnPSwODkwmGcDMohMYzdwIAShtfCss2JQBnE8TgA7qmERc4YmiCSNbFCrecCwiV6kayvuVqqTXkCU1wc4Qm9JRdTv3XzRpuYgAC7UpH9NHXJeIl5QxLltIcCrf+nug8iOqwuL6ZwlIXhnIhe1aEfo+/EP8w8koctReiLxjHLw/8DA58boWU92yrFm2OkLzKW0rlEAbWBjs1rA6g5xNLKSNB/IRwUyvc9GO1LAtnr1mAjSvnx+P60QMv4v6tB3FkpCptLxNAUb9JSim/vW6KcimljIS3LWmsbE4VreFG1Z+ua8tprGGYYSkVFG6kfxXhFgjXNVDUcAvCUCKcioRU0PbpGFWnWKVwo9ZwXeorTUWlatGs65C2ZuIse7rQBKGdg8cm8GdfeBA3ffMJfcMdhOqaqqAialTE6kxEF/+7mBXQKbt4hVveeRAWU7h1gVwQW8pdw42qWDs2mqkFVbgVIUkNZg6CAvePgYFBezCEm0FuBCMH4e/dCsBCacNV0z0cg4IQbaFp5IxYh4pty3bxCtdw47dTFUnv5pf/uSylOQg3AJg3kAQnTJXCzbb4c6gbH29D5d9LVbiJKaUuJdz49xhRMNAXnYdqXVS48eoviiDUtwcAB4Nh/Hf/WzBp9WGxM4rLK89yBBBVKN581w787j/fjRcPjnHthaHawunECp7mWHLWcGPXmM2PBlG4MdWbHyQppUP9UQHpcolZANMXJOyIYuunH8Brkg+q/XSpk+xllX1bBUq4LZ7Xi+H+MtafOk9fwy3lGOoNH/uOTACgltLk/ZKjUbgxpawjK17F3uhxNxRkFVunU+JNlSLoCcqyzBpuKTXQ2Du5a7gR4tzTnE/KN1BCMp6/LSnckt+VllInITzZOTt8IiJ7D52YjLd7fPthPLf7hLafduApwigYtu48GtdvVBE1kqW0KyNsH3Nd4aZL56TXK69aim6Vh/CJ04s7yS6ICre8u2nUfbMJVPnq5SRJDWYWdDUwDQwMOg9DuBnkRmPbzwAAzqlnwx5YOM2jMSgKMfiALsTFxbBj2yhTi6WwUPAL13Dj/7ajYkbCNt1bjAw2yaHBfn2aVp6UUoBPKu2mws3iyDNeAaT7fJRuKW1V4cZvyxZEA73RuRTJqlTCTUGCSBZVlPFo3+UAgBt7H8MiHIvfc0ib37pzBw4dr+KPPnc/Nwbdgi1WuClSIlWEm2gpjWu4+UkdOkbC0cS2S89aitddtQY/d+Wa6JhDWWlFESvobKYeTSyPqv1UKaXReNUKN52ykRGl5ZKD3oqLv37fFXj/68+RPnznqeH2mZufwp7D46iUHWxYOa85nuT9kmtLcywi3KKxO0TBFb8vkmWkfy/FUsq2U6WUstdV++kgElQqhZsKqvkfhmGmwo22T1Oks8Ir0sbC1XDTKdws1k70kykW2c/xagOf/PoT+OQ3Htf20w54wo0f4/9381P47M1PSenDAdQLxplKYtBbYC4ucjmFW0BfJ4qvvIQbR9jlINxihVuu5vONQarhlq9xnbpvNsEo3GY/umKzNjAwUMIQbga5EHp1NLb+BABQ2nD19A7GoCWwBa+6hpu8fY/COhlbSuMabvkeIcrQBIkY6B7WnzqM9/38OXjHDRu02/AKN/1xDfVPvcLNsvhrpEs4TFMtpg1VJtzo3yLBwxNu1bov1IhqEm4KS10QJksUXW2wMAzxTPkc7PbmY8Cu4dd7vofaA99AMHKQS5llllYA+O49u5I+NB/+2blhHy5pv6x4sDhWIFkku1wNN/Zasy4c2W+wr4zXXbUGKxb1x+NJW4iJqcF1LyHvVIcinq+4hptAEDLopjJrp9JU4rnNpMqiCreR8Toe3hbV2/vwm87FouFeaXvXURNqnKVUfAII3dHulUSkwlIqBy/IRFeWOENHcNIhqu6tkqJeZBgm80lU2iVjlMkH28629qYtmnjCjT/g6NmS1NBjc7XaJJFrDR9hGGKy6iEIQ4xNNrpCaFFLqdg8I8Qn6z7/HlO4SYRbx4fXEdD/B+ciSUEJKm1oQu46aMnveQRWCbnQufMuNpW3aZ3SbzbB1HCb/YjviekdhoHBnIAh3AxyobHtZ1FYwsBCuGsunO7hGLSAxBaqItzkRwG1lcqW0mIKN4nQsWXFSzcZN8uycNHGJVg0r1e7TV5L6VDf1CjcxBpudLGm+4ArJptySFG4iW9RtZ8cctC0lPYmakFqK2WEhopwoGohaqGkCEMgtBz84+j1EelmVVF/5GaMf/OPsNbZH29XJumeB45OJH3oFG5xaEJCyDAoLaWkfhZAFW5yaAIFI+ZoEfo0NUtcU5ERbiRhVUx0FccNJHYefQ239DlaFlJSiyrcGFFSdm1saNahA/jrWlLUcKMKNMexJGJQVkKmr6pjeyEh3lQppaq6bmkQCQA6h+O3VJbS5vOEPldCEIWb5nzS1+kczLoOaQt3jtAQiD42h9khsOaZsi0MoznPjasLJIHHnVfhGhHVYqAgK4qqFqcLnMJtDpIUuhpuWSm66raKkVaJpTRX8y0hv8JN/ftsgkkpnf0woQkGBlMHQ7gZZCIMfNQf+z4AoHzujSYsYZYiUbg1/yZ3v6NYMFLCLa6B1lycsUV2Xr5JHZogbJOvqa6hnCOlFACGByjh1r1HaFoNNxXkc5z+PrdtC6EJPWUnJpeq9YSwSiOjKGmSpnALwxDjYQ/+YeSV+Fr1StiL1wL1Sbyr/ANsLu8EwCti8pABrkBYcAo3ZQ236CebCzHh5iWhCWJhfAuE0G6+FQTpC5J0hVs24eZnKNyyrNoVkXATeC3Wnk55wq6peM+sDF/E+wZ/hLf23Y3w4Ha5hhshvxxFaIJE9OZYE0SquWRcMuEm107LIo9yhSYoTnHZjc4rPb9BIH9pISJUEG40xVVfwy3fMYhzkd3DYg03SqLXGgF33nTqvHbAWUo11ygMQoG0Qfw6xUxdP9J7cy6SFDpVG69Wa4W0ykG4TQG5MJcUbsepwq0LzwOD7oNdtdk6Bw0MZhMMc2KQCX/3EwhHD8GqDKC00dhJZyuk0ARO4SavGHtJ2iJ7PyYFmnaj3KEJwnaRhUzANBeULrkywagCVbh1c8hSSmkGtydbSNP/prCE400PTUhUbjqpBgABAABJREFUST1lF2OTDUzUPCwQ3ldZSukiU0u4IfkgWEcJDzTOwLtf+05Ub/v/gJ0P4d0DP8W3J8ZxV+McMqYAYRAAYQD/xCHYCBAI3yclKaXR31kKN5FMKZEabiVWw00gFV3Xlu6vkJBAKlgAwvpkTMRQhVuadTLeJqOGG5tH/VYVE2EZoXBeRMJN/PCdpaxiY1zuHEf1ri8hOLYH7tK1eKtzK3qsBlACJm/+K1xnb8Jkr4etjRXYXN6FM+7/Nn7TcXBH5QzY1sUSeS8FHuQsjM7OTxCEEkkYhqFSUZkG2cIrWx9V99apS/px4YbFOH3FML56+3Nx/1YzoURs17Ysqd5fnFKao4ZbamhCiqWUfWkg1XAjdQmrdY8n7fwQ0JfDbAkNxXmNfk9INjEIQ1f0O09Nr+nAXK/hpiPJ6PXKHZpQsA5a/Fzo4GmXLKU5513Aze/OjWeq4PkBxiYb8d9zcS6fDEgUbtM8EAODOQBDuBlkovH0nQAA94wrYbmVaR6NQatICDf+b0BNMHEKN8FWx0iBVkMTVIqW6Zbb5raU9lPCrYuWUiFxlPa1Zvkgduwb5bdXkJoU6Qo3/u+00ARav6+34mBssoFqjVhKNWQUwH8TztSS4rfjYSgsuBHCcsvoefn7cftn/w4XW0/i5/sewqLqKL7hXYI17kG8afRmjP3Lseg4AXxwcDEeb6zEVZVncEf1TPy0tjEmFoKmgq6ncQKrnEM4EAyjWq3DP7wTwfH9sHoG4Cw5XbKUOqSGG1tYiaQirX1nWxYshBgKjqNhVXEEffDhYNiawNsHfobD/iCe85bikqe+ibHHx7CsfwkW21fghDcPQESQuXsfRbjkclhOCd7ep1F/5GYMV9bBwmCTOAvR+8JdqB23YXtnwIGPdROPovbgNpQ3vxqWW4ZtAdf2PInX9j6Mg8EwvjtxPh5vnAamKa0IicQSESQQo2EYwD/wHOzBxbD75yMIQmws7cGv9PwUjS3RIszfuxU9FrDDW4SRoA/nlV/AVfajQC9wfe+TUcN1YKkNvKX/Png/O4zXNIBvOGehHjroteoIw3ncOLIWdWU0EPgBp2CUlE+K48tS1LD3XceWrJVpygDHtvH+128CgJhwC8LkPhSJv1LJRq3uK612eRRuqTXcRLKMQLRAJwq3hISuNQKOqMuy97YCGoShsxsGYSg8G9h4ZofCjX7NZBRuasIsP+GW/J4vpVTut13IoQk598v5DJmpaAihNboAGIOZjW4EiRgYGKhhCDeDVASTI/B2PQrAhCXMdiQppczyRggdBdvVW5EVbmxxxmxvrdZwcxSW0un2lOZNKV1/6jwAwMKhnq6OxxEVbuSErVjUj1999VmYrHn4iy8+1NyG318kA3VplYB8fWj9NXFRwRbbrm3FKsjJ5uKc1shSW0pVCjdRcRQKxbWb47dt3GZfhd3jPXhd74O4qmcbzi7txnxnAhA+768tHcLaUlTI/439D2Bd6QCCelRfbCgcxeR3P47XHdoKDAP10EHDL2Him9WkgUo/loSvwGEMxHOBEbINQuq43DwJUXJtBOPH4O14CINHR/HbQz/FKTgGDAG10MXzjSVY4IxhqTOCM0r7cQWeBZq8Rmn8ID409APcXzsdvmvjysoz6H+ojuqRx+CuPA/Vn30BCHyswBb85bwSjgd9mAzLWPj0IdQBXGT34Nx5PvpONFB/GPB2PwF35WZcfHALVvQ9AwBY5pzArw7+BE83lmMk6MWj9VVxaEJyvgPMs8dhIUQwOYJy2IgUg0EIb98zqN7xOYQjB4BSD8qbX4OeF7fhNwej5Epn+Qa4qy9EY8utOHB8Ep8bfSlGw17806saePLeezBWA84tv4CJsIJDG96A57Y8jRvKD8M9sh3rAHxoaBdK8OFYIX7UuAHABfG41IRbiB6rgbNLu/HW/ntR++ZtmG9fB8Dl1GJWRNs2FW6y6i0N7FpXSk3CLWdoggo0pVS0tpbdiHDLUri1UsMtLaU0q4YbECmaab/dtpTyZEryux+Izwa1ammmKm7o2Od8DTdtSmk+8oZPKeXvLRW6Qi6ICrecbU9nSumu/aPYe3gcl529tOUvDCWV9RycyycD2GWcqYpgA4OTCYZwM0hF45mfAqEPe/EaOAtOne7hGLQBqYYb+bCVpXCT6lgxW2E7hBvyE0JTAddNPx8MfT0uPv3ha2LFU7fAJ47yi3oLFlYs6sfB45NkG9FCyreX9tlafC/NUkqTJRkpyyyZdFuxvhmgJtzExXsgKtzIH45j4yfVs3DUH8AvD9yJ+c4EghDY6p6FS37h1wHHxZE9L8C69ROoWB4ea6zCOe4LOK/8AsKtn8J7BlZgvbMf/l4fAWyMB2UM2lWU4QPlXjgLTkMwegjh+DG8wbkNz+FGklKazP3YSmhb2Fjahzf13YsF9hh8OBj/SgiEPoYADLmAF9oIYKFieTizvBcAcDzoRRk++uw69i+8CKdf/1Yc/97fY3BkD67r3cKdD2/nQ/B2RqSqs3wj6gd3ohdV9NonovNjObAH5sMdPQzXBiacAfS5IYKDz6N+8HmsaLbzw8lNsABc1/MkNpb2AQAuqTyPYOtyhOdcD3/Xo2jsfAgfwCMYmjcOABj/4jdxGYBL5gP7jqzF5A/3AfXJiKFvVFF/4OsoN6/Zw+GZeOmrfguW46Lv/FfiIx+7FV7zPJXPfSW+9cB87Bkfx+DEJOqhi7fOPxu31ip4cnIpPnDtfBx+5HasCPbFx31d/VY0tq2Cu/5yWJYt2XL7rCreM3gbVruHkxdHDuBG/CfCnnPxoH8Blu+7A3867y4MWFU8Ul8N1NbCqh/A6e4B7PeHMWBVcVVpO/wjq+EsXClOVwBEsdmcz16gWCznXLiGnMJNJNwcAA2OiFGFJugWt6kKN/KeSPQlhFtT4dZcfFWJpbRW97nnUTcUbrylVKNw0yjZdK/PNLRSq+xkQicVbuJm9N5K67uzCjfx7+LqvKkmO/7k8w8AABYMVbiQmyIQr5Eh3GYpGOFmLp+BQddhCDcDLcL6ZBKWcPbLp3k0Bu0itYabMjRBpXDjSZT8llJFDbcChNBUwLFtOLYFPwgzybS+nu4/OtNSSmMSyNZfQ7l4fkpfRUITSA03kXCjC3FXlVKqCE1QJUlCsxhjbT7eWIm/G3kV1roH8WT9NCxavgyX9UeLB3/+GvzNiZ/DwoqHF/2FWDBxCK/qfRSbyrtxVnlP1PfyDfj6xJW4c0cDpzpHUbE8/N5H3gTHKSGYHMHEN/4vFk8cx28M3gZ3dDWC/nrcN00p7fNH8M6BO9BnRQWkHXhACNhL12HCGcId2xt4xDkP+8csLHOO4wx3P5Y6J3B7NbJOLnVO4MLN12D90GKMXPURfPer38Z6dz8C2NjtL8ANF5+G+U99DbBdlC/8eZQ3vwoPPLwL3//xo1jijGC5cxxnXnEVzrvwPPz09vtwyyP7sf7sDfjlKxeh/uQtgNfAlkPAd3f2Yae3BADwcH01NpVexBJnBBdXnkf9nq/A23o7guMR2TVkAX5oIYCFkpWEo5xSez46xqXr0fvKD6O+5cfw92/DaHkx/uGRQXgDy/AyJ7kvBNdRbEsfDXvj6+4HIXb5i2GtvwI3b52HpYfvwz5/Hq6oPIvzyi+g+pPPAg99G/Wh03Dh0WMYrSxCNSzj7NJuLHePY5kTkY5eaOMn1TNx/Zl9sHc+gNf0PYrrwy2o7GvEXvWLKjuAn/0xAOB/DUX7hABKVoCJb/853NMvARpVWAMLUdpwFZwFp3Hzk6W5+oo0zbzPrjAMkxAKgbQqN5WGqoADm1pKNYuj1JRSzlLK95uEJrB2op81LjTB59Jsu7HA9rykTR3J5gch90WCKnF4JiNNaTgXoK3h1sJ5kZJswxB2ypd2iaU0V/MtYTYo3BgOn6hiQ4v7ilb92XL/GfBI6hqa62dg0G0Yws1Ai/oTPwRq47DnLYe77vLpHo5Bm2AEjpiiCGgUbhU5REAkUfKmdIrN24oabjMBrmvDr/uZiaBTAd5SKhNwQFIHjW1DIddw0x+T+B6114ofxbzmysWx7XiOTDZruNHFUt4abp5kKeX7pJ8F6Xzb58/HPj8i2eYJhMLRYAB1lOA6wN76AvzL2LV4/9X92P/QbXjBWYX3vuZtOP61xwEcwW5/IQCg1rDQ5wB27xB6rvtNHP+fv8H60gHg9r/EOIALe5bgMXczPH8pgiDEsDWOKw7/EH1WHS94C/G5sZdg/YoB/MbPnQN7aAkO7R/B9558EAO9JYRoYJ8/HwfDBfBrYVwg/4TXjwvZfVmq4KH6WjxUXxsfy+WnbsYp686A1TcP9tDi6PisEg4GwzgYDOPJxmlY2bsCluNipHcF9vo1rLdd2MPL0HPlLwMAtt/+HHY+94LivIU45izEDaWHIrLNclA6+1qML9iIrzwOvPzStdi4chh3PPwCbrntIbx90ZNYtaiMnus/AKvSj8oFPwcA2LP7OPY/+DCWZpDv4nyMCLekFmRgu7i9ejYA4NnGMrxxyfO40noEGD2E8ughLALwpv4dXBtjQQU3jd6Ag/4QPDh4+VVX4ScH5+PCsZ9i0K4ihI2vj1+Eg/4QfnngZxiyq/DLAzgxGWKBE6n4TgR9GMYEvG0/i9ttbPkxKpe8GaVN18dzmqWOUqIstjunHnmCEHqF22BfGfuOTHChCFwNtwxLadqiN43ocUSFW1zDjSfc6JcQU2kpDUXyjcwj9o64YJypC0ijcFMTTa2cFymwIOOa6wI22oEU7JKzbV2Nwm6DBqH097aeeiJeorlIHp8MiC2l5vIZGHQdhnAzUCL0G5FCAkD5otfDykmsGMxcsHWKylKqUqpxCjcFwSO2kQaR0HGVCrfpJ7lKjo0a/NxW2W6Cs5AKNdzYr2njzLKYcu8Jb9J2xQ9jcQqpUuGWbJyVUsrUeXLB81C74NYpKlWqIMe2OCakNrwS35i4FEP9ZViWJSmMJmterFx0l2/AP9degze4d+DUnnFYvof+6kG8e+AO/LC2CisPP4LfGb4TA40axsMKPj92DY4FA6j3LII9FCnJ2PmnRILr2PADH65joe6F3HaqaxkGIZxl67nXdHaemPzJnU5r4X77fPz8625EY9vPUNpwDZzFq9ED4IMbyf5uGfv8+bhl8PX4X689V2qFWozTIB5flDiJeF/OsggHDzgX4BVvewe+/O/fBsYOYaCnhMvwCADgztpGjAUVPNk4DceCgXi/EMA290z89/ElOLv3IDafswY/eyCyXf/R8TfhA69eA3dgHv7uvx7D+t7jKHljeC44BZ98jYNw/CisnkF4Lz4B/8XHUbv3P+DtfgLzgjNxBL1xrTuRKAOKPbuYdZ7Ni83rFuHMVfPR3+ti24vH1ZZS29IqQuNtU/pU3R+VkoNawyehCc1tmcJNsJTSEgPdKJJOLaXcORDshvRUzz5L6dxWuHHEWscVbunbd6OGm9hU7tAEDdnYbYxO1OPfxXTqIhD/75yLc/lkQGgYNwODKYMh3AyU8HY9CtTGYfXPh7v6oukejkEHwNRBsaWU2hGzUkqZwi2FmEmDyNfOVIVbuWQDkzKxOB3gFW28gs1SkDTiZ145CCNN4cb/7TgRIRq5O9UEj6MITeAJNfkcUvKJKWZEAiMQ+qTv6o7A5xbosg2P/Q3obWiMNGQ4EMzH34y8Bn/x1kuxbAA49NU/xcDkAbz+6L/CRgDYwInyEvzr6EtwJIhsklQVqibcLNQazfnV9FyqUoPFY6EQ7TysfbatrHSUmohRKTlwlqyFs2Stdpus2mEcwZkCS3ifOy+K50EQAla5F09jLfZWl2J+qYLvja6LkkahXiyGYbRfABtb6ytwemUZgEgVF8CGVxqE1ZxvB50lODE5D7ZloXzmS+M2Sme/HI2tt6N2z3/A3/0kPlDagu/3nIcXSy+Jxk0Wm/E5Tz1y4TwwhVvzvC0YquD6i0/D49sPc6/T3x3biu9nnSImPTQh+Z2RZZWSHRFutlrhJlpK6X3aFUupEEbBiuCLBGRIA110qqUZuoA0Cjc1kUrpm1ZruOVNG+5oKmiL005Xy67bGJ1odKRfWeFmUkpnIxKF8LQOw8BgTmD6V5UGMxKNbXcBAErrrzDqtpMEiaW0+TcNTVCQX+qU0s7UcFOllM4AUVlsg5wZllJiF4Va4eYqFp8M7dZwY0qc9NCEiPioMkupn6i2VHMjSY0EqWUlqFMURaSz7EA6koKeH0YssPGL/U4IhFtM3FkWrEo/9pz++uhvBJgozcNXxq7Az075FYzY8+J9qCqUEUzUfsfuH84u3PypIqxUi09fOAes/VgtViCMZLi/rH2PIbEyqhdVuRVuwhxrkCJvqpqO7JozgqjhBfDgaMk2NhZ2zujvcZsgIQjNayHeN5ZloXzWteh7/R/DWbkZthXixt5HsRwHm+NpT+EmErFianQoEEzsvXZCE1QKokrzC5Wkhht/v4uWUu4e64al1JOt5YBsh1WRNiLZMlMXkHNd4UavMPfFQQtEpGznzOh7ShRuOclCVfDKFGBkPFG4tWNlFb/06cbzwKD76EaQiIGBgRqGSTGQEEycgP/i4wAA94wrp3k0Bp1CYiktrnBj74thAq2mlNqKlNJpT01AkkQ4IyylaTXcmj8pKSd+ZspvLVQo3AgBIn4YozXcREspJQhU3cWEGwmBkL4dD1X1ecC1L7VL1DE+SdClBDG7prq2RIUbe5sRZ435a/C50Zfgp5WX4s6V78V99XWA7XBzhbtnFMfP7h9KBKrux3gMCo5LHDc7dkZUZtXyo1i5bFD7XjzmDKLHIwRnGsRxUMLNEdSIQHKdWL8NMYVBgTAMuULQ4qIyDBMSjt3rTE0lwllwCvpe+WE81DgdtgVcPfljlNHg0jt1qsI0iAq3+NnK7gdFYIBj0dCEVhRuCsKtFN27SQ03vh3OUtoIBFK7G5ZSkTRLiFP6GneY8bWO/rTil2fmAlIXGjBXoEufbc1Syv+ddT7ZlA06mQoqPl9a2K0bc/XHD+3G//7Hu3Dg6AT3+gixlLbTrXiN5qJa82SAcZQaGEwdDOFmIKHx9B1AGMBecjqceSumezgGHQJbECc13OT3KHqJWoctBltXuPF/25aihluulrqLmHDLSCmdCtBrYluWVNMN4M+/uOAQL02qwk2yCtta1Q5Xw02ylDbJOEejcPMTGyV7W7aUhtIiRJemxerQqFINbdviriP7nRFT4qJBJNzYt/hsxju2jccaq/CYvQm+5cR90OPsVZDU8d+ENHEVYReqABLVYkwcNyO8dDXc0q776mVD+jfBxmVx/YiISaEMJbT4jKE1uxzbVhBu/HWqez6yEIQhp74QSbogDOM5WCI1BtMW6zfXLsJ4UMYC7yA+OvR9WKOHyCCjH8UIN175GCuPFTXauJTSdkITyGlg9xsjh2NVLxihF21XrSf3Q63ucySbbi60A8/XKNwEok9VeD8Ol4jv8ZmJua5w09Uu4+v05SNziwYWsOe+qM5qBy0r3BRzGIiOfce+kbYJ7ceeO4yjIzU8t+cE9zq1lLZDkonPy7k4l08GxAq3GfvENDA4eWAINwMOYeCh8dRtAIDy2ddN82gMOgkrJtws7m8gv8JNTiktrnBzmvWapEXq9HNcyeJzJijcOIKNJ1JUC3zxA3ShlFLh5LtOcn10H64d29KmlDqq6wte4cbGJ4cm6BfM4jqE9c/VlwqT8VFiKyYsBOUUI+1khRtPiJTcptLND+JxWBYEhZscNJL0rw4fUdXji49FsZDRKdy0NdxSrvuqHAq3cvP81OtqwiuvpVR8n1oIxRqFgKxwy7OWDUL+nDUUJI6ocIuOQd/mqN+Dz4xdh5o7iOXucbzs6FcRjB9rttc85wUeXonCjSlFecJNV4+wHUspvYeZQpVZSp3YUsraCeH5AWeFli2lnVe4iZZSFckeBKFSJRYKc3CmKjZMDbdshVve8yLOwMzQBGY17+Jpz1/Djf6e/HH7w3vwZ194ED9+cHeb41B/QUUtpe3cI9L/QXNwLp8MYJdtpj4vDQxOJhjCzYCDt+MhhBPHYfUOwV17yXQPx6CDYCo1tu6lNZVUi3JlaEIHFG62QPzF2+RqqbuIFW4zwN7KW0p5JZVqgS9+aOJqvmX2xf/NW0r599hi23Fs9GlSSh1HtgjS921CIIrf5oeh/H2rbgHBFHYcSUEUVzTkgymwxNCEgd4SALmGm6gYY3Pf8xOVjW1ZnLJLFZpA/7YUxDX7LW9ogviaVMNNYd/WYfFwj/Y9BkZIUoshRd7QBHFcTH3GCHjxfXacRcgdaimlfSQbyDXc2H46+EGInd5ibD/vAzjkD2IoHMHk9/4aYXUssTK2oHCj5DOgVrhRMpOdnzAIsWv/KMYmE7UKkK7S41RizfmydvkQbMvCmuVD3DiCMJSudX0qarhJxLtMkIg13BKFW/QzsY3PzBXkXFe46Sy19Ey0mlKadc0TcqGDCjehqbwtcyQyef3oSA0AcKT5s1XoiBSaUtpWDTfxM4EJTZiVSGq4TfNADAzmAExKqQGHxpO3AgBKZ74MlmOmx8kEkejKquFWKcvFyUXCLX9KqdyXbHmcfpJr09qF2HVgDGtXZFvtug2phpugeBMhWUoFwi4NUqgFDU0QtqU2tx7RUkpscqo+E0spUbj54sJJXhTpiqOz0AYVGRBZSvU13HxCuB0ZqcYqvbhPQg4ClHALiZqMt61SG7ZkKbUTWzB336heE8ZAIVlKWQ03jcIt7dLnuecY4VbVEG65QxM0llLR6s4gXicd+ntcVOsRIRQEIadWE22KvKXU4V5XgdYM61+wCDeNXo+PDP8Aw8f2YuK7H8fG+nrstBYXenbFCjdSa5D+VNVbc8j9sm33cdz15H7097j41IevibdNWzTxRE90/JvWLsSrLlsVP+cZbxyGfEIpIKeUdsVSKircWM0tkYBUdB1bSm0bgD9jF5Ac4TQHCTcVWSq+nj80gf87f0ppruZbQl4yT5dSqiud0Oo4xPGMdCil1NRwOzmQ1HAz18/AoNswjIpBDP/wTvgHngUsB6WzXjbdwzHoMBYMRWqWBYMVALLNUwRNKWWLU7G2Wd40T7ogTVRH00+wibjhkpW4/uLTZgT55wiEGR1TnvNON8naXGzPcfShCezDtqtIKWULBde2JEIVSBbqEYGotsgFKk9pSN4jYHNUVffKEWu4CeqXROEWtUEVblRll6jSmoSbFxA1GTgVHa9w4w+BJrdSVZyYUkmhVLhp7DyJzTXfPdpXyfffP1O61ltUuOmOj6nPxBpmDGINNxV+6xc244xT5+Gjn/4ZxqseghCpCrcwTOYgVRnqBBr0XM/rr+BYMIB/Hrsev7voxwiOvICX4gVcNFzBxO7j8BZcCGfRKlhuevIrI7KTlFI0fyospYoaboeOVwEA41W1BTrrOKgKlX6pkqSUhlxCKRAllvIquS5YSkX7L2TyIctSGt/jM7QmER3XXFS46Sy1fB2zVhVu+bbvrMKt2BgY6PNGVdeufcJNPZ5RLqW09fYllfUcnMsnA9hVM5fPwKD7MISbQYx6U93mrr0Ydt+86R2MQcexceU8/OE7L8LyhX0Asmu4uY6N3/3F8+H5Ifp6okeFa7emcFNZSmVCIldTXcdMINsAQRVoCcRJjiFyltKM7cX3XRKaINtHkgU7I7yiGk8BUe3IRfCBZJFFa/gpFW7ifgJJxqC0lJK6V3S+xgXVBeVUf9NSOskRbkkfSdBBQpTEfQhW355MhZvFjQWgoQn5FG4iOeRnKNzE67Bx5Ty8cGAMH33rZqltFVgNt2rdRxiG0v1Bz4UKCcnIv+8JCi+x3fg6pdgXS46NkmuT2l0hd85E1VQYhnF7eUITaFtD/RGRtrcxDOdVfwBnx1048NjdmG8fw8DOH2By5w8Ay4E9vAT2otUon3UtnGXrpTbjsBBBGRgr3DTkcRbJnl7DLfldVNYxUAt5pqW0Cys0Vb09QD4faaEJpobbzIZO2dWK1VbcLDOlVGFRbhfS90JtKtw6ZfHTkYsnqKW0ndAEo3A7KdANEtrAwEANQ7gZAADC2ji87fcCAMrnvHyaR2PQDVikXg+QnVIKABtWzuf+FkMT8tZwo4tFXQ23mah4m07whJnF1VnLwwmK+6duK1xHx06qxEkKt9gKaHMEU5UkGdq2xRG68b7EppkoemRli045IC6q4tAE0gYtRu9yCrfoBLLFAdtuQEG40X5kS2lSw80ixeyBjJRSSrhZ0fkNkSie1Ao36SVSo86CH4RSDbeslNKXnn8KLt64JDexzBRuYRgdO7ViAtkKN0Yuygo3n9tPHA5Lq01bSMeBA6z+WCDUcJNUU8l1p4SbbsFBF/+9FQflko16I8BYaT6WXPJm/OczqzD/8MN49cpRDE28iHByBMHxfQiO74P33D1w11+JnqvfwbUZ13Dz1Qo/XQ031fmlBGjaoklpUxXrcZIabqLCjRHqDKIarROQLaUy+RAEvHZNrPNmarjNbHDXUqHsAopYSsX/I7IIt+Z2nVQ/Ck3lVrjpzgN7rc25we4kUQ061iFLafLFWXTM3ajpaNB9zNDHpIHBSQlDuBkAABo7HgR8D/b8U2AvOX26h2MwBeAVVPkW3y3XcFPYV4vUmpqL4C2lPJGS53qJNeDSIL7NW0r59yjBUnJtuI4Nzw8wWfWE0AS5H1UNN7lYuuqDYLrCLQyjBYVtWRwhpazhBl4JpQpNoP3EoQkuqeHWXNHYFk9cpKaUWkmdLGYR9IMwPs82IeFU42BgKazlko3JWkKEBEjITK5fkfiz1PX1dGA13ICIVBUJN10Nt74eFxNVD+tPHY77pWiIhJNC4ZZFStjCsyQM+XMmWkoDonCjzzJdN7R/27Yw2FvGkUYVYxMNLJnXC99ycE/tDFxwzjlYfsZihONHI7Jt+31obPsZvGfvwsTRFzFkXYKRsI8bK63PRo9FRY5RSykFJUBTFW6cSiw6J67QHqdwaxJubD5KKaXdqOEmKdwYMU76DUWFG/9cYPfiTF1I6kID5gp0yaT0TOS3lIptZ2zfhRpuksItJ5mXpXDrRg23CfL/c7t9sH1LbvQFhD8H5/LJgE7NNwMDg2yYlFIDAID37N0AAHf9FTPGUmfQXXAppTmJM0kV0YqltPmHmWXpkFJKC96XfMhC+r7U4gk0QxOYckbYVlQ0MQVUtZHUeXI04/XJN+OxtU6ylMrLljg0QXijh9Qhi5VrJDRBp+IMyVgG+yKroNZS2tyvpEkppYua3pSUUmoLtCmBSu8N4X5S13Dji/5nKdyKzhsRdpNYBdRJpTqF299+6BrceNkq/Nqrz4rboaAppdG4+XZDhJmL71jhRsiqrJRSj4yXKuNUoK/bloWBvoicHZuMrFlJV82k1YGFcE89Bz0v+VX0vvp3YPUOITjyAj469D3Ms8ebx9kkmpvXjSlB2fOYHjObW7r7iQZ9qOYKVa0xaC2lzYm468AoHtt+GEBit641Au4+7YaipSG0mdzzhCQIQu7ejBVBIX9MedU79z11AHc9sa+1AbcAVXjFXAKvcFOTTqJtWN9WUYWbTEK1DY0SOwuBahKT/cM2Ce24HdIMTSgV3yuKmHBr/p9oFG6zE8k9Mc0DMTCYAzCEmwGC0UPw9z0DwEJp3eXTPRyDKQK1/OVVqomW0pYUbs0PaVnWt7kOem5tFLOIAvz1zXNqafuunRKawBbsjkC41f2EzHA0KaWkhlucUipaSkP9YkqXUkrb9sniWxcMQq2K/c3QhGxLaUKI0OOoE1KnwllK+WO3rMRma9mJRTgtvCSthlvZTQhAdkxRP2K/8jiKgqncxPRKOkaRUDt1ySDe9vL1ce0zKaXUS6zJgEbhlrGQkyyloVDDTaGaihVejq2d4wyUTLQsC4NNAmq0ac0KNapCAHBXnIm+1/0h7OFlmO9M4N0Dd8CBT2q48YSjylJKFW6qZ+2kEPQhjcFlBJTimIQvT9i5eG73Cdzx6F4AwHDz2tXqvMLN6wJZpFO4iRZbZQ03KTQhG34Q4F+/+xT+7XtPK+d1N9CKdXK2IghD3PnYXuw9PB6/pkspFU9FHgJAUrhlnM849babCreczAVHInOEWyi91tK4FOTi2GSD26YTNdyY6vtkn8snK0LF3DMwMOgODOFmgMaz9wAAnBUbYQ8smObRGEwVVHXVsiBaSnMr3BTknkQEGM0bB1HhZpFTn+e0FyboBDWYPjSBJ0qYjbJa9/hURUWXXmwp1aeUhmGorY0jpZQSCycjZ+jim7NNc4Rb0m9WDbfYUkrmfpywafEqKpo+KinNOIVb8ruVch+qVEts3IwEY38nhFu6wi3nLcshJtwaMtFC6/alQXzfEyylqjCGLKtLQt5Hf4dBlqWUV3ipbJzc9gKZyBRuMeHGdtMcuj20GL03/hbGgzJWu4fxhr4HJIWbmOKqSil1bP7+Z5is0zmLeFsGpkAJyBzRKRJVCjpGltaFGm7dULSIhFsgzGuAqZ+SbcQi84nCLbu/oFn/MAhDqdZft6AiU09WPPvicfzb95/Gl2/ZFr+mIxzlJOzs6yHes1nXvBsKN7GpvC3riI64zlybY1QpwiUleTvtNy9P/HwJ86kSDWYW6BUzl8/AoLswhNscRxiGaDTtpKX1V0zzaAymEraCBMuCtEjLrXCjv6sX2IZv4+FwhFl7BFpRksVxbH1oAlGxAYnCjapgHNtWhyYQkiGuZaWwkknKAfaesEjtIQo3tqDS1b2iih6aVskIt2rNV1osWBuUcGOqNsuyZNuisF/cPyEhOcJN2IZCPN6jI9V4McrSQ1n/bNOsGm6t3GdMuVfEUipCr3BjJCS/faRwS194i/XfIpKO9KFUuCXzN9lP3T5TS7J+BnsjAoqpRXQ2Xm6MQ4vxpfGrEITAVT3bsNHfqj4GQhaJ9csihZv8cY1aSmP7KVEhu2RBTNsTt4uOQR47U7iFABek0A2ySEo+VLwukrCi7bSIpZRyOlNVw4ia5U92VRAjpUdoMqZG4SY+8MX5NV7l1VnS/ki/htp+O4zcllJKNnL7M4Vbe4OMiWjSulhnrS2FG7OUkuCZk51APhnB11E018/AoJswhNscR3BoB8IT+wGnDHfNRdM9HIMpRJEaXwz0AxbQ2dCEVpQ3JzPSargVtYjmub50AerYKaEJQg0oaimlNrm0Gm52hsJNUg5oFiI9JapwC6Tx6UjlIEwWHIxwCxGRboAQmtD8Se3ULGHTti3UFSRUdIyygogW+RcL/rP2KOg47t96AP/7H+/G/VsPRsfePO/15lh0CrfpspSKkEITxBpuwv6UHNPBlcgqfh+RDKXKRse2Y1uvrmYSrUkIQFHDrXnOU0cJPNU4FT+qngsAuLZ+G84v74jfi5NrufnJz3dbcz9VFXUHXULMpRJuUmiC3P4YITrGq0lf3UgplW2FofS6qHCD4jyRlzP6I4vNKSIL0myUJxvYvUefj7yaS/07wD/37nh4N37zb+7AzXft4LbRJVmroEr+7QREkiKvykuncBMt0i2PK+R/Aqovttog3AJDuJ0M4Ofh9I3DwGAuwBBucxxM3eauvgBWuXeaR2MwlWhN4SZYSnMu3vmC/BqFm5G4cRBTRqmlLM9pz6s+ZKAfwF1NDTYgJTSh7vNkl2J3RsjRemZiLavIUapeTIlOo3LJjvdj49KRFByhESQ99JTdmEybqDW4Niwrmac0WCIueG8pCvMTiKQntQ8mw9Hfh3QNQ2shReNuKtwarIYb60c/huhv7XC1qJSKhyaIkC2lPEliC/d/GMoJtiIS8j5RqtF5LNUFQ0LMOrYV29iZckqsc+QLZKJcww1c/2n4weS5eLi2Gg4CvGvgTnxo8Pt4Wc8W9NaORH1Y/Pzk+reSmn8U1FLKFu6UGGY1lsLmaaCLbvFZrjqEob5yXCtwkpBvU6JwE+5n9hpH2jR/hsIczKPWUFn5ug3xWE5mMHUprXGZRTQx0Pv+U197FADwrTtFwo3fJ41AmqpaVXmb1hGPokW69XGE3E9Anm/t9KFSuJ3s8/lkhC4t18DAoPMwhNscRhgG8HY8CAAorbtsmkdjMNVorYabbJPLA1Wdqqzi7nMdqQq3HCeLu74Fz61jJwXlxYWMWMOtEhNufA03ZWgCIapihZuvWCznVLiVS45EuFECyNGQytRqaFsWeissOIGpxZL3KNjfcf2xFEspwAcnUMWdTQhHem3SLKViP6x2HlvQJmorYcw5lExZYH2pCDexYL0OMTnW/DszpTQMMxdxtnAOgzDk1Er1JhnJmpYspXENN+DLP9qG//UPd+K5PSe0x8bUkKOxpTSZz1kIYePfx6/GY6XzEYQW1pYO4ef7HsL6R/4Otfu/BjvkLZvb95zAnkPjcf/q0AQ5pZRap9nzOlG4kXqDjnpuAxGZe815K/DGl5weW5cnSF/dqOGmq8kl1j3jBW68Co4dez6Fm9xOt8Epjk5ygoIp2+oNSripSU6RIM2jSJNUcXktpSljLgzN/1NZ0FlcQ8X7LQ2L3Tsp860ToQklxyjcZjPoJTOXz8CguzCE2xxGcGgnwonjQKkHzilnTfdwDKYYrSjcWg1N4JRGrAi9SrJhEIMn2HiipKjCrSjJYhP1j9ZSGtdwY6EJPkd2cf2zfQNGUNCUUl5FpKzhplh8A1FSJxtHrIihlkENqcwrfSjh5nFtiOeN3SdUnVXPqXCzbQgKN1npmRaaINYjY/XrGp5IEvJjkCym2tHqUW4q3O5+cj8+/KmfYeuuY/F74vXTYfP6RVi5dACXnLUUgFx3Sz727BpujPSNAz4C3lLKfmekkWQpbXYZBiFuf2QPAOCzN28h+/PBDoPMUjoh1nBLHWZC+MHCvb3X4I+OvxHfHL8Y2xrLYCFA/dHvInj4G/H2IxMN/NWXH8YTzx+J+1edXz7og50TonCz+dCE5P6TyWQ6T9YsH8K7btyI+YOV2E48QRRu3UgpFcmK2FYrkC+5UkpzEW5qlVE3kaY4OtnAnlfs+QQkikQgXeGWh3CTLKUpU1KsA9gpSP9P5d1Pq/ST53wrUAVEyIR2G4QbIffj/9unKHjEoJMwCjcDg6mCWfHOYXg7HwYAuKdtguWWp3k0BlONTijccqeUks3YPnmKds9l8Ao13qKZT+FGty/ef1zDTSj0zf5S13BLFr60S6Y88Sjh1txAtJQiVNXnUS9EyiVHqgVHCSAu2VWncLMt9DUJtwlGuMW2VOGcCDZYC+n1rGhdskrJic8pR3hw9wbfIT1eT1S4lVgNNxaaEEp9AtkEXB4w0mXbi8cxMl7Hk00iiI4xi7Rfs3wIf/zuS3DW6vn8+FIUblmqiSRwISFrVQtqRhiGYRhfryj5k1eAAcCh49X4d9EuyxRuRUITAJn8Hgn7cEftTNw0egP2bXwrAMDbcitWOEejMRw6JtVbU9n3maX0ieeP4IX9o9xYAcB1BYVbrCaVP/rR5vt6ktqI7NxxoQndULgJt1Gi0hEJN/02RUITdPXUntp5FL/9j3djy46j+QefE7zC7eQmKJiC1fMTpaqOcBSvF/0SQ/cMKGYp1ZN77aBIHTkKrcJNoUxrbVxy2yIh1k4fvNWd///XYPbA1HAzMJg6uNmbGJys8HY1CbfVF0zzSAymA3TNlbcWG7UrqVQS+r6Iwq1JtIlqOdEKN9dBT62cUppn/9YVbrQPnQ2KLdqVKaWOzV1z17Hg+aTAPlHs+UItL2VoApp2QWGMkcLN5sZGCTxKPtAzQBcfKoUbW0iJ85upM2NLaYGggJ6yy1tKLbYNab+Iwq3ME25ZNliGVshXZhtmoKmBvuZc6SCdU4E0Y6BqNB3Ys4Q9ywLF3AGAsusAaCAIQ06hSdNN5w2UcXwsCkM4cHQCSxf0SYEQrGYRu/5sRmYduXgvU4wvvwhubTu8HQ/iI0Pfx3hQwfzbJ/CGvo341sTFCGE1U0rlXqo1H8fHavj7rz4W3xv0uVqKQxOiv+N7w5Hbos+IfkK4sWOuNqjltRuhCRqSXXj+KBVBEuGW3Z+uftGTzx/FkZEqnnj+CM5es6DYQWRgTtVwI6RZ3fPRU3a1C3zxelVJbUIddF/KqCDah3/0wIvYfWgM73jFBulzSDtoLTQh+V0MS2l3HHQ8qnCi1tuPfjq2Bcex4AfZX44YzDxMVXqvgYGBUbjNWfjH9iA4thewHLinnTvdwzGYBugKyqeBKtzy7gPwizlGWsgpebmbmxPgCDNYnHIpDzlZlKCT+md9aFQZsqXU48guLiiDfQvuJ6EJojLNidVGKkupup4XreEmWkrF0ATLSs5aHHoAXuEWW0o1yiVGvNDQhA+8YRMc28Kvv0a25dM53ltxE0upRRNLeSUjBeU1tDXcGn6TpEzGRNEJSylTuDGMTRIrY06FG4NIUjLCVBxniDBTSSWeQ52tKVG48fMtFlWGPFH12PZIwSceG9uGXX9o5ok0TvK+aKW3LQuVK34J9rwVKFs+5jsTAICX9DyN1/c9kIxVYykdnWhw9wsLErEtK7bSipZSV9EWr3Arxb8z0q7ebYVbTkspT56w16OfMWmfw9ynsy0yu2w3CITZXMNtdKKOe7fs5yyiaeAJN77OJKAOC2Co1rL7EO/0tNPJq+mA//zxs/jZ4/tw52N7M/tJg/TFUF6Fm0bdlyjT2iXcmv1QMk+s4daOpZRY08X/fw1mD/j6geb6GRh0E4Zwm6PwmumkzmmbYFX6p3k0BtMBuoDLbSkli8UiKZh0UztevIqEm2HcKGSFm/o9Hei6vhX1oCo0wRNqnwG8pVRHdrmCCs2ykvF5ZB8AHHnEEIbqRUjZTVJKxYWyyobH5pioUNPVcBOneGyfIaEJF5yxGP/0Wy/B5ecsk8ZH9++rEIUbqedGu0hTuHkCycHOOyORdPZGyRbbUmiCoHCblBMr8z4PxGNMatnx20XHlWLXJarPJMxCvWhgKq0QSZuuYyfppkHIEQTbXjwOQD62WE3pBxEJzEhO7SjZWJMtGPnH4NgW7P756HvzX+Bvxl6HT47cgIfm34ggjEi3s0u7sezYo3BrJ6R2J2ueZGkuuQ5+5VVn4t2v2hgTpbKlVB4xvVdUCjd6ZrPSY1tBGMj3PMDfA36oVrixn8UUburfReK+k0irqTXT8Tf/+Sg+c/NT+MYdz+faniPcmupIXVAFe11lX9ZBnC+5QxPI7/dvPZjZT+oYmj/ZnZNf4UbGo3i9GzXcfGFs7fRBn4tM6d6NZ4JBd9Etq7WBgYEMYymdgwjDAI1n7wEAlM64YppHYzBdaEXh5nRC4cYWryY0IRWi8qmdlNLWarglBBgDJapcx4bnBfGivtrw4wW9a/MppWzexIQbiMKNkFdRf5AkbiHkGk9ARAbYwjfsVJUk1jOzrKgxkXhgC71ag1diiCQS+zNRuPHKJxG0/94eBxO1RnysSoWbSLiRRYykcKsk/33XG0FC/ogkYQcspeVSiqU0pS6YCuJ4GKEjW0rTbUr0+ZNcF53CjZGTIXftk6COkKsbxYjX8Wr0k9XLY18ShOAX8ZmhCeT9kmilJ/PgIBag5vnoCxdivPY8rul5Br8xeBuwG/CO3wMHL4cPBw583ND7BDaMjKD8zNmoYAg1lOJzwcjfJ5t1yNhQqeU7bYxU4aaa290okC5eahXxRWtIAsljIrGU2tzf6f2pyS9RDdhJdFPhFoZhV7+0evHgGADggacP4heuW5+5PX1eNZQKN3mf3oqLeqOey1Iq7p9GdvG2zeT3Z1483t55I/9PiAm6aeDTIWXSozs13NSEdiugFm7x/1+D2QOVndnAwKA7MCveOQhv7zMIx48C5V64KzdP93AMpgmtKNzoYjFvzSZxW7bYo+Sd0bbJEBVtvMU0GxZHSLSucKNgpETZTeYBS8us1nzum2+uhpudKIOi8RC1mJQwGEr2BqomYii7kUIpsavyC2VV3St2DhuCwi2q8ZUEE+gspaKarkgNN2optWwrLsDf35sQZ+kKN57kKLtJQlzD87U13CRLaSsKN4lwo+mYxRRuYv+McFMr3NIIN1pPkp9LIipMpRXS+aZXuLH5se/IOABg2YI+ALzC1/ND7TwRQd8vCefSoc/G5u/HRqv43uRmjAWV+D137ABe1fso1rv78JGh7+OVvY9jjb8TQ9u+i18d/AksVk+OI+oRHx8g32u6MfZVZIUbRTfIKHHBrlS4SaEJIVfzMZ6DuRRuanWHryD6OoVupZQeHaniI5++C9/6aT71WTvI+0VbnVhP680vMuh1UanO2LzLpXCTFFv6bUULJz2GXQdGM/vSjqH5M/lyKud+mrknEsitj0tWuHXSUsrUhTb9//ckDwE5GcFNAcO3GRh0FYZwm4NobL8fAFBac5FJJ53DEFMw84AqI4pYSmnzrC+X9zwapMCyeAJLdT5FcK+3oXCjn9MZKVFyE9KAr+FGyAzSlqRwI6EBom0vhLxwCRTky2BfqdlXs21mm0uxlIpKKLYvIxXYIlFnKRWDHrJOq0i4MRLUhoV33bgR733d2Vi1dDDZvoDCzXEslEps3EFSw00ag3gMGYNWQApNmGwgDEM0PD+VxFFB3E6ncKMBB1ntJLX11Is+Nl8j1VwSHBATUiG/b6PBCLeontryRf3xPgy+H8QTNeuc0kMWFW6qLz6OjdYwGVbwmdFrcevk2XjhtFcBAF7euwUfGLoFp7lHMR6UcUdwIQK7hA2lfXht70MYtCZ5+76gUvVTiGJ6DCpLKUU3FG5xAEV8TRhpkGwTSKEJ/Pvs+uThEnT1rbqpcBMDIDqFnftHo/TgLiSrisgbMiCGJgCipTT5nb3eW4hw4/8en2zEBLkIUUVGnx1PPN/GOYuJ3uhnw/MLqyvTLNItD0ulcJMIt9bbp180JISbYWxmG3TBMQYGBp2HsZTOMYRhiPqOZjrpmoumeTQG0wlVXbUs0LprxWq4ERVHXA+JKrYM4yZCtITyijd6HYBAsT7RbZ8XbA/OUsoUbqQOFVM/1Ro+Z+fkU0r5YvO0/pYvkF9in+xvukj5tdeciUXDvQBoXTVemeLYtjRHxRpuMuHGFG5q1Za4uMhUuJG1aW+ZKtwi1RRTTontM3CEm0ByOJaFsuug3ggiwk04xmQM7SvcxNCEuhfgpm89ia27jmJFk4zK+zwQnaeMgBLtv1kKN46oiolU9fZsvgYhONsza6Pe4G+gWOF2OFrAL18YXSd6fTyf1M3LeH6l1XDjvvhots8UhLv8xdg1uRjvWHYGlvYFGH/qTgzYVTxQW4sfTJ6HoGcYGzesxtJnv4Hrep/C1T3P4MfeawCcH/VLLLNAesAFHUempbQrCjc0x2bD8xMCmd4DosItEJ4LcQH3HHINvo4W6UMgJzuJbincYvvtFCyaVQm3KtDnlTI0QREckBBuxVNKP/udp2BZwN+870rMH6xw74kEF/17gtjji0J85j79wnH8wWfuxZ//2qWpxKSOeIxVnW1OPVXaqS4FuBUkxD0khbnB7IHOam1gYNB5GMJtjqG+bzvC8WOAW4Gz4szpHo7BNIIuWPOnlCYfIovUcKOL7LgAuUaxZRBhqD9Rn9oWXxNNVrjJn5ZU1rIiYLvTlhuxpZQq3JLQBI+oh+gY3Vjhlihs5JTSZJJIH/7CxMZiAbjinOXxW3HdJmVKKd8M64ItDhJLqc0dn45IkckrpEJUuLE5r1UlpllKBYWbbVsxUUiVFWLTsqU0fcwqiIQbADy87RAAYPueEQCtp5QmCjd52zTSgyPsBfJWRDJfQ6UCsiYQbvVGdD73H20q3Bb2x/24jgXPDyNSCOpzLuKl56/Ad+7ehY0r56Uq3HTn0LIseJt+Dn9yzxJEd2TzGVrzcGTJxbjj0d24srINp7jHcN3E9+AfPA/OkrXx8bF7wksh3OgrWQo3HbHZDuK6UI4Fz0+eAZTcExVu7DWG+LjyKNy4dpPXReK+kxDVep1CrAacglWzmLKrg6cITaCjUwUHJOE1OVJKFYcahpE6VCLc6LUOw1Tl148f2g3HsfDSzadkjoEdw+LhHuw+FJHzB49NYmS8jgVDPZn7ib+riLJWkE/h1nofrCnHtmLXg6nhNvtAv5gwCjcDg+7CEG5zDOPbIjupe9omYyed42gppZQq3Aqs3JWhCWThaQg3Gb0VF3/6K5dE1jdbtJQSIqfHRX2sLu2v2z4vVKEJjaY1qERUOsxu2PCCeJElhjwwUoymlDL1jUotplocsJd0qrP7tx7AzXfv4BYDEvkEjcKtSSglaXpsTPz+cohClsKNqIZIDTfd/SbXcEt+FxVutm3FRGG9EWhruEk13VpQk4qWUhXyPg/yhiYAso2WooillKnKwpCQTo4dzw+RcGt4AY6eqKLuBXAdC4vnJYtnx7Hh+T48qrbKOPSfu3INNpw2H6efMoTbH9nDvcd9GaE5h6MTDTJn+Ptksu7jrtoG3Ftbh/cO/hhnlPZj4n/+AuWL3gjbWgMgmUeBgtxmoHdcHyHc1Aq3LoQmBInysAY1+SAWpg9CCAo3dp3zKNzo77LyqjuhCfyxdArJuepYk1rkVbjVC4QmJDXc2Jc3xRVucbuKk8CHFKgtxKzfr9yyDbZt4apNy3PbZ9efOg/vvHEj/uLfHwKQfW15dR+k39slTkPVvSM8G8M2bmFaw0384sxg9kA19wwMDLoDQ7jNIYRhiPGno3RSd/UF0zwag+lGSymldosKN0VfLvfB3TBuKpy6ZCD+XQxRYPjQm87FZ29+Cm9+6TpuX86S2kLf8T4K0ocLTSgn/41MNNMdI4Vb0muscCPpnux4xMRQQF1AXVd/iu1371MHuNdtEkwQH5PFH4ekcGu+HpAFBddXwQACXuHmxMRPWaEaosfCkFbDLVK4JWRnQMhMboxCV51SuInIuxDXEW6qc6kj0AAxpZQRbgqlJxLSKKoLl5CtbL+4qHsTDS/A3mb9tqXz+7jnHiOEfF9PcopwHRtnr1kAQFHDTXGfABHJWWvWsjo+VpPmHsPoRES2+3Dwr2MvxfuXPICVje2o3/9VvKy8DOsGXFQObUTorZCUnRQsmRVIlEaAroZbNxVuPGkWCuSIqA6i3F9sKc2jcNPY7boZmqCrG9cuEkXTVCjc8t3n9HlVE77IANTBAYVquGleV5HBXF8K0paOOUQ0B3w/hJv92ItgAaevGEZvxcFkzc+8tjqyN2yBOPX8oPnlUnJdVPNBVLS1o3CLvzizLak+q8Hsgc5Wb2Bg0HkYwm0Owd//LBpH9gJuGe6q86d7OAbTDFuxYM2zj21ZCMKw9dCE2FJqFG5FoEspXb1sCH/x65dJ23OZFC1ZSuXFqyo0oeTacGwLfhBifDKqhxPVcEv2Y4vomDRDMg9iNRkZo2rhGCvcMmqUxX3aFi48YzGu3LQMp58yzB1TQjzY8TEASbH8OIBAJNhEhVuGAIJTIlZcvOT8U9DwAlx17nLl9mmhCSL55NhWTODVG752zFmKtzzoyaFwa9lSymq4KXZPsy7aiueHp1hsl1ybhAcQC7Ojr+FW9wLsP8LXb2Og9QjzWkopygJ5Sc/HhpXzcODYJABguL+Mg/Xo96Xz+7TzfHQiqUFVDcu4bfDn8N5zTqB6z1cwr74f88oADu3G2BfvwtLB1VjrroRtD0vtUMKNKntEghBIVIKdAk0aZaQju5Rc0ABRurL9VDXc8nhKdfZO1p7fBfJKVSuuE+hGDbfbHt6N2x7eg4++5TzOHum0EJogWvUBNflWLDShgMIt0J/3gDwz+HqBAYD0515SeiBC9JnGz1a4ZSj98hKnE9UGfv8z92LDyvl438+fo2gn2bazltLmM9SklM5qGIWbgcHUwRBucwi1p34CACivuxRWuXd6B2Mw7eBCLAssGF3HQt0LCyncLCsysoVQK9wM35YNPkQh+4wV3V5EXMONs5TKoQlARMiMV7242Ltj27zCjVn+aEppSn001bfxsY1FWO/plFUsuOFXX31W0gcjZprkFRuXHJogj4m1SZF1XukipLfiorfi4hevP0O7vWwpTVG4WcRS6iVqK3FIkqW0hZtNJIlUKELaU6RZStMUbq7iCwOV8qrk2txcThRuCRHHFDiMOPb8ROG2rFm/Le7XSeyreUMTuPEIhAW95leduwI/fWwfgKju3B+/+2I8ueMoXnr+Ckxo6lqNTvJF323bRmnjNXBOOQv3/ugWbH/xMG4Y3o6+xnEMHN2KDw1txeON/Qj982A5yUdAHcnhTkFKKb3d2flQ2eJCZUpp8ndC4mf3KSZXMjBiohsqvm7XcOtkm/c9dQB7D49j2+7juOTMpfHruUMTuBpusqVUtdjvLecPTdARRrrabgzideVqBJK38pDKbAt2/8cBPkUUbrSOVjyOfNdx/9FJjE408Nzu49zrrPu0kI52LKU0VChWlRqF26yDSSk1MJg65PuqymDWI6xPor49qt9WOeul0zsYgxmBuJaaYEfI3K+5YCyicAMSckIVmmAYt2wUVayJKadFkRaaUBK8NkwBNRETbpZgleMLK1tWOpklLljCkCrh0m2eDKr5maSUhtw25dia6WPLjqO4+a4dzb6ENguqxSiJkUclVkThRi2ldS9RuHWCYBNBx57XDquDuJ3rpinc8llKY4WbYnvXsePnC1W4uSTYgxFutHbZsdEaAGDeAF/rNFZr+gn5U+QcixZNer1OXzEU/7770BhWLh3Eqy5bhZLraM8vVabRsdiDi/Di/Itwe/Vs3LHyfeh7wx/j2NKLAQDneo9h8nt/jbBRjfebqKlJDqXCrcNklLoOW/O9lJTS6LmQ/G0LZF3ePgMFMdGd0AT+WDrXLv+zE2BfPvh+yJFneUMTWL3PqC1fGp+qjlkxhZv6ddV55S3D/DOCC8zQqN1SRhH9aN5zecmnLOIx79zT1e5TWVNFojFPkq+2X1JyQUzuNpg9MAo3A4OpgyHc5gjCIPowXTllA5yl6zK2NpgLyCrgrkPJURBmefprPm0ShRuxhBnGLRO8pTT7fHEKxgLnl+2nDE3wdQq3aKE0Xo3UNmJCqJNSwy3ZhqSUCrxJSNIlpeCCnAEE9Ng8oYZbiaSUfuXWbXj6hePR+xn21axboEYWjnlIbZE8jIvdh6FEcjgkNKHhBWCnLEvh1oqllN6rC4fV6Xt5nyPa0ARFgmtaaIIq9EVFBImWUprUmSjcon76epKaf2NN5ZhYvy6xlAYtLVIkwk0IN3nLy6L/n9/80tP57TSnl5HctI1knyYBAAvOotV4ce0b8JnRa1FHGf6+Z1C943Oo3fdVVO/4V1xY3gkb8vlW1nDT2Mf8IJDGkwf0GcOeFarQBKmGG0Ju8R8feo7roltsMvVeNyyl3arh1g1LKbNZ+0HIhYrk/X+fhrw0YuWwjmiK/mCEd8dDEzQhCeKY0ggq9Riin4mlNB/5pK9lV+w66shhVQ03cT63E8zAbn+qcOuGItSgu0ir8WdgYNBZGEvpHIHdM4jht/8d5i+ejxPjPnJ9IjU4qREvcAsSZ+0p3EJOWZe8WaipOYmiijV+IV+8n3gX8qiILaWCwo2lWMaWUiE0QUwptRUKN3p84mIqDFOCDDQ1hVTEUqJw41NK41poXsCppOR6aOr2dBDTL7MgK9yYykQmOGyuhluQu+5cq4q3C85YjANHJ3D+GYvwnbt3Se/nXYiL/Zccp/l68jwKmou3NCWVo0hMVp0n2VLKCDc7Pt+MGO0pOXGNyrHJKIxAItxie3SiESlCYooKQXHfV166EuetW4jF8/iyD+Lc6K24mKx5kjJNRUTGdcmCEFsap+KWgdfh1eNfh/f8/fG2awH8+Wmnwr7qV7j21ISb+rr8+Rcewq4Do/jEB6/CcH/+FHRV8EFMPgj1t0SiLFZ22skXC7kspYq6bawP8f1OoXsKt84TbuxZ7wchV+Mwbx+q0ARtDbfmT6Zwm1TYp8U7TDcM1fjoa6JV1NeQcYVqkjFVac56Zvx5kH/PexnZ2OX/L9nrpO1Y2WvD84O2Em1pirct/N9uMHtgLpmBwdTBKNzmEOy+IdhltTrBYO4hVrgVXIGzGkY6K58OlvChlKpmCnJ3cxJFQy5areHG+kkPTZBruFE4Fm8pTZLMgrhtiThLTSlNFtpZddXEPinENMtY4eYkSjGqSpPqxeVU1zEUXYTINdwQj0uEbdGUUj+lhpuwY4uM2/tffw7+9FcvwXB/Rfl+XgJePMaSYCml1y3VUqogoFV1l0qOHRMxkaU0iPth+zFCoeTaKDVJzFjhJs5tGpogSlxyQLRjq87b8oX93PMRkO/5vgqzcfM13PjanM3jZgEEzfNzuGclyhe9MWp33gqUNr0CKPeif3w3en/yt/BefALBxAn4x/eiHFYhQkeE7jowCgB4YvsR5fs6UEIkSZSV3wuCkKt5FYRqhVuexD1d/SLWXjcIhO7VcOt8m7HCzQ9iBSiQ77yIitwkNEH1XE9e623OaZWlVPoyokWFm6jECjmSrRghKtZwzGsp5d5vR+Gms5QK7QHJ8ZRcnoRvBWpLqQlNmH1QqzsNDAw6D6NwMzCYo2CLsaLWULdFhZsd92cr+jWMWxY4QWCO02VxBF3+fhJLafRTHZog1nDj/ytxHAsW4QtcUvcqatuSFW7kb/GzH629lUbUZb0uWkrj0IRSstCjJI9UD61DajEddDXcGgqCg1pKo9AEtcJNtpS2NjbWbn+v+mNDyymlQmiCa1uoNd9LJdw4wp5XLlK4ROFGFVKcpdRLCLeya6NW92OVjWwpTdR0CcmZ/6SmWUrToFK4ATVJ4Ubt42wXqnBjbVXOfw1Kay6CNbgIluOifO4rMXnrTQgOPIfJ7/9t3MbZAH5raCH+c/wy7PEXNtuRzzN9TogkZRZUSaOJwi3ZTqzhhjDZ16K1SPMo3Djyi+8D6FZoQncUbuw50ZUaboLCLU9ghvgFQV2hcAOia0fnK1O4eX6kNKaBHeI9VqSGWxrRSbfXkW86iCnFbO5mBS7o7MyFa7hprMSqGm5U4Qb47VlKSb1QE5owe6GydRsYGHQHRuFmYDBHwdQ7hS2lSsIsGyLB53A13AyywC04cpywVvlMyVJKwOryiKSBSErYYmgCW0Sz4Vhy+8qQg+bPMAw5G0vWfrrXxTTLJDQhqcvF9Z8R0NBKPbQ0iGNm9jZagJxuy9RYDS+xCEm2V4kkbG/MA6TOmTiePNDVcBMVsEA64cZZplPqCJWcJDGXtkctpfU6UbhlzG1XoXArckbF9lslKvua5ES9wZ8jupnKUkr7tOcti5NK7f756Hv1b8NddzlQ7msONlLEr3SP4CND38fP9T6EFc4xhL48H+k4KqViHy3pYl1cwIsKN7H+VTLvE4VbHvVOlsKtGzWNuqdw6/yYdZbSPESURLhpFG7//oNn8J+3PRv/zQg3QFa5ic99bQ23DEupOH7de7kIV2ETOyf5pAvsUBFlqe0wolVXww3ysYkK0lYQK9xsK1Yk50l1NZhZ0NVUNDAw6DyMws3AYI5CWUstB5jCw86ZVsZgCwtqah3rtFLoZAQlKrpqKWWEm8Uv1oEUhVtFrHNl84Sbwh6nCiCwwK9hLMuK7aS6Gm6uZv6qLM+J9ZAPTdAlb4pNp9Wd6wTEe5EtpFQWPtu24lp6qQo3Yb92hyzWFqPjyQNxu7KgcLMtK54HDU+t7PODkDtX7FcVQUdruHGEmyOHJkSEm7o+Id1PbKvIOZVruOXbj54XgCcnKJShCbFNkq9dKO3rVtB77XsAAGEQwLJtbH16B47d+q/YVN6N63q34LreLaiFLibv2InKBa+DPbgIAJ9yKt7vWaBr9UThBm7s0fh5hVvAPRcoQa/pJwgjst+ytPXEYoVbFwgEVa24TqCoMioLnh8QpR9vKc1DrIiEWxKawG935+P7uL9Ljh3XGKvWPQRBUgdQfNamXWPpNe76iimlavIrF2nb/Jko3PLVM9OllCY13NpTuLG/6cuxpdRhKcAdULjZVm6S0WDmwSjcDAymDkbhZmAwR9F6DbfOKNx0RImBGpTfzEOgcQvvQv0wwi36m34OS0IT+BZ7BUupbVscCSHWU7MshV3TsmSyyGZjSNREuVNKFYv+WOnUPA5GyqkKw+fpK++to2s/qz+2sNHVcItTShspNdzEMecaiR5LF/Thd3/xfFy1aTn3em6llkbhRlOT2XVSWRdVz59Yuaiq4eba0nVn+7Oh1Bq8pZRCDk1IFtVBfM7zn9WSQg2aF3Tb3h414UafE6LCjSpTsmA1G7L75uFfxl6Gz4y+DE/VV6AallCxPHjP3ImJ7/w/hLVxADzhVnTxzdVhE8cs1nCTFG4J0RzXrFP00fAC/MFn78Unv/641K6KmAi6UJOq2wq3Tq2Z6fNGtpTmINx8naU0e19WDzTL3q9rS/UMUFmGVX+n1XpTgt3/Qg23rH25Em7cbOXv0ywkc1UYloK4iy2lLlO4tUG4KWu4GcJmtkFH/BoYGHQeRuFmYDBHwRY2BYVqROFWbOkupqJyllIjccsEPUd5zhafUlpE4cbvQxcESWgCTxr0Cgo3Wh8LUCvcLGHeRcoTcKtlu/lCCL7+FN9XPrKM9QEkKg0a4CGq66Ltxb5aU7iJpI0OUmhCcyGlUm45thWTVbUUhVvW361gw8r5eG7PCe61vOdCquHmCJZSMg9URKPrWKg1+HPFnmXiQj/a3o7ndEMg3BKFmx+PRbaU8n+7nMKNnXPt4UooZYQhpIGp+4CiCrfo79hWVuDZHS3QLWxpnIYtjdNgIcQa9yA+tOIhhKOHMHnrP6LnJb+CyVoynqL2Mpo0Go+ZkUhpNdyQLBQjGzvfHsX2PSdw8NgkDh6blLYRST36s5Podg23TllKRQtpjfs7Rw03IZ05sZSm72dbFnrKDsYmG03CLdlB/jJC3UaWwk2qI6cNTWg9pTTrOujGkwSF5OtWRUrz85psK9z7bVlKyT2XV9VnMPPAKdzyFL40MDBoGUbhZmAwR5EoSoo9BpwWQxPEwsKuIkXSQA/eIppn++T3IoQAIy+UCjefWUrFlFIhNEFUuCmUYXkUbmwsYcgXahb7UkH1ulhc34nJHkupQpMspRkhCjqIKa46iOQhW8QoFW62FVt7qcJNPAqppluHbjuROGo7NCGed8k8UFlpmUKDC00AU5boLKXCdW+q6Nj1q6co3ET7NK3hFivc9IcrQbx3ijxH2Xgd20LFVc8pnnCLfrJFuFi7MA/E6xzCwvPeUtgveS/guPD3bMH4f/4ueh/7LyyxT8BCCNQmClmUqEqN3WOxTVJSuNH9eEsphH0pKOnf8AJOFaSylHajJpVKcdQJdLqGW50q3PwWari1qHCzrIRIrtY8QeHGb1ukhltaQICKbAWKhSYw5E3s1JG9hVNKFXZYnU2QlVFgz8+2LKXknktUfSaldLaB01Yavs3AoKswCjcDgzmKFQv70FN2sHb5UKH9Si1aSpOUUvaTpgwWampOgifQsk9Y6wq3JvHBXiAfxDyNwk0klBybr9EmKtzowjrpV09wicXRub40xK1KORQr3LyEeGEouTa30ARkQk1Vdy4NS+b14uDxSVy8cUn6hpr22aJIpdyiCre6F3CkBYUUmtChiBKp+H/Oul3iOUtCE5pfAFiJUkmZOsqsjpSAbnatDE1w7fiIWdormzOsH2oppXPbsS1p7jpcSqn6nKdBUkkWePgxC7TjqAniaCzkd409U6cKVUHXjz9/Jfpf83uo3f81+PuewdDuu/F/5gFeaMO9K0AjeBvKm16Rq4+04AOx7pnOUkpt7CoygT4nag2fb4eSb11UuHGKow6ucJMxd6a9umAp5Wq45bGUakITsk6p1VS4AbKlVNxXd/qUltKUfnU13HIRbgLhnttSSk4PT5CxnzkJN4EstB1Lr54TFW7tpJTS0IScqj6DmQcd8WtgYNB5GMLNwGCOYniggr//4FW560sxJIvVooRb86dK4WYspZkobCktqIhL9uP740MTImJCVOmI9jZahwtQK9xUVkephhtbQJNx5A0uSFW4KQIYyiUH41VPuX3ev0X83tsvwJYdR3HJmUtTt9ONObuGmxO/r63hJp3nXEPJhGQTzkkciccYE27Nvy3bkhRpDBbZnxIo7BhVxCRNKfVjhRtP2jESQUwpVSkTE4VbkNRwKqIgLTiHuG2bx15ybOkejLeBfF7i0ARGOLahcLOtaFHv+yGcpevQ99rfh7f3aey/85voP/4cXCs6x7UHv43S+ith9Qxk9hHGC3hKskfviTW2RIKCKl/FfSnoc6xa87QF8v0uEm7dUrgVJWqyUBcspHwNt2xWT/zigj2/smxrlpWopSfrHkdcicemVbgpzmvaeWmrhhuD8Nkm69py50GhSMtLnNKxs311Cjc2plKscMvXhwqq0IRC58tgRoCbA+byGRh0FcZSamAwh1EuOYVrOnUqNIGrwVSopbmJooq1VlNK421jtUjyXhKaINRwk5IcbU7JJNqHo5RSuV9dwf8wDMm36vw2WkupQvkmhSZQhZtCoSURbAVDE+YNVHDlpuX5QxOEBtkxewrCzbIS4rPu+Vq1lWwp7czd5ooKt5ztiv27gkU9ruEGmXCjCzxlaILGgsraa/j8dRfHUnIdzlIq2kmBRGHHW0qn5glG61+KKlMGWhuRnSI2TrZA16lCVaBz17EtTuHH4K7YiCdW/RL+4Nhb8SfHX4/JvuVAYxK1R7+Tqw9KmokqtVAgRAKyMgwRxuo0eu+oCBY6N6rEgk37Z30A3alJpQpn6AQ6bSkVQxNqXkFLaXN/RlgnltL0/SLCjSjcAr3CTVvDTdFJ2nnRqdqKKdz4Z1JWAq1OVVdY4cbdG/K+qvnGnreqc3L/1gO48/G9ufu1reR50PB5YtZg5iOttqGBgUFnYQg3AwODQmCWhMKhCTHhFj12OIWMYdwyUVSxxlnLcmw/1FcCAGxau5DrjwtN0NVwq6hquBGFm2Qplckl11EQbrHKjv+Qz/Wls5SmhiawGm6EcFMohsRFSV51XasQycO4hpsvE4SWRVJKicJNVRuPH3Nnxiopn1qs4cbGx4ZpE6VjwwulbZWEfXMonkIaQhVunmgpteVtKcGkCrtg+0Z9MZJTcaBdAK1/qU3W5ay2CWENJLWlisxbVyDcGHkuEhITNQ81lHA0GMTe024AADQe/wFG7/4qvvjDp7Fj34i2D3ZvU5WrKghADE2gCjeLWkoVfVCCsFr3c6SUzh6FG63f1QmVm5hKWq/zBFwW2BcE/c0k3SQ0IUvhJlpK9ZY3nVpOGZqQVsNNaynNlpmFwv2f11KqspHS/vPODZVFOYtI1hFuQRjiX76zFZ///tOYrPFKbxGMUKQppbc+uBv/+x/vRrWevq/BzIFurhgYGHQehnAzMDAoBKdlhVv0U6VQMXxbNooSaJwiLscZ/sN3Xoy3vXw93vKydc19IuRSuCkIN7qoF8kZy7Ik4qXsOtI4423IwjpLdRaPQVnDjSde6L5isXwgsp6ltdnpdF1dDTe2gD39lGEAwEBvRI4ylVO9QWu4pbfZKXZIqm3WoqWUISHe9DXcbJvUelMo3FT1pUpE4cbOY/ylgaRwyybc2HH7fkL+FJ0HrV4CdsiuLYc7qNoWLaXsZ6uWUppKKIYKTJB75fjgepQ3vzr648nvYfm2r+HPv3C/tg+aepioWvn34m0JEcIpXwmJr1o70vFW69mW0m4o3OhsLtL+I9sO4bf/8W48ueOI8n1ag64To+ZruAW8wi2HpbQRE26l+O+A1OHUwUJyz9UbfA03MfigWA03fcdaS2me6yNswj4bZVpKFUEJYrN5iFMVWagjktn8dzWW0iAI4fnRFzeqEgbc+IjanNaDHJtsYNf+0cxxG8wMUNK6U3Z0AwMDNUwNNwMDg0JwHXnBmwci0UZVT+b/+my0ZynNbn/hcA+uv+i01D7YB3FRDSZZSm1erSaqcVQKtzIhRpJjiH4+8fwRLJrXE70mzDtdAXjV/GQvxbW8KCmosOhN1nmLjCV0VfQeyIJcwy36yRRug70lfPrD18T3YKJw8+PxZwU7dKyGm5uP+BRBr7sYWhH91Ndwo4oKl1x3sUYbN07Hlmq8sTkjW0ptjkyuKGu4JWPT1c3LgmPbykCILCSW0rTQBJmIZPOILbqLWEpFhZsulZCqYvwQqFzyZtjDyzDxk8/h0sp21EMXwMuVfVDSjA1fp/bxfJ5QUNV2zLKU1uq8pVS0rQJMTRdy5/ORbYfw33ftwOLhXrzy0pUxAZ4XrSjcRsbr+NQ3nwAA3P7wHpyzZqG0jap4fjsQU0n9oJiltN4k6PqbXwwATIWbrXArl5IvEfjQBJFwK6Jw0/dJN9eRbzqwLag6V2wnq09eZcS/nvVcCRTjzarhxp5fQRDiwLEJVEoO5g1UuG3zjp8S5Azil28G04fDJyZx8107ccPFp+GUxXItTZ3S0sDAoPMwCjcDA4NCaLWGGyuGzD6Q0f27oSY42dCOpbQV66O48AWIpVRKKZVDExgh4DqWtMBX1WsrlWyJAGF/3/7IHnzt9u1x2xT6Gm7yf29pCjcVgSFaa1ThD52EeGzsvkjSYW309bjxorQU13ALJHtTMkaRgOvMoEXVYt7nAe2e7nPGqfPw0s0r8Nor1+hruJHaf3xoAtterXBjiIlWzZcGeRRuThyakCRmFj2jRQgvCpvY8cV7MN6GEm7NQxHJqyJEMSU5HcfWWkonSeBIXKB9w9X4j/rLAABX9zwDb/cWZR9cEXZBpSYSLZzqKeTraCU2eBmeaCnl1EGsvVCrEAKAOx7bixcOjOGhbYfwjTu2K48lDa3UcPvq7c/Fvw8PVJTb8GNu//9STuHmh6g3qOItu332xUxfT/L/Ql2omyeCTVv6JQIlSUXSrGM13AI1qVdM4cZ/mZhlR+WIMI3KKI/Fz1fNYV177J5sPr8mah7+6F/vx199+eHm++rxqUDLO7jSl0Tms9xMwae/8QTufHwfPvalh5Tvc0rLqRqUgcEchfkqwsDAoBCWL+wDACxd0Fdov7ffcAae3zuCNcsHAfCWNEO4ZYOzlOZY4jNSK8835WlQWUpFhVu5ZMd9AdHCfLCvjNdfvQYDvSVJhUbtX3EbriOpsdQqtZyEW1oNN0VNNJVFTyTcpqqGW8m1IxuWUMNNtHGWiaW0t7kW19pyO4xWU0o5BZZAeL7jlRu5bUQCjSoqOGJJo4hj7TKirSGkdIpDlmu4yXPCJaEBicKl2Dl2bQu1QntEiC2ljq2sORiNhW6fqFnoT50qVIeSa8Ov+02FW2KppaCWUvo8f2DiVJwWbsA1Pc+g+tPPof9Nfw6r3MvtS0mzLIWbmFyZkHXJsSsVbpyl1OfIVF3ogB+E3Bylx1hroUB8Kwq3LTuOxr/rZhm1lOZNuEyDFJog1HTL3L95v1VKDlzHgueHmQo3NlfZlwm1RsCNI6/CTfVZIq3fIAhx+yN78MDWA7hww5KknRwK1PhLjubfjsPfb2l9JmNTjzMIQkDNqSfbKOaTTjGXBKZE9+/IeB11L8DRkarUVtbnMVrDTfqSyKSVzhi8cHAMADBZUz+rdHPPwMCg8zCEm4GBQSFcc94KnL1mARYO9RTab83yIaxZPhT/TVUe3ShQfbKhqMKN7ZOVmJbZH1W4aWq4WZaF3rIbL0iZVfO1V64BADy186i0vUpdlEeNlYeU0+0bF+MXlE6sfxFVwVIqBxIou24Z7FjKTcKNfQhuEIUbBfs7CMN4G0nhJvbRoTG3WsMtzz7sGBpSDTcrnlv02lmxsiRZCLIFZMm1E+IyTqe14+0oIktpRg235r7c2ApbSlu7CDQ0QV/DTSY041qALdRwi/qzAfhcSqlIbnKW0oBXod08cQHOLu3BwrEjqN3/NfRc9Q5uX54048csPr4oGRBCCFORH1kxeIWbx91LsZpO+H9I/HtSQyrmBUeA5Hwu50nO1NWjaxXUUuoFfPpkEMpWWxHJ/xNRmq7ne6g1/NQabqy5ElG4iSEoQRim1ukDNJbSlH6DELjj0T144cAYBvvK8eu5UkqFsdvCcyhrP0CfKprnOvLEnUwa8zbR5v8hsUI3aLYh95fVd0ieI7qgH4OZD93cMzAw6DyMpdTAwKAQLMvCouHetgvG08Wu+ZCWDYt8sM177uMC821ZSpPX4oWUQl3TW0nICdEyJ1sxLYXCTVHDTaVwy2spTa3hRhbpcf8yuSLOS7HNTqvH2GKIqTzYwkevcEv+ZotiVUopH7jRmTG7bmsKNwqV7RcgtZAkS6k6dEVSqpGxRSml0e+eQLSqariVSnlruCVzo+j9pTvuLNgx4ZZmKaW/6xRuxcbLziencCtARtVRwn+MXw4AaDx1G2r3fx1hfTJ+n5JmYt05sS2JhCE2WVsg6yhoO7WGr1SbiX1JSazV9gi3VhRuuhRNbpsuW0pFNV/WsbP/J1xCYGfXcEu+bGBjEBWuKoJJhErhl3au/SCM+xGVfZkQNmFfBmTWQMuhcMtzGbNquNFhxDXcXJ4wZwRqqNhW2y+z0hvCbVYj0Mw9AwODzsMQbgYGBtMOo3DLBv1cm3e5zJxjLXEszZ1uvnsnHnz6IIIgjD9MqwIGKqSOm0SKSSmlcgBByXUUCjd5WPlruOkVbipLqa4IPT+e7lpKz1w9HxecsRg3XByFVyQ13BK1FgX9u65RuInj7NSQad8WWjsXWQq3NEsptUWqlGoMrkI5GVtKhUtedh2uNl1aDbesJL80tKpwY8eZNzTBEsmr5rwvSo6yvmyicBPrVFG7peeH+OzNT+Hmu3fGrz3rLUfpnBsAAPVHv4ORr/8RvBOHACSLvYg0i7ZnKhrJ5inMCapqTNRx8jFQ8rZa49VWzBooE256FV8r/2cVITXiMeQg6fjaX4WHJUEMTaA13IBs2yBV5JY4wk2/D7vuZZJSKhLueY5TrXDTdxwEYdxP3SsWDsFgkftSNwYKXUopR5DlUbgpVGm6ttnxuPHziyf3VOSdDvSeE/9vz6pfZzCD0OHnhoGBgR6GcDMwMJh2mEK72WjVUhptX3yBzxZAI+N1fOmWbZyFTmVno6+JhZRdgfyyoVC4lVQppSqVWjqZF2+XonDzFMRDLsKty6EJ/T0lfOANm3BRs5YQW7skCjdZvaZSD4rgSJjCJf7VoMRUq0o/LeGmGSOtGZSW2usKVmGxNbboVFpKSxmEmy1bKoseftuWUtvWWko5hZsQmsDIm8IKtzgox1Yq/IIwRJXUCdqx9wTu2bIf3/rp8/FrPWUHlcvfhp4bPgirfwGC4/ux599+F5MPfhuB12iO3YqVvPqUUn5BzxRvduIoVao16Hir9XwKN5GEoBbzdhVuLAU1c58cRAjlODrx5RWncAsChcItnVSJCTdSE7GeoXBj9zCvcBPVjMnv2hpuitdDxTlh9wD9Iqmowk3cIq+llFcW0d+LKSCVoQmatsXQBDEBtkgNN3YdbFt+hpoabrMHAp09TaMwMJgbMISbgYGBwSxAK5bShHBrr+/R8Tq36FKRU5QAkFVogsJN8UG97NoS0WKpSLOcwQVpNdy8uHh+Mi5KtGw4bR4A4KpNy1vqu11Itbc0NdwAeS4oFW52+vutgJJa7RJIInR16KjlkLOUKuoBxr87aQo3gagTUkrLqhpuSoXbFFtKBesrBT1W0f7pC6EReeFmWEqrNT9zudZbcWFZFkqrL0Tf6/4P7PmnwB8/ger938TwM/8Tj53RowmBIBJuasWbbSfWadVYqBW12vCVtj4poCEI0fB8/Ozxfdh/dELZbxGIXFCe75l4UkVDuHXYUtrw+JAEqvwCklqADAeOTuCuJ/YlFvi49IATW5+zFG7s2iUKN4WlNIflMm8NN3Yf+6GGcMsRmsAGwe4mJyfhplOh0b3y8KZqS2m6wk317AmCUEvUqcDadRRf+LRrKX1q51Hs2DfSVhsG+dBpZayBgYEeJjTBwMDAYBaAs5TmVbjZ7Sjckn1CACfG6gCai27Fh3ZKAIgEm1T7TKgrBjBLqX4MuteKkAc64oX1z/DW69bB90OsWjaY2nen6qGJYMMSU0pLivPu2BboejjrnHWshhsZi8q+mwdZNdwYSiUb9UYAy7biBTklSMVDomMrKWoDOvF9wb9eEgi3npQabnRxXvSUtmspTQ9NSH53hYADWu+sCGKFm2MlbZLjF9N8RaIE4M+lPbAQQ2/5Uzg778GRH/4L+vfci0FrOWx7ILaax0XgRRJMIELYAt/KtJRShZunLFCvCk24+e5d+M7dO6U52YoqOysFNWuffKEJhYclgVpI/SBErZ5uKf3SLduwZcdRLBzqwcZV82OCrkTSdBuen3rO2LVLFHG+rHDLQSyqCDfVtq5jodaI1G9xinGrCrfmJWT/72XXQFP/XjQ1UnU+dHMhLgeheFYHYZirVqDYlm1bnJUcaE9hOV5t4BNffQz9vSX8/Qevarkdg3wwKaUGBlMHo3AzMDAwmAVohTRha7lWOBZxn2OjVQB66yUlAERCQbZCyov+smvLNdIUXYmvFSF70kIZ6Ph7Ky5OP2VYCimQFG5d+h80VrghWvykKdzy2Fz5ul6dGSMdS6tKPy3xJLzMVDK2Bdx46Upcd+GpuOCMxdr+RYWbzoYs7SeEEaTVcOMtpQUVbq0SbsRSqrsP6VjceKy8ZVIkxLNAQxPY+aGqJ3HRLSqiVLCcEoYufCWcpafDDjy8pGcrp2CMVWfCOlBn+7RtK8NSmlyvmmApZb9KNdzCEI89d7g5DjXxF4YhvnHHdjz0zMGMI5aJwDy1vvLUfStSfysPqKW03pCJMtFSOjoRfRkz0vzJ5pvr2jFZm6lwa/5k91wjMzRB3Y6KKFMRSLHCTWMpzXMeWbOxAjdWuKWr4ziiDPSYil3HbEup3J74f1r0Xj5iN+krIbmPj9W498RQkyKYrHrwgxBjE42W2zDID5NSamAwdTCEm4GBgcEsQCukCbNktla3i9/n6Gj0wVpLuBFyItNSqkgpLbVYw62IWidNHccpmzR2vTz10joBekxBEGpTSvOOqRV1ZBZov+0SSCLEY2BqNtu2sGb5EH7p+jPQ31PStsMRbikKtxWL+qX9si2lssKt6O3VqiIwSSm14CqIRIA/dzGp0Jw/CeFWUOFGCbdSUmOLQVS4iUX2ATWBYFkWes5/DQDg2p4tuMB/DMvGn0GvVUtUZ5KlVKdwS45dtXbkLLB1PjRBTHGN9/FDZVItbe+J54/iu/fswk3felK5HYVIBOYlNsRxyu3q+2gFNDShSn7XWSaZ4o1dd4/UnKQ12dJruEU/Y4WbIjQhT6iAqg/VeWP3RhCEsUWW1inNZ41kjBtvcy9mKYXy9zwKylBRu0/XdhyaoPj/W6zhlqnQI8+RVUt5FXg7NdzoPd9txdUP7nsBtz28u6t9zHQEHX5uGBgY6GEINwMDA4NZAEoq5FXUtFPDTVyTH2eEm8YGqLO4ATLBoFa4ySmlqg/+knqukKWU/1sXmqBbZItdda2GG7XzhiGX+idtm0PhlhYw0Cosy0rCB1ok3HTXTnw5UbjpCDr+75JkKRUVbtHfm9Yu5PcTCLdKWT7fbpM8brQVmtDaRy8295nKTjkfclhKixJ+rpMQbpQQYRCL6ot/A3oSorTmfIwsvRCOFeIl/s9w4f6v4/83/G0sG9nCjZlBquHGpZRGr6kWj7KlVFYZibXJgiCUyPf+Hpfrd7yaX40jKdwyFrmSxVWzuSqtsh1QMpUGRTD1mUiqeLEl0+f+dp38KaVxaAIhdOXQBPk4xXtfrXCT+2P3RoiEkObSWXMQR6LCjQYxpEEX/lC0ppavuO5ZCjfV/99BTiWl2K5tW7hgw2K893Vnx19etKOw1NlrO43Jmoev3v4cvnLLs3M7VXWKzreBgYEh3AwMDAxmBVrhNNqxlIqqnUyFm6smqQBZmRVZx/htVEok0aoGyEEKnVK40fGrlE1iX13i2qJ+SON+QYVbluqpk8MuubyyoyhyK9xctQU0bkdKKbW533UKt96Ki3WnDMevl1w+/VNlKe1IaEIHargB2SEajmQpldN58yBWuDl2fG80BNshRd1TKNw0KzrLsrHvjDfjuxObcchahEl3GAN2Decf+BYaz9wpK9wCUeHGUkoTwk215hctpbyih/2UyTyxjt9AX5nbls6RhuK4KVQ13FK3D8S/1e3zRFRqk7lAQxPqTcLNsa1YHSWOm51bdt3ZfItSSkloQkq0BpuSNGRBPJ8q9ZZ4LylDE1IUbnS8nMItj8Ks+ZPNu7wppToVWlHFEZ0PKkUoay8IkjOvItuDoMUabk2l+iVnLsXS+b3ce62gyBjaAZtXYu06hpmm9grCEF//ST7behHoAjsMDAw6D0O4GRgYGMwC0IV0XmUV26cVVZO4z7EMwq1USlG4KVRYKlJFPK7xqky4yaRZ/v/GdMQL6x+IFtB5iJ1uqdsA0VKKdIVbjiAH3lLauXG3q3DLm1LKSB7dpVaFH9Df5bCM5P3z1iUqN9uyuPAMdQ03XjWm6j8L7VtKo/EzNZCjIYJLwlhjW1nRlNJmO7bFWwQZRIJNpXBLU74EsPCj6rn4Wt8v4q7T3487qhsBANWffg4r/Re4bUXlEVfDLSWmNNVSqgtNCEPpnhvsLXHtUYJW9QUBRdEablK9Os3mRdRJeUAtwaw117WJZZK/3oywSgi36KfjUAuyn66iERRuADBZ5+cRX8ON2Rr561O0hhtF8ZRS/s+8llJd+EPRGm6cUi5gbdDhMaI9eVGpcAsKWkqbb9PnvuOoydgiKFJHrh3QtsV+Jmsefv8z9+LLt2zrWv9FsfvgGL537y587fbtHW3XWEoNDKYOhnAzMDAwmAXgQxNy7mOzhXIr/fF/J4SbWv2VaikVCTcoari5tiQUmshFuBWxlIrWQp6YAfR2UqA71kx1P8nvQRgmFi3FOVaRmSIS4rVzYwSSc2a3apHU2JPFmoO0hpsKqaEJri3pzyjh9bLzT8XS+b049/SF0r6quaBSuBU9rzpbdhZEwo3di1SFparhJoYmFFe4Re07TkJINhopCreihBuxqMFy8c2Ji/HCwCYgDHFjcBv6rWq8rVTDzWdqm+Q6ZIUm1L2AI1TY9lJtsiBEQyD4BgjhFgq1ryYy7KWiwqtIcX3V+FTbdaSGmyL0ouQQwk1jKWXXnbOUcqEJ+rGxa0eVxuLznz/O6Kc4l1Xkmppwk+8BVc2zNLDrye65vJZSXd02ulcuS6lCEaZSz9HxKEMTREtpTqszZ1+P50brFs1Oh3+00s+ew+M4eGwSjz57uGv9FwUjsvOE0aig+3KQPo+6qSg0MDAA3OkegIGBgYFBNlrhNJIPWu17SjNTSjU2TED+kC/WcGMqJJFoERfXgEwwFSPc9G31lKP/Dnsr+v8W6fbdSigF+A/IQRhifDJayFcUZKdcw02lcLO4n50Cre3VCnT7Fa3hJp4Ddi1LTVWOrHBL/u7rcfEXv3FZ3Ha2pVRWsRQlX9967Tps3zuCGy4+rdB+Tky48WPtKbuxGpSeCpqoGhL7VGHCjVxn1meN2g4bovVPbkNFYNQbPh7ffiTePyHNLDw6/xVYXTqCgWN78TvDN+Ou6gbcUj0HfsDfeB45Jvb8UFtKRSVLMn6tpdQPJPKQEW5RPyHXruoLAoqiCjeV4k65XcHaX1lQhV6UXFurYopDBwRLqevYsfK54QWpY4ufUbYF17Hg+SEmajyBqVLk5LGUqk6bjuxPa0duOPrBRtCKpVSrdsuVkioTR6oabnQ86tAEkYRK71f1HImPvQ3ipmhoRKtIU9KxczaTCKg41KXFIek+q+iIXwMDg87DEG4GBgYGswCtWEo7qXBjC1Qd4ZZGVEWL4eQbfLGGW1KjK3tcltC9zZFmDlfkWxpHCvGyZsUgrr3gFGxYOV+//xQp3CLyMTpfh45N4vhYHbZl4dQl/dK2eRRu7AN3xxVuzFLaYsN6S6lG4ZYzNGGwr4R3vGID+nrcZiIu/76qpiBDybWxcukAanUfg30liFAt1Ise/ZL5ffjEB64sPIfYPdbXTGhl901vJSEG6aKMqnj8ICSW0mJssUtq9SlruOVQXqgWsDff+Tw+/92ncOriaF5btpUs3C0XPdf+Jg5+/WOYZ0/i1X2PYoVzDF+auApAcryqGm4qT6moJqPJqgkxIRfplwg3MicCck6BbEtp0RpukqVUl1LaYWWQqgZfybG1KiYvVuCoUkqd+L08CjcgUlR6vodJUeGmqFUnPkOUllJlDbf0e08M0FAh3qLZFLuvsi2lpA3N73kIH5XCTUW+0nmtVPYJltK8llj63NSpH4ugiK21HaQp3BJya+YwULoU5bzQfcHC3Y8z53ANDE5KGMLNwMBg2uDYVldrdZxMaMVSyrZrhRxqaKwhOsLtinOW4c7H9uLM1WrCynHseCFmWXz4AfvWPc8400iz3oqbSrhJCjeHLhhsvP2GDbn77mYNNyD6kOwHIbbuOgYAWL18MFZuidvpxsiQnNfZoXDT1WTLaym1LQsvPf8U0mC+fqO+LfzhOy9CGKrrA6rqn3WiRmIevPqyVVg6vxeXnbUUQHJe6LygZAglFn0/bN1SGl/nJFSCElFMEVUpO6hp7j/Vc/7ISKSaPToS2dUj0oyp1EI4C0/DJ4O3YU11K97cdx/Or+xCxfLwpfErUQ1L8OHEi1CL7KtU2EkKt4TMCRRKICBS69QEtdcgUbh5fsid76zE0qIKN5Gg0m2vqkfXDhoqSymp4UbJqDBM5lWjOSd8ZUqpLymYKeg7ZdfGZE0mMFVqMLEeoorUU50T8UsgEUWskey4bA0hKUKs21ar+yiXbG2Ygg6qkAGVwi2+R6B+pgWCNTrLlsxZwJvoSA23KbKUptVwY4c+g/i2WDXYql1c9//dVCkKDQwMDOFmYGAwjTCEW35wn5PzKtzaqN2ls0fpCLdKycH/fdfF2vYcxwJbx1kWX8ONLejzjDONcBMTBUVI1sKCJ4az0HSXb5MItw0r56m3k0IT9Nt0esxM+dRqaELulFIWmqDpJquuX5qlVIW0IA7JHp3aUmexcLgHr7hkZfw3Oy903lNLF1WzNPykbllRgnTZgj4AwJL5vfH9X1co3HoVhNvKpQN44cCYcgHtCYooqnxlm3uhg3tr63Ei6MevDNyOs8p78LHyVzEZlPD3ozfC909t7ptcC9XiUbSnT3AKt+Z+CrWLqN7rT7GUioosEeKCOSaqvACHT0xi+cJ+5ft0PCrwYQKpQ8hEEISS/RaI5j27LSh5ScfI5kSDWkpjwi1IrV1I71GmaBX/D1KpwcR7X/V5IlTwX7Zlxc9YFfIQPuK5zlvDjb5/eKSKD33yTlxy1tLCBIgqaZfW5RItpbYtq33ZeIrUr0tquCkUbh0KTejmx8JUhZsmQGU6wcbS6rnV1nArSPAaGBi0DhOaYGBgMG1oNa1vLoK3lObbJyHcip9nVjdMxPzBSuG2AF4ZZFlCwWUnv8JNJAt4S2n6d0iywq3Yf4FTZSkFkmsXE26nqZWDUg03BQXEtun0mEstKtwuPztSaN146Srl+2JzrHadlZOgE7cTdyt63SlES1a350EaGJlB6yfShaJtJbPB94N4MVn0el161lL85W9chlddviqua9dQKNxEW/llZy3FR958XtS/inBrkmDMnho9F5oqNaFu0Xacin8afTlOBL1RX3YDb+u/G34QjcOyrVTCXpVGyKBVuKkspYRwi2y6VOFWsIZb84XPf/9p/J/P3odHnzusfD/uT7Mq1tUEawU6e3CkcGMqpuSYqbWY/e4TS2lM0DbSa7jRa8dsqFJogqCsA+R7WUWUKBVulpV6H+QjN/htYtIp4xrQt/ccGkfdC7Br/2hhS6U6NEHuh7XlOHI9y2hftVpOB3b5OYWbJsG2CKYsNIHaZ4VjTRRuM4eB8uNnYYuEWw6F20w6XgODkxGGcDMwMJg2dNuWdzKBt5TmVLix2l0t9DemWTyevWZBC63xCyNbKGTPSAzxc+EfvetivHTzCpxx6nD8mkim0HYXDfekjqGo0kmE3QLp2SpsgaBcT84BRb6UUvZLp0YXgRGlRRVuv/aas3DTR67BqmWDyvfF6xRbSrWhCcLfwmZSe20QbuICfzofYczeKdZqY7AsK7Zre8RSWnTeW5aFpQv6YFuWWuHWJKVEws1xrPh+DUN9DTP2Kn0uBAJZUHJsPO8txR8dfyP+5PjrMRmUsNo9jDOO/Sza15L3pRAVbqoabnJoQigFCPRV3Hge+n7R0AS5fQC4Z8t+AMCXfvQM976uvpQIzlLaJlGhCkwAontQFRjCK9yiedAgllI2Rxt+IKW0UigVbimWUl0Nt7wppWJZAxH5UkqTtgBqKVWPIa0gf9GkUHGbUEHKxAo3QrSrntWRwi2b7DoxVsOWHUfVltKO1HBLfm8nfCELfgqxp6qFVwQTVY8joTuB+Nq22Kzu/2durrTWtIGBQU4Yws3AwGDa0I7SZC4iVqwV3b6DCreNKaECaaALIwuWsv6LOM5VywbxjlduxEJCpKVxBa+/Zi3OWbMAv/6as5TvS9bDggpL7hi6zLjR5pfM79OGUuSp4dY1S2mLCjfLslJDNugh2JZFCFkN4SYRqemkmM4WnQeywq3lptpGqakEKgm12ijYeD0/iN9r1QIMJCQfH5rQVLgJlm7Xsbm5IS5uRRKMWkoZORMHPTSPMYSNo8Egvj1xEQDgrJG78I7+n2LVxJOwwojwUak1RAKFEoZsIStZOMMQNUHh1ltx4+eGHJqQXsNN5DHERT2rZacbs55wk0mWVjE6UQcg3yP0WtI5Rq8hI+t8YillarVGw0+1rdFnf0mRxgyIBIGaPFZaSjU13NJKCuRSuDU3Ya3oLKWeH+AP/+U+fPqbT2jHI+7TiRpucWgCu+8ttQo0quGmHwvDv33/afztfz0a/80nInfWUponpbXlflJruDHCrXi749UGPvD3P8Xv/PPdbY1PRPzFRKsKN62llP5uKDcDg27C1HAzMDCYNrRabH2uwrIAhAVCE2IrYfG+VPaogd5SKlGSBnqtbYv/EBiTGGScdMh08SeSBSVCgMwbKOOjb92sHYNkLSyY1kj3n4rQBIa+ir42Xa6U0pio7eyYmXqq0/cxZ5+2rZiQzVvzLVPh1gbhxmyaibpl+p5hscKNHI9I4kRz3IfnB8Ra1vrxl5qW0hpnKY1+7xGeDa5tc/eJTuHFwCnchEWmSHTeW1+PvokaXtf3MC6s7ASO7ET1sT2wcbZSriHWJaOF7XXKI5XCrbfHTZRMQVDQUpocSxS4EP29aLgHh0+wAIkqFgz1cOeAQae6UaV3toqd+0cBRF92PLf7RPx6ybXjGpweOWZPqOUXkBAF10kUlpkppeT3/z977x0guXFeiT+kjpN3NufIDcw5k0qUqEQFygq2JUu2LPvoIMu+O/3uHM/ync8+n30nB53OOluWk2TJlmVlShRFMee0JJfcnNPs5OmA9PsDKOCrQgGN7umZnV3W+2emu4FCoVDATL1+73tM4SaC1mKLariJCjeZpTSjhlsa8lgjoyOFczbNUjoyUcexkZnoGsuuUV5yNW2b6FcJiRLd97om/bvleXxoQto8EwlhvqapnGxsB34GEdZNZCrcWC28Do6/50hwv4xPNTvvnARplvcs0Hst/e8zJeo76pqCgkJOKHmJgoLCWYOylLYHIyLQclpK2c8OxllUnwDA2qU9bbfDQIvNa5rG2QDN8AWnOCC/UsWDqEqolCz81O1b8eE3b81Rw22WltL5DE0gfc06r0QNN2lKKf+zW7A6tJS2gqicYNcpNTRB+E9GVB+Ku82GcNM0jSOszuYTrBgqygrk/hAXZdQCyj6ZDUGarXBLWkrpscS+JRVu8VyK6k9FJFXymt1TvxDfH3gPflDfBg86Sseewk/33AvLrye2FZMjbTdJMIgEICOQKCpFM6pH6XrtWkrBnQsbD3p/79x/JtGv6HUOhdtsa7jtOzYBANiwvI8PtiEppfQ60sRS2/ESKbnUUtpuDTcRMiVfntCEtJTSTMIthzWS9YG1kmYpZdeNzXeppTQnuZq2D/udH6PgZ2QlN/RUhZufQUIxiPX9uNCEaE4n/2/44j2v4Gv378s6lUTf5zI1k5JR6Qq39o8/GzttFtqprxf1RajlKW1XKdwUFOYNinBTUFA4a1AKt/Zw62UrccnGRZzFMgvRgqKDYX77DesAALdfswY3XbwcRcvA+1+/pf2GQlD7Ji2ODsTqFapioWosSpDIrJw3X7ICN128omUfkqEJnRNucx6akDN9NZfCba5CE0xe2dEtcPX9dA191QIAoLdSkG7fbkrpbGq4AcI8PYtfGly3Yxmu2LIYN1y0LHpPXCyzsaDF/2fzRQcLaJDVcCsJSkzD4EmNPJZS1rU4LTB4nUaSHjHX4KszV+HJZe+Crxu4sHAYd+lfRO0Hn4U3cSraji1AraimHVW48dsw1BrxmFVLJgZ6CkENN0I8UYIpbw03kXCji2gWkkLPPXqdsibmrGE5VTAnR2dw8MRk4n1GuK1f3sc9H01CnmZZSikByVtKsxVudE6mKdzyKPlk76fVcMt6brWl1AqbYYrptNp7vs/qpSWbkNmZW8GVEFS+hJT0CDmZrnCjx5YfTwwQofe2mUI2TtVsfOfRQ/jX+/e1VA3Sj+cyNCGtBiEQn3sn/NNcqfKyFHmp+5DrkB6a0D1lrIKCQjaUpVRBQeGsQaWUtof3vW5zW9szMqCT9fUdN67HVduWYvmiCgDg/a/f3FJBlgVDIKv40IRQ4cap4OJ9KUEyG7Kguwq3OSbc8ircEnbKZL/0WcyDLHQamtAKtJ+GoeOqrUtgGjq2rhlI2T57DMTuzUbhBrDzDhefZ/ERtmK4irvedRH3XrKGW3Cu1AI6m+durHAjltIUhZup69zcSKSACn3VCCGQR+FG2zzVsxXjm38Fzr2fwbAxBeeVB+Eeeg7WRW+EsWg1HNeN+m87HmeFTCuUzoIVDF3D7/3stdAQWpxJrS5ZDTff91PTIINziS2p4ricGq3F24vjlUvhJt1EaMfDJ//PwwCAT3/8JlRLQfKq43o4dHIKALB+eS8MXQOrSmeZRkSmcYQFuYa240aBCUAwzywampBb4ZZCuEnIJJHE8ySkjoykSCOfGHKFJoSbsFbS6phxikBi7ea2EcjnfDXc6O8xqRe9x4jk8Bqlhib4/Nimnbtor+YUbhL1Y7BPWFcRga0767uO+VK4ZaWhpgWo5MFcEW6ydN5WoLbvtP9zVA03BYX5g1K4KSgonDV0e6GuwIONbyfkkKZpWDlcjRYmsyHbAH7BLF529pmVRrhl1HBrBwmFW5s13OY1NIF0TVQOUbSTUtptNVanoQmtQPtZLhgwQ9ItXeEmvG6lcJsl4UYJq4X2CBPrR7FrRBfLs7KUhgo3x/WjhWBaSqlpaLxqTVS4CeSIriOxLftpplwztsjVdMAbXIv/On4H/tp5C/ThdfDrk2g+9mXUvv3HuNp7mus/7UlETCQUbk64j46+SiGafwancCOEW92B5/n43c8/jv/5pacTfU0o3Fx2jvE4nJmM62TltpS2aTk7eGIq+n1yJg56OHRyCo7ro1oysXigzM0TTuFG+ksJtqbj8eQOTbW13RaLeqJwy2Up5X9G20gtpcm2dKGsgQgnD+EW/mTPlyi9VpjXtN+O60vHYfY13NIVbqw/Yjo43bcjS6lOf5cTbnR+yMpUcP3g+pC56ayQrXALxxHtk1D0uneTwMpDhoqgStO0P/vcXOmsawoKCjmhFG4KCgpnDcpSOreYK2VTJxAVbtxnIYHBK2/oAiz+z342c2a2KaV0/zmv4UZWM1mW0jw13NpNt80LtpieS4WbWIhfhlZJrd1MKQXimoNh67Nqq9tYESpSGZiaiircZnO96Ng1HRelghkp3JKW0piQdVy/pcJNJ8pX0Q6XZgNmZFVEdsDAPm85Km9/O5rPfAveyEE4+5/E641HMVny8KJ5eaINXyD3GGpNRrgJ56XHllBKGs40HJwer0XBAzN1G5VQPRacU/CTEW6yYujjU024ngdD16P3dU0LkiRTFW7Jc8nCroNj0e9UWcX6vX55X6JWIVfDjVw3ur/teBHBEn2JQmr+ZXEQdEpagqW0VDBQb7ocCZOqcJMcQzYmmsY/Y0XIlHLJhvl201JKaVOOJ69l15GllFM+hftxbbDjUxI02Y6fIzTBE+oVAmk13ARS3aGEW/Y5cX2YQ49j1nHEcchKshXhep3vm4VOiEhXYpkXQd9WAjcFhbmFUrgpKCicNSjCbW4RD+/ZH2eecOM/Y4vpNBUcV8NtFqeSVLgtZEtp/Hve0IS0LsU13LrStQiRwq3LDdOxLWeQjQwJS6kYoiDM/9lbSheewu03PnQl3n3LBtx62UrufdFSKtZPbBc84RYs6iKFW8JSyit/WtVw00iKIlOYiCSViEjhRpR0PgDNLKJ4xTtQvu2XYF38JgDAOyuP4536PRD1HGkpgPWwhltRUFzFxfE9jnzyfb7uG0uljD+XK9zEhfrEtM31i415GgnjtyBLRLx8aCz6nZIg41OBum54oAyAfz5ahi4lVej+ruej2XTDcwz2pSEbWX2j9zAdb0PXsGSwnDg30XJM+yAiLTQh6/mfy1Ia9T3sa4qllM57N0XhlkXSpR4/Zw03pno1shRu5PAysktUt2kaf80Mck9Q0PlByTcZzoalNBmaIP+93Xa7qdATnw9pODVWw7/evw9TNZt7tqY/N+jvinFTUJhLKMJNQUHhrEFZSucWsaX0LHcEyZRSCiMi3Mj75FdqJ5sNWdCquH47+8+1apDeG1mkE6+6k3dqriyli/qC8I6B3mJX26W9FG2KMrSqY5dG8HaKNPLnbGL98j685bp1ib6xe4pZStu1UYvQNY3YVINFeFTDrSimlPIKSNHumhmaIKhuzBQ1KrP+6YRIFNeOxWvei682roXj69jm78aNxV3c53FoAt+fGWIp5c8rJhDFfcanY0voCCHcfN+PCBoWNsLUcSLBcWayzr1vkuPJ4EmUTmnwPJ8j3HjLH388jnDjUkrlllIgHrNY4RZbeO0MwoUrIUDGe9miSkQ4+hLiIY+lVDYmQamE1O60lTjJmkmzVdLxclw58ZiWlpkFTuEmqeEWkZLsHtHTQhNak11Z9dsAQrgJ+7ZjKaW7zlU9NLHttIAL2WezaXc2yGsZ/24YTvHgc8c4ojOtKzw5O/t+5oHjenh+7wgaTbf1xgoK5xGUpVRBQeGsodvKGAUecWjC2R/nLIVbtMCjpFxKSulsVJHJ0ITOa7gtlNCELKuu2Fa3idfrLlyK4f4SNqzo62q7Ws5zZ+itWNzr+azhthDurSyICrduqIqLlg7H9SLVkh0RbsmUUnrMpMItaVFj1873fU4lknbNKJnAHhkiWaFpGh5obIXjeLiz+ijuqDwBHQEBtsk6gXVjU5j+l34sKewAMBTtV0+zlGoxsSISM2NTzeh3qnCjW7HnHOs7a6OnbGGqZmN0ogGsiBfwZhcVbodPTUWkGCBa/oLfGSHNWUqN1pZSgBJuwbb0ujXs9EU2H5oQj/fKxb0YnQiCJPIo3OQ13JLvBZbS2SncxMJX6ZZSqgiUW2s7sZTKwjKkCjdSV0/2uHI9vyXRJCaUis8R2dwA5PMrDe3WIuwUeRVu7fYhrxKtXdAuZhF5zAI/03CEFOYUov4sKNzuf/YY/uY7u/C269fhnTdvmJdjKigsBCjCTUFB4azBWIBKkfMJ7H/ihcAJGEa6So2RArQ2VtoCrKuhCW3WcNNykFvdAj3PvDXc0oYm3qa7fTZ0HVvXDna1TYC/TpUcCrfh/hIqRTNa7Leu4dbappqFtHCPhQiRcOuGqjguhO/BJsoXWUopPWYidVNUuNHQBJ9ftKapEtkCn6//ltzOcX38yLkAVw+cwhp7H95dfSz+0AO8U2ewBftwc/Eq/KixFT40zDBLqUi4EeugWFx/fDqFcJOcC1ugM1XQov5SQLiFwQlMtSRuLyLvghwAjo3McK8diQIpUhyLCjeJZVIkTWuCws00gq9OfCRJGwr6PKU1O1csrmKcKf5yEASiwgqQj4mudc9SyiYtre2X1qc0S6mIXISbhCTj5kKk3CQKN8k5U+t22rEbgjpRDA1KreEmUVCm4azUcEvUAKR9aK9d101vdzagCsmscWFjb7teLrXd2QhNGAtt6/Q5qaDwaoBa7SooKJw1KEvp3CKq3XWW+wHwlrCkwi1cnJnybawuWUrpoq6TWlZUkTlLZ15LcHXMMkinPAq3iG5bCBMhBzh1X0ZCK4OmaViztCd6LS6kxes8W4UbX1NwYQ+qIYQmdEPhxghw2/HQILWdRGKY3fNpVjuRrGKJyABTuMWfiyozBprAyE4tWUif2VM13DfwDvzT9NU47AziRXs5/m3mMnyj8g5YF70RAPDu6mP4jf5/wQ3FXWg2muH58vOFEogiaThdi1M/RyYo4RZvk0wpDX4u7g8s2oxwixRu4fa+H5zbiTMz+N3PP4Yndp3i9hePI4OoMuJqbLmM4EtaSk1Djwklbh++PZFw0zQtsojmVbhRS+mqJT0Jwvbo6enIxixyCXkVbmn2SgbRKiwDm2cyS6mfQtw4npevPluObWSKKpnCjX1mpJxzfH8k22UQydJUS6lwcp1aSueScONTSvk+8SRUuwq3fMRYu8ir/GPn5Ti+oHCTb382ari5Hj8nFRReLVAKNwUFhbMGFZowt4hTSs/+OGcRQ2xhnpb+aGXUf2sHdLp1UstKn1eFW/x7XoVbq9CEubbBdgu0m3lquAHAmqW9eClMXxTVF91OKaUKuYU+pJZQb60rhBsjUBw3UrhZps7VWgRIqAYjTMQC92JoAiHcPF9QhaVcM5rkySCu5ShBVLAs3N/YivsbW6P3thmDKF57KV48Wseq0w9ikTGFH6s+gj3Ofnwab8i0lIqqnel6TLidHq+RPsXbmYJSjC2oh/uDcICohpsQssDee27vCPYdm8TDLxzHFRcsbstSmq1A4hNGdUHhZkpIFZFEmanzhBsQzMGm7UV1wDQteY3SQhNWLu6JPvN8H7sOjuK///1T0edrl/bgxJlYtScl3FJTStPvhbYIk7AZem/5PlFrCorArincpKEJ8edxbcKYcJM9rzzBUioj+8T6e+LQpalYnQxyVtYP2e/dRtZx2lGLiuAJ0M76JoNMtSg9fji+tutx455GHNL353C4ObAxypOmrDB/EJ/9Ct2HGlkFBYWzhlsuXQEA2NjlGlAKAeIabme5I+AJrsS345LQhLSU0m7VcGvXTgrMb0opVdNlEW7t1HBbEFLHHKDnkSelFACncGt1bWYbmsAp3GbV0twjVrh53OvZgBGOtu1F6YUFU08QGIZA9GaRPYBoKfW5RWC6wo0RbiQ0QdiGHkfWju/70DQNu4duwq+Pvgf/NH016r6JjeYJXFfcLQlNiO1z4jkxwgngQxPoZpHCzfPg+3EbiwSFG1vwW0T564UkXwG23EbYYiErjrlMgRQRpWSumEZsKXUEAomiJtRwA+Ixj5JyJXcNfYfe/ysX90RfPnien7DEXrZ5MX76Ldvwq++7NNpGhGxIWlpKc4QmMEKLtULbo6QkZ8F1vFy6qU4tpVk13HQ9eY+yY7WrcBPHLiJjM2q4iQEbsn7Ifu82smu4dU5CccmgXSSU8oYxsM8cx+O+zEi3lNLf50nhxlS9SuG2YOB6Hn7tzx/Ev/+LB9V1mUMohZuCgsJZw2WbF+NTP3MNFg+UznZXzksMhumRAz3dTZHsBNmW0lDhlkKEcJbSWXAl9LhmB8Qd3WU+U0qzggPy1HCbq5TSuQLtZqkNhRtDQn1BidaUOkbt4FyylIqJot0gipnFsum4kWqpYBnJQuqiwi1PaEKKpTRV4Ra2oZGEU3Hx6LZoh9a6smHi/sZW6PDx7upjeGv5SeyqL4LvboZmBOEcOlF6iZa0aUK4Tdcd1BoOykVTULjFhB1d4CweKKGsNdCYHAv7lVS4uRMj2LT/S/jDoeexd2ILfHd7W8XmxTHni9qz4zFLKVGpmXJLaVpoghi4AMSEm0xxQ++juh2P4UBvkage/agwPIOua7hh+3JMhVZeP9yOVzwmj6frWua96yOYr3meFawdnSPcfLAoF3pNWpFOcZ9bb8Nf9+R+PsL7iFhKZWfjea3DAhpCSmmihluKbVyWgpsG2fnMBbII6tnYWqkKsJsEVl7lH6sV6IgKt5RdfHGyzANkXxIonF1MztiYCGvqzdQd9JStFnsodAJFuCkoKJxVrBiunu0unLd42w3rsGP9ELas7j/bXclUuA1UA0LQSLGOzkUNt06UcvOZUkr/sRbTH9P6lKpwi5RGXercHIOrX5cjpRQAli+qRL/T2llAej3ATsETbrNubk4RhSY0Q0tpFywjrMZW0/YiEqVg6knVi1DDrWVoAgk+8Lx44a9p6apEtk2QUsrIOn4bdhwNaYRbqAQi/bu/cQGuLu7BavMMLh/5Bmrf3I3y7Z+AZhY5csFx4z76PjBDLKVAoHJbtaRHqOEWjwcdkyX1/fjN/n9BQXMw872XsHZkFHeUCzisXQcA2G4dhv21L2NpM1B5bbBfxsw//zbeUyjilF7Bw41N0XH85gxgFqHp/LNDHPMsSym9nha5vpRkFAkkpvCzyBcsbL5EYyBVnMW/X7ppGKuX9ODCDYsCm7EeX9d6g1daaZL9Pc+HTo6fllLa6m+A24JwE0kV2h6voorHqGnnI9zykD1camtKbSwfoqVUS1h6RYWbbLyaTosabnlCE5xWCrf49zw19DpFlmKMr4fYHivkOPmIsXaRu4Zb+CwKLKVE4Zayz2wSWTsFIwXn0jKs0B7oc6uV7VuhcyjCTUFBQeE8RdEysG0OUiQ7gSFRuP30W7bhlcNjuGb7UgC8Co6CIzhmwRpxNdw6IB7y1EvrFmgqXDGrhpvWuk8LqZZfLpBuZpGNFIauY+PKPuw5MoEd64f45lLI207BW0oX9piacxCaUIxCE9xI1SFTuIm1wJKLcf61pmuRgpUq3HRNS7XCMgJJ1+IaKaKCih3HMJKkIDsWEC8CDV2D6+n488k34Ibiy3hTzwvAsV2offtPUHrtxzjCjRED5UKQkksVbkCQVBoQbkThFs4fz3XQfO5u/ET1USwzxlB9YBTQQ/Jv72PoA/DaMtCcfgWDpQvxlvLTQNPHWGklvjOyGu+qPg5r9DAutwBYwDXF3dhrb4dz8FnUvven0HuHUX7rJ6GX45INwYLKR69Wx/XFl7HlpfvQwGWwtr82t6WUKzovXEOZwk0MnZAttek9WiqY+J2PXB2NU6Rw85IKN5m6zPN8gDw2ZNyNrrVWurqeByuj8g47j4j0owvXlJpotpseHEGRhwCRhyYIfaT3EbF4uwLB1kpF1So0QZeQsYCgoGxBorWqI9ct5LeUtqlwI9e2mwRW3vRW9pnteNxYp3WFI2znif9iz2tlXVw4oJdCrNWo0D0owk1BQUFBYc7BE27B7zdctBw3XLQ8ep9ap/gabgZ5fzaE2+wUatz+cywXowucrICHXCmlzFLana7NOSiJlWWnFfEfP3A5ag0HvZUC316XFW6Fc1DhxlIdu0G4RQo3x4vmaYFYDhnYsVg9Qn6B5ycW54FILd6WEgVpCje2YNaIRTChcPPi+nXSGlYe35Zp6nCbLmb8Iu6uX4TVF12OSw58Ae7RFzHzT7+OHeZVeA4rwpTSYJ9y0QgJN17hNjnTDM8nfm/AHcVtpWdx7f5vwWuewlXE8f9wYxOeaKzHz19n4tCkCW3vg1hjjuBtlaeCc1t3De7XbsWDR4+hvmgrPnZDGV/+xmO4xtqFxcYkLtj1/1B79hTgOfBGj6L27T9G5c2/Bt9uwD36Ii449DD+++BLKGlhP6eA5uP70Xzq67hZ2wzLWgxLDwIlzISlNBi7Y7tfxgP/8BguW+5hxVgZQ3oPzniBpZvVcLMkltIsZN1HUQ03308o3Njl5OunCaolmaVUy04plbWTCi1uk6nH0kidvAvafJZS8rskpZS1QxVuALvHeHVcKytlU+i3OKa5LKVO9knRvmeN/ZHT0/jKvXtwx43rsXFV++r9rDTRvAEFMtBr200Bl4xYzdrOcT2OCE9T6vGO0vkhwCJLqVK4LRjQ+SHe5wrdgyLcFBQUFBTmHHQxnrbO4RRuZCNKcMzmm9FzKTQhr/VIy6G6ixVus+7WvIByInkVbkBALolkGyAo3LphqTwHCTdmKe0GURzXcPPQYKEJliGpzcgr3ERrlHgr6zqtw8bbRVMVbkQFl1bDLapNpssL5YsKN8vQ0UBM7DQG1qNy2W+g/oPPwhs5hKsaP8Cm/grGjo/BcpYACNJ0NdQx7I1gwJrGlFdCWWti0/P3oD6xCb7t4r8MPI5nm2tw3eG9MCs20AT8Yi++MboRp7w+3PWxd+Irn3kGTceDveM6nNgzgn96ugf/fskPscQ5ij32Eqy75oOwHz4MABjXemBtvBL31GfwcmMxPt73bVRrxwAALzRXYo15Gj2n9mH6K78Jf2YM8FwsByKC6JjTj5kVV2Kztxve6QPYhhewrRdoPLULdvlOLPbGoEGDDw2WqcPybXy05x5cWDgMTALuJHABgF/v1/BoYyO+WrsyItwMzlLa+h7OmpU6IVLrKQo3eo8nbJWSxb2WMhcoWhFucWgC+bui63BcL9UGmJdwy2Up5VRpfJ/iPsbEdqRw0wEyvRO1BPMo3MTziAg3sUYgTSltpXDLqS575IUTeHr3aQwPlDoi3DgyNEFQdm4ptd3sMewUsussQ0S4Oa0tpTJidj7gRsTw/BxPoTXoVBXvc4XuQRFuCgoKCgpzDjOHEosq3OgWlOAQaxC1A3rYTpQ+eo5z6BbEmjlpyFNXTtOTi9KFDPq/eN7QhCx0vYYbN08X9pjOhaW0ECpOmzYJTTB1aGHyY6SoiYrvt7YiApLQBD9+Py1QhSfc0hRuIeFmpKc00u3EOVKwdBhDK1B552/B3nU/Rh/4CgYxicHD38C/g4Ynq+tQQRmrB/aiV+frB2IasF8MCLJ+HbiptAvwgX32YkwtvQTbb70dd//lM4FttjoIU9fRhAc7JG2asPCDwTtR3/8MdjZW4Pc0I1pMxwXIfRzwFuOvp27GbRtdjJVX4y+fMrDcGMcnl90Hf2okGKPF67G7uQT/emgQh5xFcGHgLTvW4pKbfwLu8ZfxwDe+js3OK+idPo763X+KtwK4ob+Cg+4wSgddLDl1GksLh+H6Gnbaq7Bh+zbUD+/CcP0ArivtxnrrFO5uXou1xQlcPvUC3JMVGEs24AL3Zby170E82tyIp5tr4fkaxv0qNpnHscU6hoLm4JB/i/T6smvLzrfWFGq4MXVZSv00en35NluTz+IcdUePAK4D367DPfICVtg6nkNP4u+K4/KW0k4Ubq2+WKJhCHR7cT+PqO30lL8Dnt+a7BK/AEol3GZTwy1vOEDYZp4kWelxMtR8ee2bMtDz6yrhlpOIjCylrs8RnbKuiG/Nn6VUPk8VsuF5Pp565RQ2rOiPwtC6BU7hpgi3OYMi3BQUFBQU5hxU8ZC2zklTwXF2oQ7/yQ7a5JUI7ULXAnrFx9wHEORVuOWr4RZ+PttOzRMa5J++vKEJWeh+DbdYsbPQOUw2z5tdJNyYpdR2PK6GG2ufElyAXOEmUw9pNDSBEgVaujKRPQ90HZw6joIt+g1Di+ytFGx7tggUa44Vw3PTdBOFbbfiW3sWwX/lPrxx+DB6a8dwZXFfoBjSgbpv4ZTbi8XGJEqajaP9l2J1P+A06vjnvb24vvQKsGgdPr13B27auBoXWFVujExTBxrBebEx8s0invfWo4mAhGPn43o+fKIUfMZeiy3LN2J0sgEfh3HUHUTljl9H87nvwFx9Ecw1l+C57+7C/n1HuLHRNA3m8gvwPYzhy+Pb8J8vPIDexgk0Ro5i0JjBoHEQeOLvsFgLxuHvp6/H482N+OTmy/GwfQUOPPcUPlS9D8uMcfyk8R3AAjANzHz1cejD63Dz1H5oJvAO8wm8o/IEAOCQM4TV5pmoH4drM/C9q6FJnsvR/PH9VIVbmp2TXd9F+iSWGuN4xV4GGyYMeBhyT6KIJhpIqmKD8Q2JzelRNB76Bzh7H+U+fzOATb3L0HQ3JvuaQh7ltWy1JtyE7dlckSrcYoUnkPxixhMspbJ7U/wCSCyunhaaYEtScNPA2zkziCVJyEk7cDOeQ7OylOYIKugEWSEP/HbB8W3H476YlCk8kwq3+SHAlKW0M9z/3DH89bdeQrVk4tMfv7mrbXfyfFJoHwuOcNuzZw8+9alP4amnnkK1WsUdd9yBj3/84ygU5H8QAeDkyZP467/+azzwwAM4ePAgent7cdVVV+ETn/gEVq5cOY+9V1BQUFCQgSfT0hRucgUZ/b3Tf7KDdkh/OrCUAsGCyvX8uVe45fymkavhlkKpnWuhCQ2iYukGQUZb6LaldKEzbhaxfwJdVrgJNdwAXjUU1XCTqF9kaWi6FpPDVMGTZSmNttHi2S8uHt3IUtpC4Rb2SZxz4mvNtHBfYxuGN7wZLz/zLHY4z2N4qBffO74Ie5wlcGHAgIuC5uKWzZtwwWs2YXSygftefAAP2NvxjkvXw927F47nRxYrdn7sGWi7XnQeVPnn+n6kpHG9ZOUlz/MxPtWMXut9i1G64Sei11GqKoIvDmhdLdv1MO2XMHnJ+7Fs1QD+6evP4dSup7HdOoybS7ug+y5Ouz14srk+Gi/H9bDPWYL/OfFmvKn8DLZYx2H7Bvy+ZVhZexne6f3QEFhc15qnUNJsaPCx2jwDzweeaq7DRYVDWOUcQP17fwZ9eA3cwzvhjhyEViijuXY7qu5Fwdg0x7G5/jyGCjZetFdgyi/zQTi6BickKr2pM7B3PwzvzCF82HsJiwdGAQBjXhmPNjbhkt13o6d2DLcN6tjjLMXO5io8b6/CSFiLTocHHHkejZf2ofnCPYBdD+Nyy4DnwlixFY2DO7HFOo6pl/4G3vqPQe9fiiXGBDaW9kLf3YC3/WroPYu4Ba2dU7nciv9Iq1MnswomQxPEYwmhCZJji18AiceXJdgC8hTcNLQi5OPtktu3gywlHSWnZERVFvgabl1UuOUm3ILPHNfjFJZShVuCmJ1dH/OC9VEp3NrDiweC55cYytMN0GuhFG5zhwVFuI2Pj+NDH/oQ1q1bh09/+tM4ceIEfv/3fx/1eh2/+Zu/mbrfzp07cffdd+Pd7343LrnkEoyOjuIv/uIv8J73vAdf//rXMTQ0lLqvgoKCgsLcQ5ZSKiLNNkYxG8KNfrNvdkg8MMJtrkMT8p5lnuTUuM7RLDs1T6h3+Z8+TuGWo55UK1ACZq6VjrOFSFR1h3CLVXNMjUgVbgztKtx0EnzgeXxKqUiUMjWTbF+xZRqaIK/hxveJKhgBoLfMf+FLU1cPe4uwc+Y63LplBV4+fJRsZKLmGdEChhEhmhZ/+eC68Tky5R0bM6pw00m9sUDhFqtEZGqu8ekm0sBIxVLRQK3hcqocV0gp1UwLL9or8aK9Ards64e/71F8p3YxPMRqJkaiTGtVfGnmuqit2y5YjS3XDsM58BQefuEEPr97CQAfGoClxjiuKuzFs/Ya7HcW4wp7Lz7Ycz+c/U8A+5+Iz8WuY/qFB3Cb9jh6K+tx2a79sPw60AOMe2V8bvJWaJoG98RuaMWe8Pnuwx87hpkf/jH82gQAYDEAz9cw7RcxoNdwW/k5oAZ40GFqHi6wjuEC6xjehcdwwFmEo84gtljHUbx/Cmwk9SUbULrxQ9AXrQnOQ9Px5b/7Nm6f+jJ6JvZi+ov/EfrACvxS8ThMzQOefhLTL34dldt/Fa4XL7XyKpdbkUnJOnXhT2E7qnBLt5Ty9lQZ0dRqIZ5ew60Nwq1FH8TtOv1fIOs5lNe+KQNHuHVRKJRWD1AER7hRhVuOGm7zRYBFhJvn454nD+MHTx7BJ957addtkucbesrWnLVNL33e55NC+1hQhNs//uM/Ynp6Gn/6p3+KgYEBAIDruvid3/kdfOxjH8PSpUul+11xxRX41re+BdOMT+fyyy/Hrbfeiq9+9av4yEc+Mh/dV1BQUFBIAVefLYfCTVwXLxko4+RYDVvXDnbch9nWcAv6tbDIqzw13M5lhVs3wNVw64LCTbQcLmSYgkVP78BKLYKRa03Hi5RzhdBmSucjI/t0qcJNQrhpcYqo78cLgUDhlkxApW1oJDQh2D9WobLtjDSFm2BzEhVt/T084UYVe3FKKf/vdLVsYWK6GRGSUYF9co6e70ckV2QpDc/Tdj1O4UeJSFuwlHLn4vsc4UbHAYhrixWtgHCjC3NW9J31Ib6WGoqv+Vk83nsjHr33NNeWQ85/qhYntJqGDr06iML21+LosVfg4xAADT6AY+4gvla7Itr2ieYGDPatwbuWH4LfmIGx+iIYSzdCd2qwH/sKcGQXbim9BLjACW8Auu9isTGJX+j7Lpo7RzBzNLB6/nJ1EfbYi2Hd8xX4zWnogytgbroOf/PIFJ4b70PNL+CKwj5stE5i7aphPGFdgadfOIId1mHsKBzGRvME1pojWGsGNe+8QhWFdZfDXLUD5saroWlsXgTjcspYij+buA0/u3Y3esdfgTd2FKYG7LaXYN2QAXPyGGa+8QdYsuT10DAIHxpHcGYhrdD9/uOTWDpYSfz9yarhJqaUireASNzKLaXZ/TYkpDoA2E72Pc/3NVuVJW7XKUmUVaeNS+5ss/lWQQWdov0abp5Qw002l7JfzxU8ZtP2gUdfPIkjp6fx8qExXLNdvr5XCNBLCDfX8zoqiZIGTuGWU4Gr0D4WFOF233334brrrovINgC4/fbb8Vu/9Vt44IEH8K53vUu6X19fX+K9ZcuWYWhoCCdPnpyr7iooKCgo5ARHDKVswyvc+FXBpz56DRq2i2qp82/6KCElLuBzt5FSB+dsIZfCTc/+fKFBrNM0W3S/hhtVuC3sQTXnQOFmEYWbHYUmBCQcnY+M7KNF7xlk4Sc0pZSqbnQteR5MzRS/5q+z78fz3YmUW1q2pTSlhttACuHmeXECpBjuUS2ZmJhuRooBXuHG1EBeggxh50mTLjmFmx8XZw+IEuFcPB8T043otev53NixsSgVTABNjiRwyTgFfYrHwTQMbNq6Gdq9p6NRd92YMCwXDYFwa++eG7GWoXTLbdx7pqlj8Qd/F1/8y7+HfvgZLF6xEv9791oYvocP9dyHHYUjKIRkGzQNq4wRrDJGgCagD69F+c2/Br3Ui5cfehBTfh2GruHR5iY82tyEH1+zBfbpaZzyJnFvYzvubWxHj1bD5YX9qGhNnPD68PYfewfWrlqU2mcfwEF3GAd23IxrN/bAOb4L//dbe/H45BB+/a0XYtnzn4d75AVsPvJ1/Of+Xny3dhFse1nLsQDkCrdn94zgf335WSwZLOM3PnQlv31K+iO1i7LrqQn3gOfz+8lDE1oo3MK/p37Yd3af2W0o3HzysWhN5bebncItu4ZbtxRu3WOw+BpurbdzxBpueSyluTX1swNnKY2UxeeWqsr3fXzhuy9j+VAFb7hq9bwcs1KK/75MztgY6OmeIpCr4aYUbnOGBfU17d69e7Fhwwbuvb6+PixevBh79+5tq619+/ZhZGQEGzdubL2xgoKCgsKcgqs1lielVEt+NhuyTWyzc4Vbsq2ziTzjutBUea0wpwq3V1logmjT7gbhxu7D6ZpNLKVMFRUfL5FS6qcvdIFgLGlKKbXCiechkga6qHBD8ljpltJ0hVulaCYsplSxFym8Cvw21VCRwIgKtozRtLgenevFpGJcwy04tkPJOKqKE0ITRFLAcX3UGi55LdTeCvtbCvtLSQJbsJSyPllhAu3igTL++BdvxKaV/eHxPU7hRkGvV55SAekJywaO9WzHF6ZvwguDt8LxDTRg4XNTt+LJxjoAQOGKd6D6E/8L/9q8Ho82NqB2xQdRecdvQi8F9diiMebUwEml15Rfxn2NbfiefSmeaq6Hq2f/vYlUiwC0Ug+sdVfgkL4KgAZHL6J8+6+heN0HYOtFLDYm8eM9D+LyM9+EidbPNxlf88gLJwAAJ0drSaIoCk1IKrZES6ksNKFVOmdehRvAEyiOZH6loW2F21zUcPPl2+VBKxtnp2i3hpuocJP1J2FJnieFWxQEQ+bcbMqEnA3sOTKBe586gn/4/ivzdkw6QrRGZ1fappZSpXCbMywohdvExIRUrdbf34/x8fHc7fi+j0996lNYsmQJ3vKWt8yqT+Y5ZB1pBSP6J+r8OSeF7kLNEYVW6HSOFMmC1LJ06bOVbqNrWtefv9wi0JT3oRXYeZtGZ/vnxcaVfdhzZAJXb1uSeRxObaXLx4z1eS7GVIbZPkdoDbdu9JeOUdEyZt1mqUgJt/kZ005RFIggo8N5T7F4sAQAGJ1sRMTSQE8RpqlzNeNKRQOGrsc1wchYyZZYlqlH1ypQqDFLqp48D4EtMS2dI8YMIz4uO5Zl6AnyjB3LNPVo4VEgdf4GeouJ8WJt+IgJrJ4KT84wC5DtesG4EDsfO0ePnKOhB9eFnj8T+Rpkf2h8HSRdUP6NTTW41xDmJ9uXEWSe70efs3MpFgyuLxZ51g31l7hrwciVviqvAmRtsN9bQfbsip614bnXiPLVhYHPT9+M1W/7GLZsCsLRnsB2jE9vwqfWXQOrEF8Pn5KaYRNZz/+CacBxHUDLfv4w3sog4xPPdcAqmLAuexO+O7oWk09+C28uP4ONtefxy33H8LmpWzHmVTPbFo/tECJLRlCaITFKoRtaPP/Dc5aSmxxZnTy2jHCj2xR88kwk11JM2Gzn2ZO2LWvR9/2O/tb4wu/cccg4pP09pZiYbqJSMmEaOkcodvPvAu2vpvP99XwfL+0fxZplvREZ5zhJIl43NP7LECdZE3M+/o5FSkzwRM9cHrvb6xp6H56Nv/1Tdburx6VfXtlue/fo+YL5WPsuKMKtW/j0pz+Nhx9+GH/5l3+JSqXScTu6rmFwMP0P4rmKvr7y2e6CwgKHmiMKrdDuHKHb9/WVpc/WGVLvxTD0rj9/e4gMv1yyOmqfLaiKRXNO/z789kevx0PPHcUtl69CJUPZ19cbj6tpysesEi7+LcuY179pnT5HqK2hG/3VrfhfnWq1MOs2F43HpIZlzu+YtouB/mnudaXDeU+x3ggW12PTTZQngrFYu3IAg4PViKzSNGDRUA80TUMpnL+6YeD0VBMbVw5gZNpOtNvbU0J/f/g/mwZUw/vVMnUMCX0WVVN9vWUMDsb/7/X3V6K+sOOXShb6+krJE9LC//VCIqJaicmj4YHks6on/NwwjWgBOTzUw20z2B/MfdcP5jB7tum6Ht2zuq6hXInPcXCwinLY12LJghXO22q5EJF8PT2lSC3n+UBfH/8/7qigfujpKWGQnDNbXPWxZ2F47oE9NjyXRT3o7ymipxpsUyjwc5zZZ4ulQjRmyxb14Pm9Z6JtentK0T79vZIxF1DIeJ6y62dLlDC9w4ui/Vh9xkdeOgVP03HZBUuicwTYnHGjcalI5iA735mGg0q1mHmvmNE1ibdjoSzlSvyeUa7g7vrFOOAM46f778cacwS/0vdNfLd2Mfr1GYx7FTzTXIMpP35eFgqS8dDiOd8rPFutcPuSUFy9r68c9ZM9+8QFdaFoCgEkyb8jMhUS3Yaqu3p7y9E9QmWneou/6VYhfk5nzQd2X+iGHv2NaedvDQ3OMYW/iQXShyqZwzIcOjGJX/jj+7BpVT/++Fdu5VRlreZOO9DJs47OKwB4+uWT+P2/exK3XLaKr20nfCHR31/lvniyZvjnhCWbb3OAKMBJ1yImsVic/d+kPOjWuqa/f4b8XpnzAC0gGCMG2+vO/0UM9G9xq3v0fMdcrn0XFOHW19eHycnJxPvj4+Po7+/P1caXvvQl/Nmf/Rl+7/d+D9ddd13rHTLgeT4mJmZab3iOwAj/OE1M1KT1UxQU1BxRaIVO50i9Fv+DNzVVx+jodGKb6al69LvnedJtZoMZ8k+m67gdth9+i2x3un9+XLttCRq1Jhq1dAvBTC0mf3zPl/ap2QhkHa7b/TGVoZvPkW70d5K77rMfAzqX3TmYp91EvcYrnpyO530M3/Ohaxo8z8fRU1MAgKIRXiti3xsbC/5/ckObyl99fScA4INvugAbVib/p5uZaWIqfAa4ro+J8VpwPN9HbZo/D3GJMzPdwPh4/P/a6Oh0RLiNT9TDfnuozSTvJXZfNO1Q/kQUDD0lMzFezVBpNUmfVw5fd7AQKs9majZGR6ejsQCARj3oQ73hRH3Wwj6z+lRjEzXUwnnWbDqRSmtsfAaNjPv52Okp7vXpM9OAGytGa/VgccWEcbW6E5w7sRJNT9Xh2Q6ajWBbU9e447DC5xOTddTDvlSLvIqt2bCjfewcNRllz1P2HLFDxevYRD2xn+xvyb/9aC/+7Ud78Te//noAcW06quyqzTRT+8UUdWNjM5n3CuvX9HQj3i68TuMTtei96XDOveyswFcq78Nrx7+K5eYYfqz6SNTWbeXn8CcTb8KoFxC3bN5QzJAaeWeEz+r1YPtpIaF2bGwGU+G944ZjLNoLZ2pN3lbWdBLHrjWSY0W3oW2OnJmGHc6dWiPus+ycuGOQ5+rMdDN123o4hxsNBxMTtbb/1tBxrAl9on0YH5/B6Gg6WfydB/cBAHYfHsfo6HQ0HwBgYrLWtb8LDTL2k5P8fD90LHB/nRiZ4kjPiUn+eXnmzBSn3J0UnoNs/sw1mMXett1ozk1MNeb02N1e18yQv0WnRiaj+qVziSlyzKMnJ7s6XvTv5sSk/H/z8x2dzpG+vnJuVdyCItw2bNiQqNU2OTmJU6dOJWq7yXD33Xfjt3/7t/FLv/RLuPPOO7vSJ6dF3YJzEa7rnZfnpdA9qDmi0ArtzhG6QPY8X7ovt4jWtK7PQboo0DtsP6oxhQXy90EQHsj6xDbRUj6fK3T6HHnr9Wvx9QcP4E1Xr+lKf12XXvfZj4H4hfaCmAcp0ARqqhvnDwADvQWcmWhEc6uvUoDjeNG3/YahR8cRybGv3rcXv3jnxYk2fd+HR+qT2dH+SQWBqCrwfZ+7ztM1G5/+8rO4eNNwtLeuaVIvK3seOUJKJxBYJcXxYu3VSa1BMWihEqrAGk0XE1MNjIzV4n1ZsXA3TnnVwucRI3uatgeHKH6jIvS2F1nXHM9LFLMfExRujabD9Z8tytni23ZcOI6Hep204wfjEdldybUEAD0cAcdxo2skJrnS52veYJG0ecl2n64lSR/6t0Q8Dg2XAPg5k1Vji13/4Bqk3ys03TbqA7lO7D3axmm3B/9r8o34QPVB9OszOOIMYYt1DMPGFH6x97v4Tu0iPNbcKH122oQUtYXr7oTbi4tF2/aimpiGrnHXNdrX8RM1D8Vjy0ITxG0MXYPr+Wg0XThFLzo+bSNrPKlCzMn428HmsOPG59vO3xo6RuJx6DPEdrLb5BJ+bZevh9hi7rQDVzgOVxePzTGXT5qdEQhS2/a4+0PsW9r/ZN0Gu8ZBwnLYNyd7XnQL3VrX0HCPet2FXpo7hdvBE5MoFgyu36MTja6OF71HG835uRYLFXO59l1QhNvNN9+Mz3zmM1wtt29/+9vQdR033HBD5r6PPPIIPvGJT+A973kP7rrrrvnoroKCgoJCTvAFq1uHJnSz6DADXWh0HJpwDqaUxkEPC6PPrfCOmzbg6m1LsWK4S5YcGprQhRodtI2FPqKGmO6pd6dGyWBvEWdCO2lP2UIxJHCitE16vwv32nTd4Ra20XYkHMCnKaV6Wkop/5q+s+foBJ7ZM4LjozW8/opVQZ8MHbLTF4uwU+vVgFCbjJ4jtT6XC0JKaWjtazgufuFPfkT6SUIkvJgkNCKikpFZHpfSyobQ9X2OSGr1mBSLpzuJ0IRQsUtUfVE9m/Cg4j0T9ZEEOAwKqXn0eplm67sk69HErvV0PWkBpfNARsJqmiYPTdDlARpATJ62KpoffZEh6QMNDqDt2I6Hml/E56ZeE73Xr83gl/u+jUXGFD7Q8xCutvdgj/2+6POv3b8Puq7xibKJdE12zhDe9yNSl81r8bRpYqSsbaB1SikQnLtLknsBnpQS56IIWncsq5A++6jT0ASxrlxaH1rdW2LaKd283YTTLHChCWL4Aavb5nrcM1VM+m4VkjAX/2/JQOtP+rO8jmcL9FnVKnl3Nqg3HfzXLzyBSsnEzZesiN4fF9TeswW99I1XMdk211hQhNv73vc+fOELX8Bdd92Fj33sYzhx4gT+4A/+AO973/uwdOnSaLsPfehDOHr0KO6++24AwJ49e3DXXXdh3bp1uOOOO/D0009H2w4NDWHNmjXzfSoKCgoKCgRGDmKISzpr8c95J+BSSo3Wi0AZaPHzhYB2UkrPFeiahlWLe1pvmBMc0drhdaegNYAW+tAmyJIuTdzB3hKACQDAUF9MtjDCgZLn4jFdz4cjWWTpuhZdK98nyiQtmVIqEmd0XyAmCJq2Gy2KDEOT1tsRF350zPoFIomeI1UclcSU0lLw7/VMnV/40pRSx/MT6it2bMcjKaU6ISI9HzZRibRarIqKJzYWrL+RWihcaBm6Fj0vIsJNDDNgpJIbE4bVkoWCqUfkDr1eltHacpU1K9klk9kas5KnHdeHZWqRQ5haf2girgjLYgX/Wyw+w4lDWzG0mExloOm8svCBcb+CP5x4C64rvoLbSs9hk3USGw5+GjPfugj+9R/BV+8PrIuLB2J7YyJdMzWl1I/mKbO+JVJKWyRYAkDDjq9rGslg6Bps8Oduu3LyTQY/g1iSbed2SBJlEXtcSmmL9kUiNe2z2YKepzgl2XFs1+MIv3qDJ0hl84JrZ544L2ZH93xyHefgf725BB26uSTcpmsOmo6H5lSTm6fj091NKaXzPA+xrtAZFhTh1t/fj89//vP43d/9Xdx1112oVqu488478Su/8ivcdp7nwSU1KZ555hlMTk5icnIS73//+7lt3/nOd+L3f//356X/CgoKCgpymJwqqLXCreVipwPonMKtM6UPa0NbIIwbJRDSuqQtMJJwvkHXlyJx0wkoIbPQFwsiwdgtwm2oNyaiFpGi/Oy+oseV3Suy+1vXtOhaeZzCTWupcNM0/jqzBbDteNGiyNT1iBChYItWtqjhFG49EoVbeP1jEkJLpJ8yhZu4ENe0+J6lQQVsvFjbnMKNkGAuUZX5fmvSQVQVuZHCzQw/Z/bUpJ2W9cVKzKGYkGLKOMPQ0FuxMBKqHjnCLUfqXZb6lo3XdF1CuJG/JQmrpOvBMvVoHDnVpSYnX4PtkgmbecGuI6dKIr87jnxBW/OLuKd+IXY2V+GDPT/CKnMU7qFn4Tz1NQCBQnOCFDcXu8YVzCfw/XgOMuWeOE6+0FhC9UXm3E/dfgH+8usv4k1XJ4UMlIiNzrcNwo1Tl2VsKipS20XatRH70Kp9L4VYDNrpqGstj5MkR4OfjSY/r5IKN2S+nm+Fm+/Fz3fZly8LGfRvl3jd5+w45O/I+FSXCTcy/opwmzssKMINADZu3Ii//uu/ztzmC1/4Avf6Xe96F971rnfNYa8UFBQUFGYDbgGepnAj23Sy2GkFnnCbpaV0gZgJKYGQrnDL/vx8Bz3vbhBuBStuY6EvFsTz7Z7CLSbchjjCjVlKCXEjmXcye5mukxqJgsJNLEwskiWUrAPihZDtxEoxM03hBka48dY7QK5wiyylDquNpXNzAgB6UpKFNU0jhFW86GRjFCncXF79xo7p+T5PYrSwAIkkByPIIkupoHCjxGaqws0g5B9RtPVUCjHhRmykImH3hitX4+7HD2H1kh4cOjkVjkv6OWQpdLMVboyY5FWErE3ZvWDoGnd+WZB9GltK5SoqkYAVccIbwB9OvA3v3TKN609/Bcbu+9Cv3YFxv4oGWQzLSDGghaXUyrCUZrymgRpXXLAEl24aRrmYXD6ye5QnGNuxlMa/ZxHJIkHeLtKuDcATTy0tpb78PGkfuwH63YTYLuu/qJysCwRckojNtpjOFSJLKflCZS6+XJ1L0Eswl/XO0pSi3Va40bkgU+AqdAfdKeahoKCgoKCQAaooS1tA0fcXqqU0Vrh1o0ezR74aboxxm4cOLUDoXbjuFHShvtALDIuEW6XUne9ZB1MVbkyplV5bCwiK+YtIKtziNkWCRCRLREspIzaapLC/YehSZStb78kW8v2ZNdziYvSmoXPPr2rKOHM13EjRd10YN8f1OMKRqQQdl6/b1orAEQkFsYZbVNjfjYkzhnXLelEwdWxeNSA9f9f1SdCEhr5KPFaUcBXVfzddshz//eeuw8+8dXv0Xh6FW6vPxO1Y3yJLqbCt7JgcIdribxD7lPu7IrGUUgVZHJKR2TSOlTbCWH4BNM/BL/Z9F5da+7nP05ROMiKlGSncgusgKk49jycRRFKHLsItU0elZEnHzpCQjXaK2k2GLOUZt53fepvcx8mwVrZlKU0o3LpoKc1Rw812RIWbaCnNPsa8EW7snvRjde9CV4mL4AjlOex7GlHfsF2pvb5T0DmvFG5zhwWyZFBQUFBQOJ9h5lC4UcyFwo0PTejQUrrAQhPy1HBj7y+UPs8/qNpm9v/2cMTOHFpKugHRirl6SXdq4/EKt/ZquAHAyHg98Z6maUThFhdfF8ko+l70WghNYAsU34/rGRUsPaWGG0+00S1kSh49Itx4VZhFVG7lkil9zmmEOHSppVRQk9kubyllRI5oHXNaqEPEGm5uVMONWUp97iedL2uW9uLTH78Zb79xPdcGVeix45uGjt5KrOqj118MTdA0DYsHyvyzK+McxOdaT9mSfiY+0tm9GakIhb9BaQo3M6qx16qGW7L3MpUXVUJF5G+Lvz+er6F43QfgWhUsNibx4d77cFvpWWjg52q8vc93iXWR1HBLC01wPZ+vnyYSbna8f9bfEDaeTmpoQn5LaTbhNjuFW2YNt5ykn/j5nCrcMsaFfdZoCvd5hnJPbBMAfKles/ugyb4++f1cAh27ObWUuunzq5uEG6dwsxf2/zPnMhThpqCgoKAw58hDDFHMDeEm7087YOukhUJecQqPFtssjB7PP7pdw41iLosmdwPi+a5e0tuVdlsq3DKURwBwWkK46Vr8bKCW0rjNdJWspkGqcAOAqTDdsmga0vs+qiUULnC2rRvCtTuW4sdesymxLe1PZCkNx7hArJcFU0fBSoYFaBpvyUyeY6wek4UmNAUlS2tLaQuFm5uucAPk9dfi/ntwHD/ajyPcOEupYAcOP8r7N0HkpvpJXT1OvSrWcCN18ILj8fNHNi91PR4bsfC8CEZS0MPKLKUc+SZc7zR4vg9jeC12X/lJfL+2AwDwlsrT+E/9X8V1xZfhOUKNrhRLqe/Hi+iYcNOEbXye1BEaYSRvoUUtPrGGm08SdYE2FW45LKVzU8ON/r4QFW7yz9rpKyCfJ/MBRj57fnwuc/G/3lwii2jtJrKs6N20fnKhCSk1JhVmjwVXw01BQUFB4fwDXezkU7h1/x+ZbqRVskXdQrGUtiI2gHi8X6013OgCU1R8zRbnEuFm6Jo0BKATDPQUYRoaHNfHcL+khlsLhZuUcNO1iEChgQJ6DhIvIpU1ZqOLFw5TtYBwK1hGZkops2FViiZ+9m07ZKfN9YMRGew1JSRMQ0fR1BOKNKricz0/WoBGKaVU4UYspezzhmD5aWVpStRwE1JKWR25NMJNhkjJ5Piceqw31VLKt6lFz1ByPTNuS5Eg6q8WcOTUNNcWILOUetziWJw/UsJN01AKVY1i4fkEwqZpKzJbpYxQyLLJAvEieNo18LXaFTjjVfG2ylNYYkzifdWH0XzwIKrajZj2g3uPqVRkSqZWoQme73PhEyI5UwuJx1Z2dBoGAoTKOfJ5q7nKJYRmkDCiIrVdzEUNN5EQ6SaBlaW6EwMvUttIEGzZCri5QmQpJV82nHM13DhL6TyFJgjH6ab1kw6/UrjNHRThpqCgoKAw56BERx512Fz8/8epIWYbmrBAyCu+hpu8T1HduYXR5XkHX7uv2wq3hf3tPCWWly+qdo10NQ0dH3nLNtQaLhcsEFtKWyjcxmqJ9zRSq8xHUg2USbiR0IGm43E1jKZDws0y5ZZSz/O5NNNSMalM444lkCpRmmdYI8sydWiaFircbG5fjQRAeJ4fLUBFFZ9LCTeSUioSeK1quDmeB9/38Zl/3YlKyYz6XCJWWcfxiKU0P+FGyT/L0NFbpgo3nnykYFMwT+ALkLzWtK6eTF3GYLseRyRkWUpNQ4fjejB0DeXQbjvTwrYlcZQSwi2+LjLyqNXfH9ZtRnbd39iKRxsbcV3xFbyx/Cyqk0fx4Z4f4uu1y3DUGYxVXxLlEpsjbH4mQhM8n1MRim3MNII5XEkJAonPiU93TSN705ClshP722qbzONkKtzy9UHcdy4tpVk13PKSjrL0Wv7zzvrWLmIlZvxlwzlXwy2DaO3qceZJ4caHJiiF21xBEW4KCgoKCnOObhMdnaCbNdwWilpM1/hFpAxMYbIQrsHZgDaXCrcFHppA58eK4UpX2752+7LEe+y+MjpWuMXbsoWYrIabaB+kteOajsfVuJmuM4WbLu2LD6BG1ExM/ZUG8dlhCgo3ZqGUWUp1Ld7e9WJSLSbtmMItDo2ggRHiQqsVieG6Psanm3jspZPc+/QcHRLekOf+YH2lhJuZULgRS2mKwo0jyNpSuMUEb6bCzfG4hWqRXA9d4+dawQwIN03XUC7mtJRGCjfSjpXcV0a+tFS4hftQlV0TFn7Y2I5dzgr8h6HvYDNO4Fesb2PCK+GHzusBXJFQKjmkFiBL0hWP7fngGBeRxJmuB32oSOoZUlCrcXDsZF+yILPeSrebpRWRr+EmWkHl/ZEhLUVSPEYWHNfDxHSTS3oWkaeGWyu0quE2H55Sal32/LiGW1Yi7UJE1nXvJmgCukiEdVXhRtN23aB2aqf/HyukQ42ogoKCgsKcgy50u1nfpB10p4YbU7h1o0ezR546SJduGsZ1O5bh9Vesmq9uLViYXf5H8lxaKiwb6i7hJoNUjSaZl1KbnaZx91VcYD6pKhVJA/YRI3co4TFVCwiDYoqlFIiLUAekXL5aVdFrITSB9UFW80oj9lBap42dW0RauB48Lz7/OKhBtJTKF3yMXHFcL6GKA3jyyXb9aOGYR+HGyDRKuBm6jt5qPoUbe8XXn8yvcOsjCjfacqKGm+ejYcepoJT4C2y68bZsvAxdi4IyGAm758g4/sc/PoXDp6aEniU9pYvCAJGRiZhQlhEKeWq4AbHCjeK4O4CD2z6IffZiTHol9Ol1vK35dcx87b+if+Ygty29RqmWUs/PJJpmGOHWwlJqknkNJFU5ttNCMSYQS2nqoYi0mWNLaVs13IRzy9u3z/7bC/i1P38Qx0amcx0nLaW0FRZCSilf15CEX5zDCrc5tZS6dH7NZQ03/rWylc4NFOGmoKCgoDDnoMqJs1Ukly7YO63hxtpYmJZS+TZ91QI++rbt2LJ6YH46tYBhtij8fT7jgjWDc34Mdl9RkqWVmifejt+WkUCxwi29zchSGl5fqnCLyDTTSJAyDIxUYHbCLCQIN50RbLGlFOBJLQZqZQxSSnlSkanjbNeLU1P1mOAXF0NppARNIRXrvrHjmITccyUppWmILKUhkcdqzPWU5CmlaQq3vF96iJv1VdNSSmUKN1bw30iogen2TJmma7GltB7Om4d2HscL+0fxuKAS9JN8G4b7ywB4y3QnllK2Ty2ljtx4z3r8yeTt+O2xd+P7te1woMM9/jKuOfR53Fl5BIwM5FWI8pRSz/d5okkk3Br5FG6i1VokI1zB4iuCHvfAiUn8wp/ch6/+aG/qdnMSmkBetyKhvAwFUt6uHQ+JthNnkhZ7hrQADvEzGZiSNUHUJSylc/8/GT+28ZcNCz00wfN9/NuD+7Hr4GjwmqvhNnd952q4JcjrubGUAt0l8xRivHr/81RQUFBQmDdQ1cjZioHnLaWdEWZsvwXCt7VUEikE6AnrS61aXD3LPZl//NKdF+MDr9+MbWvnnnDLW8NNuq+mcc8JRpYYEoJGvH/Z3GekgoyosCx5DTcgJtxa2UmB5PlECjdTULhJLaVxDTdXFgwRkWCx6sjQ434nQxNSCLfw2K7rJfZhZJNJyL12FG6ipZQlktKUUvFa0UcT+50Oo5ehFRWfa305a7g5rhctHoO6evy2dK4xslTXtaiG30yoLmOLanEhynpM22UBIqeJwm02NdzqEnUiEFvZHRj4Wu1K/KX5k7C23gIfwE2lXbipuAtAfI1YXcGgv6Kl1M9UUdXCe6PasoZbNuHmI59VFADOTDRgOx52HxlPbMe6NzehCbQ/LSyltPaVcI/l/R+Hza2s4IBMhVtGHytFM7qfk7X90s97riDWoouu4wIPHtp7ZAL/ct9e/OP3dwPgQwbmq4abeC91NzSBv/h2F9tWiKFquCkoKCgozDn0jMXyvPWBs5R2WMNNVn/oLIJTuJ3Ffix0/NFd18Nx/Uj582rCpZuG5+1YecixNGikVhkQq7mkKaUpNdxkllKGommk9oWpeEotVDxAUh2bXsNNZinlz4MtuCPSjpBgjNHRiRpLXGjZKQqLYkgcBrZKfh+2CA9+unAcWsOt/dAEZtOulCx86E0XwPMR2TKDc9aiMAv2GuCfXVkLfpEgojXcKOEgXlvb9aI5VLB0Xg0n2JeppbQipJRGNcnExXV06LghRriNTjbguB5MQ++shlt4XvWU4AaR/Jv0qyjd/GE8faqAHSN34x2Vx9HwTTSbW4LzM9PVob7nw8so+cBqIJZbWEpjIjnoGyMjSgUjIg5d14eZwmnLyCNZjczZWkrzhia0SgCl+zYE5Wk7NdyCn+nbu5z6ML0PInoqVjR/WhFs85FS6qYowxa6wo2FhrCf82Yp5RSUcxmawL9uKIXbnODV95+ngoKCgsJZwVuuW4uxqQZWDJ8dlRGncOvUUrrQQhNy1HBTCBL6LPUfz5yD3VdZ9s80MGJJQ8BlMNWVrC6cONXZR4xwkyVMFjIVbiGpkEPhlqzhlkwpBWLVFIVIKooqPkZ4ua7HEVPs89wKN0a4uR4aTX4bQyAnHdePiLs8lmuRcKOW0VsuXSndxzJjwo2dPiVNsxb84ncjVOFGFSZiE47jC5bS+DNaSy/4nNkttYiUZ1ZkL0WxFbfF980yddiOhzMTdSwZrMyuhluKpVRU1rDx29d3FdxjL+HiwiH8eM+DOLNrBCuNzbigMA53bBOMgRWJL2Zcz4emzd5SmlS4BT8p4Wa7HoqQ32MygktGKEe1v7oSmpClcIt/f/nQGB598QTuvHVjND94wq0zhVtsq0wnOfwshVsW4Va2Itu35wW2YfZMSRBwuXo7O6T1daETbqw+H7vnspRn3QSt4SYSz3MVmtDtthViqH8/FRQUFBTmBe++ZeNZPX53QxMWBrmVRUIoKMw3aFooA62b1lO2MFWzM/fVdQ0uKZouU7iJ968mHLcus5Sa8pRSgNRwy6NwS0spFUITihKFmy4o3JrCOUY2T8eHYbDjadH5JVJKU9QIrH5cUMONH4tY4Ra0adOU0hzPRdZXpiLMFbRAtmlX4SY+a3vK8TUa7I3VbrJACTZeBVNQuOn8dYhquJGUUhZYwAgBMZHQl9AUmqZhuL+EYyMzOD0eEG5yS2n2mDGSJS0pld0bpqFzSaQ+gL+augW3ll7A7eVnMDS+C/+hP7CXznzpR9DK/Xh7s4ibejX8qL4Vz9hr4fliYAF/rLyhCWmW0qJlRCR6FkEhVbhJtu9qDbeE8kv+2e//3ZPh58BPvvGC8PN4v4SltE2FW1ZwQFYNt6zj9JQtjE42AAD/9sB+vHJ4DP/5g1di8UBZonDL1d1ZIY1YW+iEG7tGEeFGBmsuLaWOpIZbIfzioquhCZ4i3OYDinBTUFBQUHhVgK/h1pmldMuqfjz18imsX97brW7NCrpgk1KYH2ja/CxSzjX0VQL1UW85rvdEiZW+aiGdcCN21FaEW6vQBJlFKyulNLKUdlTDjSfamNJNVsNNVFbZoRUtDpvQwv570LVYdcXOPWkpTSHcCrSGm6BwE4ItHIfUcMujcAv3Z6olMRRBBp5wC37yhFuWwi3eLiBNdfzJL90IV7CIi4tQaim1pJZSicKNpJQ2bDdI8BQUW3Gnw/MR+ruIEG5ASiJvS4Vb8DNV4eay2nQaHDdeNPs+4EHHPfULsc9ZgrsG7oXl1XEcw1imjcKvjWMYwLAFbLZO4InGOjzr3oq61keOzauh2L1RzUu4sZTSqI86zFD1l0m4ST6SEm7h2PjorNh/Vg23VpbSFw6MxttShVuz0xpuoaU0q7Zdh6EJPWUrutee2TMCx/Ww79hEQLgJZPH8WErl1z5L3dcJTpyZwcGTU7jygsVdUf1HhBsjR+ctNCFJ7JWKJppOs6ukmHgGKjRhbqAINwUFBQWFVwU4hVuHltLXXL4KN12yIpeqYz6gFG5nB7QmlUKMWy5dgb5KAZdsWhS9R+do0TJQLhqReoiCqbgMQwMcouLRYzKEIZVwy7gvC1ZGDbd6/hpuogqMtclUZXFoQusabizd0BAUbo7rRc8oXY/JITGltFVoguP6CTKAjadFjsUWjmaOLyLYNoycyEe4Ja3vnKU0Y1+6HRtjRuxSiItQ1/Wj8S2YhhDcoAlEXpxSSkm8etOJFVspoQki47aYJZWOB8mTnYUmhJbSFgq34IsjNyL/afjEPmcJ7ln983jomQPoX7Icv/GBHfDGjuPr9zwH98QreF1pJ64o7sel9b/BMX05NGsrXrRXhseP/56w0IRKsUVoAgkDAeLxMsNEXNvJJihk5JlMQeRnEFB5kEVgpVlKGc6QMAxKFIl/C/J2KwpNSLmPPZ+nxpKW0vS2e8oWNMQEfrB9TMxSzHcNN+79LpNWf/Wtl/DyoTH8xoeuxPrlfa13aAE2B207SNn1OcJtfkIT2G+lgoGJ6e4q65TCbX6wMFYMCgoKCgoKmNtABZ1TuHV+nIVCtgGqhtvZwkKaAwsJpYKJ6y5chkpJrnArmHrqwl2s7cXIEpnCTRNYDsYTZSm0LDOjhluo4innCNUQ2zBTUkqLKQo3WsctUvFpScKNLYR0Qg4larg58sUqI40cz0ssoFh/2VjZbqw8YomjWRCfne0kmwJ8eA1DVoF6jeyQpUAUx8Z2Pc6KpZM5I1p7aWiCZerROc00nHRLaaRw408oSioNFW6yU2upcAtrbqWFJrDadOxaRpZS4VhTXhGjXk9gqS1UYCzZgGPljfh67XL80cSbsdteCgMeVnlH8HO938ebSs8A8DlyJG9oApvDYs07k4xnVyylGTXY8oDukrBoUpKjBQFIycNEImuXQhOSFlLh8xaWUpE/Z+OVTDvN09vZIY0c7XZq/cR0EwAwOSNXUrcLdt/7CJOlqaV0nmq4MbC/T90NTRAJN/VF4lxA/ceooKCgoLBg0KnyLA+6RbgtJOhK4XZWkMd6pxCA3neWpXO1oLj0RGYpJVZHgBBuGaSNlkPhZpk6dE2kRwIwUiGPpTQRmhCuapmyiREustAE1rsodTRSKomW0tjKyCncnE4spVkppcGxInIkF3nGn38uhVuLLway1tx0uLOuT0L958Rko2XxCjdd16J+aFp83uy6VMI6bvWGmxGaIPeUDg+ECrexdEtp69CEgEBke4pDRmu4Bdszwk2uVrEI+cvO+7C7CJ+evA3/z/xxPGtcBAC4vfIMXlvaCbc+Fah5fD+/pdRgNdx4C55l5CTcZKEJGSmlafu0QpalNK2Gm+xvKz0X8bzy9CsgVVk/UhRuCUKQ3y7TUlqxEvdamsJtPjBfNdxENV+32gOC+ciFJsyhyl02Luz5193QBP61+DdGoTtQllIFBQUFhQWDuSTCuhGasNDACAQfqobbfMKcQ2L4fAO91yxD5xbulmUkggNE9Zc8pTSthpv8uhRCso0dR1zM1NoKTZAr3K7ZvhRLBstYs7QnOKbUUhqfiw3ADhdOjEw0zZiYcAnhFiWDComjaQRGsRBbSuvC4owRIxYj9xxiKc1DuAmymTyEm8FZSmVb5KvhVspQIDacNkITiMrQ0OMwDXaoUtHExIyNWg5LqXg6/WGK6uRMoLQRSRIgGIOsOpCe70d2Ul3T0FOxIuUOICHcPDnhxshWntjmeoIz6Mc95i3YM1nEOyuP447Kk7D//km4g6uAK+4M29RappQyUpUpc5j6kllKgVaW0uR7su29DMIsD7IspWnqt6HeEkZCO+l03Ua1ZHFkoEgM5qktR+/dvGSUOJWylKE9JSvxP4GbQszOi6U05dpn1a/rBFEQRbcINyeDcJtLhZvkuRERbnNoKV3oIRbnKtRXtAoKCgoKCwadhhnkAReacB5ZAtmCVPFt84dWi0+FGJyl1DI4UqtIiACxtpdIxGWpOdljwzLkCigaYCAj22cVmkBqzG1c2R/VA5ORd6zfUQiCaCnVY9UZWwQHKaXBfuJCPpVwC8/X9Xw0xRpugsKNs5TmIJLF8ctSFUb7SFJKKfKmlBYzFW5J9R97r2CJNdyoclKLCEF2bsy6VeMspWLhq7AtoR+Wyau5ZEobTQhtEOH7fpS0Wy4aibmUVLiB+8kQKdwk9xkDC0m4t74N36vtgOuH1tDRw/C+9yf4+d7vYYk51ZJYZfeBmFJqGhoX0JF6zpJxygpNAOZa4Ra/T++Lk6O1RN9EYjBPDgBvSZWfh0iEifd/FjnSW7ESz0lGeon3G2vm3qeOYOe+M1nd7hhpJGRa/bpOwcayk0ANGeh9bzseNy8SzwQBvu/jaw/swxO7TrZ9XKnCLXwOdDU0QZxTXaypx6zxCkrhpqCgoKCwgKAUbu2DpTqqGm7zh5992w787688i3fctP5sd2XBg1O4mTpH0FAijG3GyI9shRt/DDGlVAR9nwtf0DR4vh+FJuRTuPHHSLPBX7h+EW68eDkmp5t4Zs9I2O9sFZ9U4UbUWCJkljvT0GL1muvBFdZmpuRYs7GU5rFXc5ZSyedZi2NKTLVlKXV9voabcN1jkjMeX1YvrhxaSmsSS+n4VANff/AAjpyeDk9IbrFlx5bWcNM06RckTPXmeXFgQqlgJgh+WyBI0xVu7PzpfZa0GXp6oGL7t9oV+E7tYvzhz14J6+W70Xz+e9hqHcPHzW+g+YwBrdQDa+M1cA49B2fvo/BGj0DrGQbg47IxHY9rm+G6DtdHaxY13FzPh+f7XJ9nq3DjSLWslNKUWnGnxmpYv7yPI8lsQV2ZS+FGWLn0BM9swq1lDbdUS2mSaDw9VsPffGcXBnuL+KO7bmjZ/3YxX5ZSNpbdIvIoSdx03LYspS8cGMVXf7QPAPD/Pvna1sdyveALFk2TEl/s+dfV0AThMN26Hrbj4Tf+8hEsGSzjE++9tCttnstQhJuCgoKCwoLBXNZw4xRu5xHhphRu849VS3rwBz9//dnuxjkBMTTB5Ai3JBEWk1GxpY6+D/D3skZepxX9T1O4GYYGz/ExXc+vcEvUcEt5ZlVKJj7y5m2458nDEeEWk4rBeUcppSzIgLRlE4VfmhpKpowxDD1OjHT9xAKKfWYR1dGsLKVzrXCjllJJEAXD+uV92H1kPHrtuB6adkzEUnJC17VILRek14ahCRoj3EKFG7WUhgv4h3aewPefPByfj9APi4RRAPIFbGApZcUAYhi6HgRm+D5qTZaca0Q15RgihVt4LEagiOPYkCjcRBG55/mcIqsJC16hB6Vr34fDA1egcc9nsMYcQfPRfwrafOALgEvCHEaPAgBWA/j1gedhveKhZl+GZu/bo2PTeoFpSCOPHMfj7t80IiwPfJ+/H/zwuFHgA1XPpRyHKdxsicKNffmVi3AjpEmaqigr1EH2mqKnnKzh5nryeeL7scq3lhLUMVukJrF2mXCzQytz14gjsYYbGbxWltKR8Xrm5xRTNRv/6bMPY/u6QfzcHRdK+x+FJnS1hpuomuwOmXd6vIaTYzWcmcw/Buczzh9PjYKCgoLCOY+5TSklxzmPLKWROkMxbgoLEKLCjYYmFK2k8iYtUCAtkZeSCWnkTzFF4cbaZgunXAo3gWArSsIRKEwJ2ZRmm6XbxnbT9FRL1m8umIKrmdU6NMF2vWjxn+cLj4SlNEeyKR+akPw8a2nMhyakX5+fu2MHXn/FKrzmspUAWA232FJKx0jTNCwdLOPdt2zAT7xhS2KOlThLqRe1ByTTUMXzYXOQLfxlhEKpYEjHwSCpo3WSnLtmWS+3XUS46fH2gETh1ky3lBpk36R1Mfg5aQzg0xO34THjCpgbr4HWuzgg26wSCpe8GeU3fRzFm34KxZs/jInSChQ0Fxp8OPufhD5+DABQLVncfExDGvGSCCTgFGrtkQMyHoxLJuXqu8XbcITbWGgppbW9BIVoHhKJ1i5LJdxE62cb9baqZSsRLpM2T3ySTJtFis4GaWPSTYWb7/sRsZd1DXzfx5Mvn4pVqhngQhPc9mq4taNEe27PCKZqNh598SQ835+3Gm4JS2mXrgdT6NLyCK9mKIWbgoKCgsKCwXzVcDPnkNibb0Q1rs6fU1I4j6BzhJuBasmKXssIN9FuGSvfKGkQt18tx+1ZKeSXJVHS0WMxdFLDbfPqgcztTYMnegBimw0tf0xZlaZwS7WUEmthMyR4DFozy/Ui0kXsDyMXJ2fsyN6WT60mEG4pdfP4fZJptBRZCzI63lk13Ib6SvjAG7bg+08E6jPH8SImr2DqnO1PDxVmb7luHQDg+OgMdyy5pZRXuqWBWnWpoorq2bauHYxUjxRsHnheHJpQKhq485aNuO2qNfjzf3kOrxwej6+7yQieYP80hRunJI3mmg7Xc+F56SqXmbqDJiw83XMTXvu6S+G7NtzDO6Ev2QC93Mft8/SZVXj4gafwk0tfwPL6XiwdfRLANlSKZk5Lqfx9sU5WGhGWB7LtXc8He2ykKtxIv0cnGyEhkiReTENDw85HuNE2nVRLqUg28p9n3Temoacq3BJ5uz4467Tvd79ERbqltJv2SD+6x7Lmxj/ftxffeOgA1i7txW99+KrMNimx6jge125aSnT0eRvEGP0iamyykWkp7arCTSRxu0S4shqUQDCn0v42v1pw/nzFr6CgoKBwzkPVcGsfsaX0/DknhfMHoqWU1qPiariF/5GmppRS4oq030sIt7Si/7SGVaQIRZI8y6NwEwmjzav6M7fnFW58H5IJrXpC+WRkWUolyjRT1yNy0vH8hCKLkV8rF1cBAIdPTc1S4ZajhluLlNK8oQl5CNE4tMDnU0rJrNGEc4gspRHhFsyDOg1NcFhtKL6z4nOXkpYOUcTQvS7esEhay47NA9+PF6ylgglN09BfLSTuDXYsRg6JxBlT+NHFLusuGyfP95NKqvA1sxkyMkAzLJhrL02QbQBgmhaOuEN4uXwpAGD11PMw4KJSMjk1ZRpSFW4ZCaDt2hFlVk9O4UauUpp11XW9hD3SESy++VJKcyjcWlhIWxGO4veXrN+yGm5ZYRLdQCrh1kVFHUvGzTrenqPj+MZDBwAAB05MtmyTztmmaCl1svveipCjoPPh+JmZKFGWIgpN6KrCjX/dbYUbEKt9X81QCjcFBQUFhQWDubWU0tpN58/3TcpSqrCQQe+7gmAppcqb2OrGpx2Ktd3otgDQU6EKtxRLaYp1Vbxn8hA6FJtW9rese2ZK1F2ilZUjzAydU0bompZqKWULumDMggWOacaWUldqKQ0+W72kBwBw+OQUlgxVALRfjy04Xh6SrlUNt9kr3KL+MPWg60ELT11MKRUJzAvXD2HNkh5ctXUpAFLDrZGs4dZK4UbnoFjziWGoryQdB2opZdetSO6RBBktWBgTCrdmTDgy6IKa0vP9REIoe83CRCpElZoGNs8PGmuhVQZQmhnDW8pPoVK6MJ6PLWx+MiQspbMghmQEHW3D436X7+d5foJAYH2MCNBcKaVdCE0QPr962xL4fjCfAXkiLYCEh9vzecWd68aqv25hPiylVCmYdryHnj8e/d5Tbj2v6bPYdnhLaTcVblS1dvzMzJyFJjiuhz/8h6ewfnkf3ve6zS3nVKcQFW6vdpw/Kw4FBQUFhXMehYyi2LMF/dczbQF7LoItoBTfprAQkVXDjUtPlNRqo/unpZT2cAo3+b+1BQlpoWm8DVsDT8zlwYUbhlpuI1N3JZJOyWvxHPKEJvCEHbWU+gn7kRkea8VwFZoGTMzYGJ2oh+20lzgKdGZDFZElCKKkQVZoAkN07o4XKUEsU+fGUHz8rxiu4rc/cjWuuGAxAKAcLmxrzWRKaavFo6HHWjrb9RML2OWLKtI+AKQmm+dHqat0ThpRfThG8GTXcGPvFyQ13Ng4+ZIi/4wEYTWuFvUV0084RBwWARSvez8A4HXlF7D0zJPRPZelZkpThYmkxmwUbjJyh1O4pVlKKcnn+4k5YAuhI3lqVtGxSKub1qqGmzhmBcvAz7/jQtx0yQoASWI5spSKh/PBKarSLK6zQVZKabdqfHFBFCnHo19A5LGz8mm0Hjd2rVJK6eetzrHhCISbtIbb7EMTjp6exiuHx/HAc0GNRXEO0WtvOx7+5xefxjce2t/2cWj4RjdTVc9VKMJNQUFBQWHB4EO3b8VATwE/eduWrrdN/604nyylUcFvqUlJQeHsQqzhRtUynMIt/CnemzIiji4ke8qtFW6WJDRB13iFW6lo5laJbl0zgL6KhddevqrltrKETpGAoucj2mJ1PV3hFlnZKGGntwpNCD4rWgaWDgbkz8hEA0BO8ixhKc1PgqUhW+EW/17KYfml9cJY3baCySvcWl1nucItIAZEckRsStO0mHyy3Wj/a7YvhWlo+Njbd6T2gRGvPlG4FSTqTFHh5vvBPmnDaEpSSmNLqZyo830fuw+PAQiUnK1gkXG3Nl6D+7wrAACLd30FK52DANKTKoF0VRglt8RznI3CjY0lp3Dzk7+LdkvPSxJu0X0oWHyzwCvcclpKWxS4F+9NcYrFSkiJpZQSgHNAkGRdqzzjlQecTTdNNcgRaO1dp0DhlgzLSAMlmlqdY5PU2jxxpiZPKS3GoQmdkpTsSwj2M8tSeujkFJ7fdwb3PHmk7ePUyPkohZuylCooKCgoLCCsHK7ij+66YU7skfQfnvOJcNOJYkdBYaGB3msFS0dVklKqacn0RHH/tECVPIQbJS2oBZsSXWwxkwefeO+lAFoTSQBPYrHDJVR8gqWUQka4aVqwUJJaUk0tImKatpsgiOg4rlrSg+NnZsixc9hDRUtpjn1ahdRkLR3pNcqjQKTqvsjqZ/EF5NMUgwxsvjRtlyM9HNdPqH80yRcdpqGj6XhokAX3B16/GR++fWvUtqwL7Dp7frwg5hVuWtQvgJ/vvp++qOeUpILCzfMkNdw8HyPjdYxNNWHoGtYtT9ZsS5xzpHALGvtO4xJU9DO4srgPrxn9J6zpXYrFr/wQM6d7oVeHoA+vgbXpOkx7hSiIQAZaJ0vcJK/C7fDJKfRWrGieaVowlp7jCwq3+PexyQb+7rsv46ZLlnNtua6fIFqieWbGCsVWoPMojZBoVcNN5JSShJtc4ZYYR58nWlollfq+j28+fACrl/Ti4o2LMreN+5repuv66LTKx56j46g1HFy4flEuSym9dnkCIuj2QUpp/FnLlFKX70/WOdJnxfEz01gvuedoSrPteB05Quzw2WGHpF3WHGPn14lCrU4VbopwU4SbgoKCgsLCwlzVIqP/SORZJJ4rUKEJCgsZvMKND01gi2zO7icq3BhBkEfhlrKiKUqsqwHJF29DFzOtkIdoY+DCHiTnAgi2W5Fw05IppUXLQL3pJoIlgrZjhdt03YEIj9BbqxdX8fhL7Jw0LA1ruWVBJKvyhSZkb5Ol/mg7NIGo+1hoQFFQuLUKw44Ugl4yjTJBRkgeu5apAw3e+mXoOrdAblnDrZlMGGXXmfWAWmy9DIWbzFLKhSZIlFSvHB4HAKxd1puT6IzH3fd9zNRd/IN/PS7fNAj90JPYZJ0ApgF3Oqw2uAtoPP4veNC/DF85vhYO5MfgSIsWCi8ZxqYa+K2/ehSrl/Tgl959MYAwiITZXDmLarzfU6+cBgDUmvw95Pp+QgFmJxRuLbuVq8B/q/pa4ufJZyffnpumcAM/B1pZSo+cnsZXfrgXSwbKuHjjdZnb5mmzHaXiNx8+AAB409Vr8P+++SIeDGuy/dFdN+SylIq25iClNoNwozXcbJcPTWhD4eZ6PrIqxtFnxenxOlYsqia2oTUsmx0SbjRwwXGTNSZdNzkvOyHcqMJNWUoV4aagoKCg8CoB/f8rTS1zLsJQNdwUFjAMMjEtkycd2D/idKGYULgZSUspV8MtR2gCfT+yYAthBO0o3NoBJdDY4dJss0DSbmroWuLeZoQbW8RSQss0tOj5Vg8XPbqmRQsrautbFQYnAMCPv2ELBnpa1+oS+5eHcJtVDTcyNnkIt1hplV7DrdWXE0zF57o84Wa7XoJskbXExqTRpIRbtt2PbuN7fkwWStSZDHQB7mXUwrIIacf+9FGFm7if6/l45UhAuOWxkwLEUup4qDcDYsKDgdLr78I3v/sITu56DhdtWYGrNg/AmzwFZ98T8EaP4Hrcj0sGHsURdwhfn7kMB9zFCCjFmMCj50iRR0k2NtWA7wOnx+pcEAt7LqWllDLMCKR1YCkVCasAdExbgbOUphA3ydCE7M9N4f+aRGhCSg033xcVd9n9Z2NSbyYJ/TRkKtxyEm4zdQdfvncPgCCd+kESgDA500ytwUeRqL/neJlfCDgJhVt+S6qocMsCtf77PnCMKI8ZLEOHoWtwvbA2Z47Qh0SfyPMrsKYGv7N2Xc/DxHQTtaYT2XI7Urip0AQOinBTUFBQUHhVYOlgGdWSiXLRPL9CEwiBoKCw0EDvtYJQ72vjyn587/HDfIJwmqVUohQDgN5yIfrdTLWUJmu4URsrAFRzJDF2AlkNN10MTaCkZB6FW8EApmOVDKdwM/SEYqNYMKIi1nQxvX3dEHasH8KG5X24OSy03vJ8Oqjh1tLCn6lwi3/PRbjRGm5h8EChTUspUyC6Hr/AdhwvqdRJU7gBqJNFtPgdj6wPFrHDximllHDjGymKCreU86H3HbPA0sCFBAHjAbtDhdvmVfkINzbututFhIyhayiYOurFxXikuRlDPWtw/QWbgj5d/g44rzyA4z/4Rwzo09iiH8fP9t6D3c5SbDaP42u1K/B0cy0cO164d6JwY4qdphPbgzmFW0pKKYNYA9H1kpZSBqoabAWO4OqwhpuYLptQuAmv43OdXQ03psZqRczJj93eZxQTM83o96d3n+Y+s12PO620gI5E/b0WZBAdCzF1uJUlNY/ijoGFpDCcCetqUhi6hoKlo9ZwO1aNNUk4Q9OOn2+mqcNtBjUn//vfP4lTY3V8+PatAIJ553peW19U1xukhptSuCnCTUFBQUHh1QHT0PE/f+HGlnaicw00dVFBYaFBTCkFgD/7xM2wigUcODIGgCcj0haNBqdQij/PYynlarhFpJfGkTmVHAX5O4E8pVSu4gt+b51SOthTxMnRWrT44xVueqKNoqWjFq7f6MKvaBn41bAeXV6Ifc9Vw62lpTT9M66GWw7bL1VaNVNDE7Lb4BVuvAVLXMin1XADeIWbrA6fCBYKUW+6URF1LjRBYi1m8Lx0ooeqEJkqjgVDeJ6c2BmbCibMshw2YyAmux3Xw0xI7lZLQRAJm9907DRdh7nlRvzevzawTDuD91QfwRpzBJcWgoCF91cfwvurD6Hx6PfgrfiP0HsXJ2qWceTH4efhOw2Yay6DRh4ocbpsTJRREjstpZRBTIR03aSlNBqDNkITOOteCjkkkjStXreaY3FoAv++76MtSylTjrZjBc0k3HIqoCamY8LthQOj3GfiNUk7nkgStiINxdAE2TVIewZSsrbVUFEiTDwug65rKJgGag2Xs4a2gyZHILrRXLAMHQ0EhNvIeB2O6+HMZJ1s68Eo5P/nmUspbYOYPV+hCDcFBQUFhVcN8tifzjXIUhwVFBYKqCWQkSG9lQIGB6s4cjxQ0fAKN7n6K61we1pogmlo0WKqIEkp1QRLaaU0N/8Sc6EJSKr1aJ+C7ZMKP/HeHuzjrZ8mR9hpiRpxlJiZrb1HC8kKtvDsjqU0fUFG1UR5FG5RsIAT11ujoQmislHahs5quHmCpTSZUClrKrKUUoWbsKGsBxEJ5vuYClViRVrDTVQu5qzhRq/R9Rcuw+RME5dvWYzHd50KlXGMuA3umciyhnxBFUA8z23Hw0zdDs4nVI2aEsINCMiOpqfjIIbxV1O34Jd6vw0HBp5trsHNpRdhaR6KtdOofet/onTbL8I9cQivKe3EcXcAfdoMqvsnMGEux8zRA2g8/U0AgNa/DKVr3wtz7WXBMcn1iyzW5J6iRJOMKBMVbp6fnAMM7DxF5ZkMeSylrRRt4ufifS/OudhSGiv93NBSTMcpjQBkYORQO8+SblhKKeFGyWwgeE7Q+zrteO0q3ChZFKSU8u1mWVI5wq2VpVQ4HxkMPU5AFongvLCJkq5JFHusXdeNLdMNmycbSwXkBq19qGq4KcJNQUFBQUHhnIZSuCksZFBFlKw+GcATIGn1zbasHsAvvOsiLB0s475njkWfczXcyMKnXDQxORMs/GUppbrGq5Mq82Ip5fsg9kncnu0jLpzFWmti6IK4AKSkSavFdB5whFuOAAmxtpSIzBpu5PdCDnKP9adOFrAFU4/UjHms9yZRydG+OY4kNCGjD2zBrWtaguSTkX5lQiiOhwozagc1hH24Gm5+eg03Om4DPUW897WbMUnseexaGoYOx3XhenH9u7yF2ePQBD+ylLJEYkaiu4JyihISZ7we/O74O+FCB6Dhm7VL0a/P4JNL7kFh7BhmvvSfAADvoIK7l4HTL5PXVgn++HHUvvO/oA+vhbn2chj6Giw3RtGn1aAfcHGhdRSn9FVw9TJ37oB8HtabbVhKmTIyF+FGCK4OLaXi52mBM9ExBYWbHhFuYkppK0tprHBrlfLJ0A1LKZ2zDBoCJ6nteNz5uin3QtuEm1DzTBzzrP3p/Bbnvog8ijVd06JneecKNz7MICLciBWfvUdJvXZJM85Sqmq4KcJNQUFBQUHhXEak2JFqJhQUzi449ZpAzvRVC9DCn/E2IhkV73P5lsUAgOlQQQPwZBKt4VYw9UixU+BSSoNtAoVbfJy5spRSxZpPlCUUdIyoGokRNXT7aslMqI7ouBopNdwYurH4MQwNCAUMaXXzKFrZTrMUbiuGq7jl0hUY6CnmWtjL+hNYSpPkbhrYeIuL2iCltLXCzRRCE2R8Y1poQrFgoNF0o4RZeu3Ee4PWJvT9dOJSVmePkjOMhDV1DQ3waht6jCxYJKyC9Z3dU5SMo0jYNUlSqQMDI14vXtr8YVw2+QO4B5+BX+zBc5ODWGJMYMyrYOWKJVjab6I5PQVzy40w11+J5tNfR/PZb8M7fQDN0wewAsAnWRm654GP9gIN38LLWIcXi0PwnEuiY8rmYdJSmk66mlENt6yRituJzrVLoQni/Ei3lAY/I5WfL6bxZp+AmL6Zx1beDcJtfDpJuK1cXMXhU9OB5ZHcaOk13JIKtSyIllKxq1ljRe+jVgq3PIo1vRsKN0og2m40F0xJu5QwbPfvRk2FJnBQhJuCgoKCgsI5DF0p3BQWMDgySSDchvpK+LX3X4bB3lix1arwNwBM1+zEe4CQRmrosEwDjuvwtjwSMsKHJszNv8SUDIuURKJt1kj2D4iJGjoGfdVCYkz40ARNUsMtJjK6YasP+h8sxvIo3MT+MCwdquDEmRlctW1p6r6apuFDb9qau2+ius80NK5eX54anoxAEAuZSwk3yRcdCYWbZA7LiD9N01AKCTcGqk4T5w2rTcdqcKUq3CSkGacGYoXTperAvAq3WBXIarhVWijcRPWYDJPmECpv+hX4jWmM1Xx87jOPRp/93LYLcclNGzE6Oh3V8Cpe/R5YF70R7sFn4Ox/EvUju1Bvupj0SugZWoTa6CksMSZxEV7BRVVg5lkX/uq7oJEkX4qGMAc8vzs13GhQQhrhJFpIxe3E6y0qINNSStle/BxoTQAyUFLGdX3kmSJZddry1nBjimWGasnEQE8xItx80o/8ltL0a+UL1zpIKRVSTjP6Tud3K1KRPStKBSP1vghCE4KT7NSmaTsCgRi+ZM88Ot8bs1C41Rqd73s+QhFuCgoKCgoK5zCiIvCKcVNYgCgWDLzm8pVwXZ8j1hi2rR3kXouLRlnCJVPQiKDkj2XoKJhBWIAlreHG3zNzZSml6g+26MoizGR9pdv3VwuS4AI+NCGhcLMM/PRbtuE7jx7C+163udNTadnfNIgWWIZf/+AV2HdsAtvXDs26T1F/BMKNqbu0Np6TacSJLQlNkPZBULjJ5rBUaacBpYKJccRKnmJGaIJl6tA1DW5oJ2XdpZZfQG7FlY0Dmzes4Lll6rlrgzKFjOv5ESHO7ikjReEm1keTgREkWrEKr17nPhPJDwa93Af9gptgXXATnn3hBP7P13YCAN535Sb84z2v4MrBMWzUj+Aa7ylUjj6O5jPfQvHSN0uVaQmFWw5Laa4abjkSLKPnRUgGtiLgkpZSeXuRwi38PJFS2opwI313PA9FtGbcskjITlJKAWDJYCW618Q+p4cm5LeUuh6f/OvIFG4ZZFI7NdwYud9TtlIJN02L7+U89470OCmpq+KXBACv0MsiFkWIX0y0s+/5CkW4KSgoKCgonMNQCjeFhY6fvO2C3NtmBQowUEsphckp3DQMD5QwMd3Eov5Sor1ESulcKdyIKokturLOsUpCIBgpwhFuPcUEWULbM42AhGG1jQCgVDRww0XLccNFy2d1LrLj5VG4XbRhCG++di3WLO3h3q+WLFy4flFX+sRgmoLt0mQWYoQ/81tKRTiu3zLBEUiGJsjILdkhdGiJYAhaQ00sis8IMdfzOYWbSLjJirrLlH5MiVhjCaltqCHpPGDECFONsn6LJEieQvF04S6SNnmIGqrcCs5LwxF9JU4aq3F4ysKPVR9B8/F/hrnuUilRxt6hSsLU0AQztmi2gpNDURanEGtoOn6yhpuocEvUfxQVbsFxKDEbtMOPZd7QhDzbRtt1OTQBAJYOlqN9bYcPTUirmcZIX3Y9s8gg8bo0HTd3DTfP8xPW2yywMa2WLZweryc+N/RAkR1ZtztWuMXXrul40TMjsqoKn8f75T+eSBgqSylw/sW1KSgoKCgovIpAUxcVFM515LGUptWv0Um9M8vQ8Yvvvhi/9eGrMNxfjrahQQ00QXWuLKUUkaVUuFcpkbJ0INlXStj0VQqp4RPsd03jbaUrhqtd6L38eHkUbpqm4c5bN+LqDOtot2DoOvflA7NTxgq3HG2kkIiy0ARpDTdBLZJX4aZpfHACkK1wK4QKNyAgXzzJdpapp9pX0/pdD+sv5Q1MoPsCwPhUQIywGm5sPMWFt6jSkV0aO4Nw23NkAl/63suZBenp9WLKPZZS+kBjC2YWbQU8B/V7/g8uM3fDgPzZwqy1rpvDUpqDX+BCE1JIK9Hq2yo0IS1wRmzPE2q4iSmleUMT8mwbHTuDmGul/mKYCC2l7DyXDJa52oGUFEprk82VUiGYm1kKNZFksh0vEcaQRtjJ0m2zwMhnmrpNwa7V7EMTaAiEGyn22BxrdsFSyu6zTvY9X6EINwUFBQUFhXMYKqVU4XxCor6ZhKz4mbduR7lo4CNv3pb4jKncDENHX6WANUt7uc91QrzQI82Vwo3CzaFwWzIYxzAyUoSOQX9PtqWUtU1tpWuW8GMwW9Br1I2acN0GHY9CZCkNXuexSKYr3LzMBTqDaCnVpIRbcr+ghhs/Dy0reW3j4xiRUs3z5aEcaSo12TiwOcMSBtsj3OL2WHF7dk+xzxIKN4GUkPXJceJ9RBLl3qeO4AvfehHffvggAODYyDS++qO9UUqqeExGJBoRMa/h5OZ3AmYB3ukD+EDlfvx0z73QkbzGjLj1kU52WO3UcKOhCSEJdPT0NP7twf2oNx3O5mkRuy5FIjRBGD9xjsWW0uB1TLi1V8ONqqScnGRZFqmWt4YbU7hdu2MpTEPHjvVDnOKLtpOmKLPD+cSUpFnnKgtYEFWQac8DWbptFticSvvih/3dYvdkvSkvq9AKNiHUbKJwE78kAIBmszuEm1K4KUupgoKCgoLCOQ1dooJRUDhX0UqlAQAXrBnEpz9+s3TOW4aOBlwuHVTWvq5p3GKxUpybGm4UbEEokoo84VZOvE/Ps79aSKgqTNIeOz+6WFy9hLdyzhaihXWhwTT0aIHIFuRsDHMlnaack+16CUuprD3RUipVuEn0XJoW2H8ZqIINSCojLapw8/wEkUL7IkK0HQNJhVuxDTJV07QoFXgiItzCGm4sNEFUuAmkRDCW6Za9NM7i2T0jeOPVa/D1Bw/goZ3HMdRXws2XrEgcsx6lxmrRGDWLg6jc8euwX3kQ08/cjR2FI/hk/9dw0u3DjF/EffWtOOwu4ojLtPpZ7YQmuBKF29ce2IdHXzyJ4b4SHnvpJJ7efZprl5I9tGYfg/isFOdYIqU0nDu+0J9WKaWUcMxLlonKMO6zHKSd7XgRkfPe127Gh960Faah47EXTwII5olNzl9G8AUkJlO4McIt/djiczZ4zd8TafuLKuwswtHzY/tpK4VbtRxQNzMpdUxbgVO42V7UL5lVtVOFW8JS6uQjZc9nKMJNQUFBQUHhHMZgWJC8v6dwlnuioDB7JAIFUgiSNILZIgq3rPY1jf8mnhIdcwW2uMkKTVg8ENebY4sqMaV0bKrB708IMDYulKjoq3b32cCloi5AhZtlaKiFvzNFSKRwy2UpTa/hJlrjZFuKaZ+yuSqbvrqgcBMVZuKcpnZRz49ruOmcwi19XrP6b1G/w/1YwmCh0N49YZk6HNeNargxSylTuIlqqKTCDRAdnZT0SAsjODMR1LyaCWs70vuanh87L12Preeu58NYtAb60Gr86QNNfKTnXiw1JrDUmAAAXFbYjwcbW9BnathbrOJlezka9ippP9i9kMci6QhqLN/3ozCYmYYTkW1APH60WRmpl/yygv88UrhFn8eWUtrnVnUKqe0wdw23jO3yqOQmwzll6BoqJTO6p0xCFNEvHmQknufHIQjlcG5mKtwkllJxjNMspSLplDUnKDmXRrix41ZDEjstqbsVqDrRllhKKTjCrQ2VmrKUJqEINwUFBQUFhXMYb79hPS7csAhbVvef7a4oKMwaYmH4vCmJDMzWlVbMnyrcpoktZz4UokzlwYgIsU9AnKoJxItBunDurxaixadsf3G80hZwswFTLJmGtiCVtZQEjEMTwuueYz7pmhYlQ1LYjpdcyEuay6Vwk1pKwYUmFC1+Dovt0BRRz/OjxTM3n6x0QlRUlBmzULgBbNHuRgtsRmKnKtxEwk0yKFmhCQxnJgMCmql3OLsm+b3W5Gu4AUT1BeAFexX+y9i7sNo8g359BhcXDmCbdQy3ll4EAFwelkIcO/QQposb8WhjI1yS0CkjxtIgKqNcUmRfnGMyIk9G4CQtpWkKN357XwhNaK1wo5bSfGRKtqW09YAxEre3YnHzhD3nbceDZWZbSqnSit1n7YQm2I6XsGgzUu7MRB3/ev8+PL37NG6+ZAUu2sCHwWSp+CiBmZaWHSncQstpWlJ3K/A13GhoQvLe42r1tWMpFeyuKqVUEW4KCgoKCgrnNIoFA9vWDp7tbigodAUJ9VeK2igNjOxIU17RkJFO6+B0Craw3LSSJ8dlRApVBVBrWF+1AH1EHKP4XEXSotuBCcHxWJ24haduA/h+McIxSimVatKSMAwNnmCFks0XWWtWVIA8VlQl9pMybkCJqNpEhRtth5Gd7C3fT1oFgeykUVFRxsat1kENN7o/A1PrRTXcBGIlF+HmtCbcWC0qGWHF1XBrxDXcdKJwA2JCaMKvYKcd1FF8uLEJN5dewiJ9EpWeKqozx7HZOo4B+xTeVz2F15RewD9NX4NXnCD915JYP9MgkjkuST8VP2PjSm2ZMp4rETgjjGdcw00WmpCfXLG50IScCrcMYi6PBXdiOlB09VV4tS61QmbV+wN4crDT0ATWLKOqWZv/ct9ePPD8cQDAc3tHsHnVALdvHoVbwdSjWoEiEgq3lKTuVmgKNdwiS6mRvNc7VbixGpAMqoabItwUFBQUFBQUFBQWCETyKa2AfRoY0SYq5cT2dD0mFuYLbHGzbrkQ5CD0dbi/hGMjM9HrGbK46q1YiRpwZobCbePKvtl1WgJm812IgQkirt4eJKNGYRk5u2waGmyBXxMXkgCkUjU2LrRmmAjZ9GxpKZUoISOlFqnpxW2XQYqKhEwUmtBBSqnsWCxxNaor6IkEZo7QBDebZGKYnLEjgsRx/ajGmcullMbXg9kPGRkg43w86Li3vh0AsHV4ALtOjqGkNfCuFcexdfoRLDUm8O9678b36hfhu7WLYmKsE8KNpGyK9b9kRJ7sGInakMJwJkITIjuyoHBrZSklCrfcNdxmGZrA6gKK9niaUsrZdCUXlM4llvaZRRiy9lhtQo6gsnQ0bS+aX5PE4um6fuIaZp0/I7YKlpEechJeS6Zw67SGG28p9SJ9qylRuNE+z6aGm7KUKsJNQUFBQUFBQUFhgSBRh6hNyyJbnOZRuM032ALGNHSsWdKDgyengj5pIuFW5gi3pUNxcqmh60lSkqgA2WcffOMFePKVU3jb9eu6eg70eAuVcDs5Wot+vzi0dkWW0pzX3ZAUFMutcBMtpdIabnKbKWcpFcaXJ9z4MAjPk9dwszJIsyThxhOFWeo4GcR7jp0LU2CKxIpISshISDuHpRQAjp+ZiYgg1/XwF/+6E/uPTeCSTcPRNlFKqa6hHNpdaw0Xn/vGCzgU3otpMEIbas0r4knzUnxlfDnuKD+B60uv4Lbyc7imuBtTUwMt+8kgEjAOsZSKyr/YqkrIxxw13NIspV5invi8KrCN0ISupJTmaIPZFMuCHZ/dB47jcX2RnYMbEWh6ZKHMUm6xzypFExMhocvOo2AaaNoxyUdJJtfz26vhFo5n0dK5kgIU7Foxy+lUpwo3zlLqRv1qpVZuhzRj6jvT0INkZ6VwU4SbgoKCgoKCgoLCwkBWoEAeRJbSFCkTreE236ALy82rBiLCTVwYr13Wg+f2jkSvh/pK+K2fugq9lWCxlRwjYikNP7v1spW49bKV3T0B4XgL1VLKcOmm4ZhgDd/LS7TKrMziIjpoL7kvI32ZekZuKU3up0HjCAUxtIBahwsi4ZaicMu2lMrvNVb0vNi2pZRvrxgRbqHCTSBBxPHUZAo3ainNIC2On5nhFG47951BreHg+Mh0tA1VuFWINe+B545nnxiCsTfCkImm7aLuF/DFmeuwy16Ot1eewCJjGj3PfwG92pvg+a1DSpIKt9hS2rD5z+IabvF7srHIayllsiZO4callOa3lHZF4ZZHESikDjOYpIZbq7liE8Ua2y/LUsosquWQcPN8P2qjYOlALZ7TDY5w8xKkaXYNt1jhlpoqHD5zZ5tSSomzwCLLarh1j3AbC2sqLh4IlNqqhpuYbaugoKCgoKCgoKBwlpCwRXVKuEksMkC8yDwbtf7pInD7uvS6i2+5dh0u37IYP/2WbdF7a5f1YqgvSDDNst3Ox3mx4y1UhdvH33Mxbrx4OX7mrduj99g8yjufZIStjHCTQRwXeWhCHoVblqU0DIPgQhMkCrcswk2jv2vRsZkKZjaW0oKpx8QsC03wRIUb/7pVaIKfpXAbmSE13LyICKoT4sMjNe6YNe/0eL3FWQUwdC0iDikh9rS9Dv9t/A4cdQZgNCfxgeoD8HMECSRCE4iltCEoKdm40iRauaVUVLjxn7PzZ23EoQlCSmkLhVuDs5TmreE2O0spI23E+cxZSsm4S0MT3FjNFRFuOUITKAneiNSfBtd3SrA5rp8g3LJUj40chJtYw812vIRCNA+oHbhpexFJn2U9B9qr4cZStBcPlAG0F7hwvkIp3BQUFBQUFBQUFBYEEpbSdmu4GdnqK9Y+JTzaVfJ0Cko4XLJ5GLdcugJDvcXEdsWCgV9410Wp7WQtrNtVBHaCyFK6QBVuF28cxsUbh7n32BjlHR65wi2fqkScezLllmzkKOkFZIcmxJbS4LXnJ9MngZgYkIG2p+tAVUi0TSvgngZ63vQ80hVu/HjKCDfOUppB2pwaq5GU0liJJCNJDaJwOzk6k/hcBkOPE3kZaVEwdTQdDzZMfH76Znxy8FvYXjiKS5uvALg5sz2RZHI5S6k8NAEIrrGmycnHVpZSdkw2jHFogphS2kZowjxZStnYiM8cK03hJhkfV6ZwS6TFenj8pVPYsnogOiZHuEXkWLh/2HdKsMkspXlSSoumnlHDLbhWpYIRJShP1522SHHf97lrZ8+RpXR0Kqi3t7g/INyUwk0p3BQUFBQUFBQUFBYIdEGt1XYNNzObcIuUTqTZUnG+CLd40aVrGj70pq142w3r224ni5Rsl6DsBOz4aXXyFiLareEmmz+ykA2ZUi2hcGurhlu8uC8KhJcpIdwYGTBTd1JquOWzlGqaFiW6MmSRdTLQ86bnkRYmIBJLMhe4zZEo6ceu225UEN523Ih8bEgIN12PFW603l8WdF2L5j0jV+j5HncHUNv6ZgDAm61H4I4cymxPJHoc14uICVEdRQkwL0vhZojPBf7zKDQBTOkXvO/7PqcOa0W4UZVU3vpcs7WU2imW0qiGm+txYypTzcWWUj2yP4v9f3b3CP7P13bii/e8EttHTT0xh9m9Ia3h5ibVZ1mEYx6FG7uWmqZFttJ2k0od1wftRXMeLKUAuPTYVyvOnb+UCgoKCgoKCgoK5zUomdSJWqsSEhDlgpwsoAq3H3/DFlimjp97+44Oeto+shZd7UAk1ShRMh+16ZhVcKEq3GSIrMQ555Rs7rUbmhAdO6OGG617prWhcGML/v4wtXFsqhEr3MgcyJtSqksIN5Hwa4VUhVvY79ahCclxmq47ePHAKFzPy7Tl1ZtORLhQ8kOmcAtquDHSIp9q0dD1qIYeUySJ18fd8joccBahrDUx89XfQe0H/xf2nkfhN2tovngvmi/eC/fkHviek0gCdVw/UmiJhNs0ScAUgw+48xLGLxGaEFlK2TnFCjf6bMqyiXqeLxBb7VlKxTp/9LMspFlKGelvO60tpayvhqFzVlSKMyFZNDbVjFNKTT1x3EjhFibi0rnseH5iXPYfm8R/+IsH8fDOZL1Atm/RMlJDE+jzKKo/WGuPcKMJpUBAuLG50ErhlpdYbdguZsIakMMDSuHGoCylCgoKCgoKCgoKCwLGLNVat129GpWSiWsvXCb9nNbyet0Vq3DLpSvmrfh/noVlHojjsiis7QbMs6X0HFK4bVrZj61rBnD19qW5tpcRA9IabrLQhDZquBmGDsd1w/eQSbjJargNhJbk8emGtIZbli2UI9ykltI2QxNMOeGWpnATx1Psd9P2MDHdxB/+w1P4wOs3RzWhZJiuxcQZJRd1PfYAAFwjSURBVD9E8goICGpWCysvDINYSiUKNwAwCxb+z+Tr8BO9D2I7DsN55QE4rzwA6CbgEWLPKuFi50ocwQaun2x0msK4TBJihY2hjLxvlfAcKdzCeaIRwi1vaIKodBKJwzQwO71J5nv0WQ5ChpGR4rO6HUspOy+Ls5Tyx2aketN246CGkKCrNeLtaA03x02mvIrj8vy+EZwer+OpV07j2h3836ZGROAmiT0Gem/0lEycQPvBCU3h2tmOl7seZ5rCrdF04cOPFK2sflvB0tFXCb4MUDXclMJNQUFBQUFBQUFhgYDaojohj5YOVvDuWzZG/+yLiFIrI4XR/P0rTImx2UAs6D9E2q0U5/67dGZtPJcUbpWSif/wgctx66X5klvF8A4gJaVUsq84pzIVboKtM8tSSvsUEW49AeE2NtmU1nBLU8wAvNpPrnBrNzQhbq9E5mGkcCPBDkCSDKMEkWhn/eHTRzMVblOElKLXSUYUDPUWI4VbXpjEUiraCoHgehqahmm/hM9Nvw7lN/97FC55M2CVAM+B1rsYxqoLgWIVsOt4k3Y/fqzyEIoI6l01azPo1WoowE6MCz03MTSB1vwyxNqBYmiCJyjctDg0IW8Nt4YjkmXt1XCTETuzUbjxoQnZyjt2XgYNTXBEwi04v6bjcRbURO04ctxkIqmXGMO4vmBybGlKaVoNN6paZQq3qTYtpUnCzY3mUyc13BzXw3/5/GP4/z77cJRszOykgz3FKLhIKdyUwk1BQUFBQUFBQWGBQBdIgG6DLZrnw3rJ8J9/8gp846EDeO/rNnWlPTpGhq6hv6eA971uM46ensbWtYNdOUYWIkvpOaRwaxcyhZtMLSWLhU1YSjNquNGFrqYF+5qGBsf1kwo3gxJpIeFGLaWsNhch5tIW8EG/+P4karh1yVJKx9J1fegmXwtNhqJlcETTov4SZGKq3koBkzNNzl5Xb5HeONBbbF/hpusJ4pSOj6FrXAiBuWoHzFU7YF38Jnin9sJYuQOaYcH3PTSf/iaaj30ZN5RewVXFvfCgo3SvjU+Ft+4pvx9He/rRp9WwxBjH8/5mvFBYhB6tDvdgH9zhZfCaJfRr07imdAhFdxpnvB7o/pVc/xKhCYLCLeov+ECXrJRSW6i7124NNxmxc2qsjpOjM1gyWEk/bosabqLCLTulVCO13/jtGHHUaLrRMbMspa7rJ+oE+n6SoGKkmmxsGYlZzKzhFl9LVsOtXYWbbSctpeyyy5533L6S6/z4rpM4NhKEjuw7NoHt64YwGircBnqKEUmZd46cz1CEm4KCgoKCgoKCwoIA/SZ/LuyR+lkg3Dau7Mcv3Xlx19qji6/B3iJ0TcNtV63uWvutwIifcyk0oV2IaqE0SGu4CfvKLaXBT45wA0siNDFVsxMKMz59lLeUjk3JFW6ZhBtHbmPWoQlpllKqzHM9DxZ0eCSVk4EqlIpCDcZSwZAmc/b3BIQb/UQWlEDRicJN17VEKAEdW13X4sRYGo5S7oO+5tLotabpKF72Vnzm/im8zXwAi41JAHx/F2vjWFwYj15fg524pid8ce+jmAEwCOC/CNy6/61XUN90NawNV8NYsgG6BmjwMaRPYZkxhmF9Es1Di1FsOFiij0PX4iRfzlKaYRNtigq3nDZ5N0Ph9tDO43ho53H8xSduSVx3htSU0pTQBJnlNraUxqEJIpHEglGajssRdOJ9REMTGMFr6Fp0nuIcZLZRucIttpSmKtwo4VYMa7jNVuFmx3URDUML02/l+8oUbt9//HD0OyPcxiYDxeZgb5Grr/dqhyLcFBQUFBQUFBQUFgQo0TEXiZubVw1gsLeIizcu6nrb8wW6+OqWTbWT459LltJ2kZfslVpKc4Qm6JHCjSe9gIBcmqrZCYUZlz5qBAv+yFI61YgIobyWUko6a7qGStGEBkTkVbs13CxO4UYspeQcGYkhU7fRWl6inXa67kgtpf09RRw+OcW9J621RzDYWwyTJ7VMNReFYWiJtFk6toauxTXRENQQyyL1d9nL8dz0HVhVrqHWcHHbzTvwd/ceRFVrYJ05giF9Ar09FdzxhothP/Nt7D1yBuNeBRctBbSZM0BjGgBwwF+OY+4gtur7MTBzBvaz34b97LdhLNuCrY1eXD2wE716PTpu41uP4zoA1w0A02d68bo+Ex40nHSW4xv6Fox4vWEQgAdN0+EcfQnO/idgbbsVxuDKiBxiyKteiiylGc+MqZqdINx8O+i747goac2EEovWcKMqPTejhlu2pZTVcIttoVaL0ARGrlVLJiZmAhIsLWlWphSjZGKatVOTKNzyBn6Ixwnq6HlhaAJLrNVg6Hrq9RRJswPHJ7Hn6ET0em/4+5hSuEmhCDcFBQUFBQUFBYUFAdEu2W2sHK7ij+66oevtzifouAydBcJt9ZJAbrN6aU+LLc9d0IUvW6BKIQtNyKNwY22ThTyzADKyKkvhZoUL/v6ewFI6VbNRDVVbHDGXaSnl7dssvZMt5LudUgrESidGSFBVDR3jzasGsO/YZPR6umZLVUvs/CmyrKpAQAZomoZKycLEdDNzW3oOWZZSXdO48fQ8H3qGTc9xfXjQMWUN4UytgWnXBBDUgNtprwSwEmsHe3HnuitgrbsC//sPfwDH9fE/Png9hvpK2LPvOP73l55AuX8Iv/RjF6Neq6HU2A3n4NNw9jwK9/jLWAkAOmD7Ok64/Tjj9eDigUl4tUk4HlD1JlENmYDVOIMd/S/jkDOEVc0xTP3fP4e+aDW8M4cA34e98x7oS9ajbA7i+qKB1cYIbBjoH2vA99cCvgdv9CjgOtAXr0/aWd2kpVTXNI5EZeo53/fhHn0Rzee+A/fQ84Dv4megwxj0UHv2fjT110LvWwpj5bbo/nFcnyMD5TXcwj7oWioZFNVws12OCEtaWcPQBC+u4VYuWYRwY+QWT+q6roed+87g3qeO4Cdu24L+niKXhqppgd1VJLhkNdzaTSll41stmxgPU1jZ/ahpQY1CJ+XWYf05M1GHaeg4cjoguUsFA/Wmi33HBMKNKNxYkqs4J15NUISbgoKCgoKCgoLCgsBsU0pfDeAUbv3FeT/+tTuWYcf6IfSmBFOcD6BjXLTSCTdNwriJi3PZQjOq4aZTwi34ecNFy/DQ88exaWV/ap8YYdBTtiIrGyPKOrWUsvZYO20r3Ey5wo0t5l3Pj1RsjKQoWkZEcriej9/+8FV4bu8IXnPZKnz3sUNRG9N1W65wqybnf5aFrWDq0XlVS2ZbhFuWpdTQecJNZn+ln7FxYKSqTJVn6jwhCvgR6egYRUz6ZVR1DSuGqwCqAIZhbboW3lV3wjn0LPa+uAvf3l/G8/YqeGFO4p999GZ86+H9+M5De/G2TTZeOHAGRTh4XfUlrNVPYLN1IjqmN3IQAKANrIA/dhTeid0oA3hvlXTyyEuY+eeH4E2NRKo7c/2V0KqDgO+hcMU7oJd6I2UXJXEtU0fDdmHBwRvKz6H87W9hulyBX5+CPzXCjYWBYP/y1GE07v+b4DhbboR57QejbZg6DZBbSl1CbBlGTAZRsBpuPvndNPSEarUoUbhVikakEI2CEEwDjhv3y3Z8fP+Jw3h692lctHERbr5kRUy4hX2yjIBwo2QdV8Ot1GENt/C+6ClZGJ8KwzrCfupa9hdcjuuhabv4jc89gkrRwluvXwsAWL+8D7sOjmFsqonRyUYUmjDQU+C+eHBcL1Nte75DEW4KCgoKCgoKCgoLAgancDt/LYuzgX6WFW4AzmuyDeCtnsWCkWrfkok2RNtbdg03PqUUAN549Rq88eo1iX3o/cDUVbqmYaCngJGJRvSZLlHCyUBvL3bsnrKFE6O18Bht1nCjKaWFZOCD6/lRnTZGUhQLhHBzfaxZ2os1S3sT5Np0zZGGJvRUrIRSKgtVUqeunTpuhqFnWkp1kmIKQNrX6DPfj2y7EeHWSM4vaq9nlkJ2noxPks0tvXcYhe2vxd6JjXj2lT3cZ67nw4cGGyZOllfjJbsMANjf3IDNzisoaA7GSivx83deiS/+7b9gxi/iIx/8IIrTx+BNnMTxl57D6b0v4ZA7BAMeri/vhRkScyiUAbsJZ9/j0fGcPY+ieP2Po2kH58fSa5cZY7i2dBAbyoew3BhDQXOBacCbZidvwtp6K6ztr4Ve6cf/+MJDODJSx69dMY4h5yTcQ8/Befl+6GPH8fpSL6a8Ek65AziMATRgBWMszAmbqOxYom6awg0AJmcCUqpg6ol6hhZXwy08t4IJIyTJGlHyqI6Z+NaEQ1JNGdkl1qezLB1o8GQdV8Ot1FkNN3YcOu/Z+cpqFIr7Ts7YqDVc1BpudP/2lC2sXFzFoZNT2Ht0AmMhgT3QU+TUjLbjw3oVs06v4lNXUFBQUFBQUFBYSJhrS+n5AM5S2jv/CrdXAyi51VOycIYQWq2gaRpnQ5UpNdNSSrOgSxRuQFDHLI1wywo+4Cyl4T6UkMpSx8lgpVhKgUDJ14QXqYyYHa5cMDGOYJFOC/DrmoYff8MWnB6v4TuPHsJMw5EW8y8WDBQLelTsvhUo2dBOUqkps5SKCjcyXFkEoOPEn7FxkiWrcl8+hNeKjZFHrIBpkNWQcz0/svDS82m6Gh5vbgAADFgFuNVFuL+xFQDwQddHZdEaGIvW4Fh9NT7zzNpov/qm1+GtS47AWLoRxsoL4Z7cjcaDfw+9bwm8saPwzhxG/Z7P4BPFXhwyhwB7DV7b9yLWm6e5fo26FbgXvwOrVy0GilUYgyuhFWMp3Rm3iglfx8wFN2LV6gHYex5B/Z7Pwju5G28Twk2POIP4x+nrEtcgUrjpWlzQXwxNICq58ZA8KhfNjJRSL7KyFi0jrIPmxoSbcP85rhcdk/1kKjZGeInEG8Bfq0qHCreonwUjUpwy6ytToabBdj2OnJwJCWLL1LFmSQ8OnZzC0ZHpiDguF02OgH+113FThJuCgoKCgoKCgsKCgLKUtgYdI1Y0X6G7oIvFvp4CcLK9/S2zFeGWPE6rGkdUgWIR9Zk4B/jQhHTSjCrYqMKNQawh1wpmiqUUiPvOamudGAtUdIsHyjh+Zib4TCDUXnfFKrieh+88GlhLZTWripaJomXkJtwoyVZtQ+EmKtgAXj2o6xp3/TIJN3KehUjhJrGUSgJkPB84OVbDyEQQJpBFksimk+fFyi+uth4hRBzX52qg0WRSMTRhSu9D8cqr4z4v2wLzXb8NAPBdB81nvonmk1/DMCYxbEwCUwcAE3B9DbuxFo9Nr8R+ZzFOez34d8MXY/3aJdJzYeQUm8/WxmtgLN0EZ8+jePBHj6OCGpabYxjQZ7DSHMUv930btX99CfbQChQuvhH+4CZ5aIKocCPXgRFupaKZqMtYjBRufqQSY0QWECs4RYWp43pRUANTnNH0VCCeE5bk+gOEpG0RDiLCdmIS0DJ1uE03fka1Itwcj7NqM7LPNPToOdFouhGBV7R07ouHV3tSqSLcFBQUFBQUFBQUFgQU4dYa1Gq2qP/sWErPd1CFW1+GfTaNJKsRi+DWNQOp+xltKNzMFIXbgBAckDc0ob8a70druAHBQrrd+y8tNIF+xsimk6FtdelgGc+F28gK3Ru6jnIxINQmZ5KEW6lgtGV9pSRbpQ2FW1DDTVA5cZZSfrxkNcQYaN2wiHBrSiylkhp79YaDT/3N0xGhk+W6l81N1/OkCjebI9x4NRMlS2yhqn6WckkzTBQvfzu8TTfjf332G1hvnsTlwzN49HQvHm1shF7px3gzrqEnknkUke2SzGe9ZxEKl9yOr/ygGlm+e7Uafqz6MC4uHIJ/ai/sU3txYtf9gFXC6r6roWENLENHoTGGAmw4jhXUjKtPwj74LG63nsZ3nEtQ8wuYmmEqTEMSmhDPZ1qPkBHozbC/SYWbT5Rt/E9aw421x0DtzJ0SbnGfdBRMndtf07JLONiOx80RqnArFvSwP05kk2V9t8wgiEEp3BQUFBQUFBQUFBQWAOg//cpSKkfRMvBzd+yArmlt2eIU8oNTk5k6KkUzWmTmwWBvEaOTDVy8cRGu2ppU7bCpLaY2ZoGzihLlTL+ocCPtZNlCacJnZCktsYTU9usncpbSojxhNVK4haq2JYPlaJs0iqpaskLCLSBnaDH5YsFoS4nXqcLNMPTE9aFjq2v89cvg22Jro6FFBE1NFppA1Y/h+J2ZbERkG5D9pYTsI8/zI/UdH/IQb+O4PkeQUCKsKSiVZCSpCNuo4GVnOV52lsNasw7fP7w/+EAIrMhKl5URbgxUWTnpl/G5qVuxxhjBgD6NjdZJvG7xSbiTI9g4ch9+uXcxiqeG0bv/JfzWQAHH/EWY+pvPRfu/pgQs0qfwualb4YeBKKUUS2kRNhbbx7Dq6LP41b6dWH54EhcXluBpdwV22qsw6vUk7iM7Q+HGzoOp4jhykVO4mdF4eX7Qy3/6wR4sHijhNZevSh3DJhnDoAZdTGDrWnYNN1GlVqOEW3j/TdXsuDZhSAoGzzc3Yd19tUERbgoKCgoKCgoKCgsCulK45cLV25ae7S6c16BEmKFr6KlYUsItjSP7qdu3Yv+xCdx+7Vqp0ogRy5Q4azXbKRlNya2+Ck+68gq3dDKKWlFZ2ipTuLUbmAC0spTyFr5I4TYkFOCSoFqycHq8HincApuaGx7HiBb3eXDhhqHod5nCTdN48inqv8xSaia/HGABDtkKt9jayPaTppQayfanBFutGOTAn4u8hhtDmqDJdT1OhUeJlqZAijlZzKKwT8HUuTFcMVzF0dPTie1kEIMFKJLvaTjoDuOgO4xn7bV470ffhMlnfojJez6H9dYpYPoUAKBHb2AzjoaNlOD1LoM3chAXFw7hYz33wAcwpE+j/+AUhu1+vKvyKC4r7EdRc1C452/xB0Me4AA4g4BR8YHN+mFsrh7Ge/AoDjuDOOVswYyxCAfdRQA0uKSGG6vlZ4c/LUHhJptfAK8ebTRdTNVsfPvRgygVjEzCjVpKCwIRqEtqFIqgql1mKbWIpZQm/ka2WFYrT1lKFRQUFBQUFBQUFM4+ZIXCFRTmG6K1uadsRSQRRdoMvWjDIly0YVFq+6+5bCUc18OVFyzBwztPBG21quGWkj7aUy6kbicurCko4cbIFxaa0G5gApCdUso+c0OF1cmx2FLaCtVysFylhBvA6maZuRRud73zIjRtl1MbyhRuQdH7JDlgSFIcKSnJyApdBzwX2HVoFJduGk4Qj0BsKTV1LSLVWltK5YRbpsJN8plLFW4p+/oQ6rZxv8cqKdvxuNpvaWgwK6NlcKq711+xCq7n44ldJ/HSwTFO4eb7Po6cnsbyRRVomhYRhaZkXmbZpgHAcYHiBTfgqy9qmH7lcVy5SsfKK2/Fl756H5bqE3jLh34SxsByHDk9je9+4a9xZ/UxbC8ciRt47p9xDQBQ937IM06jjDOlNfjR6UXYdumFGN39DNbZe7HOPI1V5ihW1R/BZf1BKMSjzY14tLERDSd4LtghaewQxSMQ33uGrkUErmgTZ8RwvRkHNNSbLnzfT32OMKWiZemJMQsspW0QbpylNCTcwvuzYMZq0LRaea82KMJNQUFBQUFBQUFhQYAuapXCTeFsgZJHRki4SdEhKbxpVT82rerHgeOTuZvS9UCH5oNX9fRmKNwyLaVcDbdgn6WDgeJssIP0W4tTuMktpY7rY2yyAdvxYOharhqEzAY6WWsmjlO08llKVy2uJtR065b3cfZUIHj+OBKhlWHwCiANyTkCsHH08dmvvYBtawfx799/WaItloRZKpiZCjdDYjcWgyOynpHpoQl8mzLQ/jSdpL20XDRhO01u7NIQKdwsvs5d0TJw3YXLcGJ0JiTc4uPc8+QR/N3dL+P2a9fgjhvWR+/nUbiJ19R2PBgAJvR+/KixHUMrN2Dt8pV4qHEcAPCWvkAtXG84+FFjGw46w9hgnYTna3Ch4z1L96LRaOLl6T7c37gAoxjAz77jYvzhl19ET18f1vX14fGjJ7Gpfw0e1w386+QFqGp1bLeO4Jbh01hc24NBYwZvLD+HN5afwx5nKR4pbITe6AUgqeHGCDdDh2Fo8ByecNM0DaWCiVrDQb3pcOoxx/VSVa02qeEmjlkQmpBNXEoVbmZS4UaJaHYcRyncFBQUFBQUFBQUFM4+6CJQ1XBTOFvgyI4Mwm22M5RyHnm4O10P1D50USv2jd43poSgYKBhC0wVs3ZZL371fZdieQ6rpwi2uNaQTDhl/XA9L6rfNtxfarnIB2LVXaxw45V0WSo+BtmzZOVwFf/7l2/C9584jK/8cG/Qtq6hId1f5xS3hhAqwX7XyHsvHhiV9oWRFdWSGY1LQ0q4JWu4JRRuGZNG9plLUkp1LSZwRdD+UEJnKiQ9B6oFTEw3E8myMsSWUoPrkxZeNjZXqKX0i/e8AgD41sMH8eZr10bvy9Rs9D3T0EKVIt9/wyDKQkOHSead4/gwCjEResBdjAPu4ujzn3rfz+PRpwICEAjqk+nVIdT9AkquF41V0YpTSqf9Eh5rbkR16c24/6mDuNA6hGuKu7HVOoqN5gls7DkBnHwQM9+8EIu9TTiNPkK4BeNhEJuneC1LBQO1hoOG7XLqsYadTrgxpaJl6onngqYhs4YbAM5SP9OI1aaMXGdzk977TJGoargpKCgoKCgoKCgoLACYSuGmsABAE0ENXc9QuM3uOKJypRUMIyDcqEKlJ0XhFljP0tukYQvUzrdj3ZBs85Zgi/hiwUgcl4YmnJjKX78NiK2fjPihZEHe0AQxYZShVDC5sUwj+Sn5EfRB478c0OTEiAxMpVYtW5lfKphczb5gu3EhaGA2CjdNC+acLylaRwk3SoSNTQXHX9RfwsGTU7kUbpGyyuLnY1zHMLh+dA4uGaxE9d2Yqi7N9sjVOjP0RCmCpuOiZBicddM0421s10MRBuqNJOlZLBjQdY0/hhaHXTiuH/W7VDAkSbY6HBh42l6Hp+11GNCncXVhDy4pHMAqcxTu4efxUXMn/q/1WpjmNdz5GLoWnYt43lFSacONLMLBWLlAyrPKJsmpojVXJ8cSwezDlHCrNWLyTrz/aE1Fdm+xOnWvVrRv0FdQUFBQUFBQUFCYA+gc0aEIN4WzA0MgYeZK4cYpfnI01lcpQNOAXmIHFWuRsTZb1WGjC+UJgcjpBIz4o1ZVhqiWk+dFtfCWDLSu3wYgkcTLpaEWzFyhCVnqHe5apxBzQQ03qqTiU0vZcyvPM2uaKNyy+xV/xubfydEZbpvZKNw0TUvMOfaybssVbmNTgf5vUV9gBc5Vw80mNdy4unTBz0jhRo5D1ZdHTk0BCK67jECmBKwlKA9p/6l109D16NzZ+zVJHb1yOLcsQfFKFZuMnCxYhqTOHz+fxrwqvlu/GH848Tb8Q++HYay5BIbm4yM996Ly7D/BPX2Ar+EW1QZMIdyavMJNTJGl4Gq4ySylKXORHatWT46PZeqJgBVO4RYRk0rhpqCgoKCgoKCgoHDWIVvEKijMN8RaglRFxgqZA/lUaVngCYjWbf3ynRdjcsbmSC1D11EpmpECxSAKt7wQrYqdYOlgBR9963YsGUoSaVThdmayDiCwlOYBC01goGOeV+FmZinJJLXYRBiGJlhKNemXA+Luz+4ZwTcf2o/3vGYTNq7sBwBM14OxrpQsTsWW1a/eSnC9T4/X+X61qXBzPT+ykAYKN/7zgmWgYbtciEOTI9xihRuAfDXcQitj0dS58YmIYStpq6U15F4+PAYgfT7T9wuWDlfokx0STSx4gd3blqGj6XhRfTGZwo2FXtBj6CRAw3H9iJwsFYzEPCtkpASf8XpRfsMv4rHP/Ba2WUeA3fdiZt+DWLrsPQCMqIYbIFO4Bf2qNx2ub9lJr3FarCmQa4F6UD6+wTnY0pRmi1hKGYoWT0wDinBTCjcFBQUFBQUFBYUFAU3TosWFUrgpnC1QIsTUNfQQlVWemmF5wddwaz3fVy7uwda1g4n3qQKPEUFZi/25wnUXLsPGFf2J92NFUBCaAAADOYMZegSFG7XQlfJaSjOJrTwKN145ZepiDbewfp3wzLr7sYN4+fA4fu8LT+DwyUCpNV0LFW7lbIUbnYMsGEN0f2amlErmk5dQuPEKS0be8DXcgt+bthsVzo8UbkINN9/3sXPfGRw4PhkdJw5NMKR174oSS+k0UVO9fHAMgDyhFODJsG1rBpMKt7CeG1O6MXUXu+6svpgsKbZcNBLH1jWeSGLnR2u4MYjqLwrH9eDrBj47+Rr81dTN8JduBdwmrjz6j3hn5TFU/emYyM1QuNl5FW5ZllLyd5fC0LXoeScl3GSWUk7hpgg3QBFuCgoKCgoKCgoKCwhpNhoFhfmCqHCjSaB0ET1LgRtvKZ1FO1QFFtVw6yIxOFvEKaVepJIaCGvItSLWK4JllhJuppG0tEmPn0VsGTy5Kt1f5y13iRpuKcXtPUKQ/WMYBMAUbtWSlUkEGhKFm4jsGm5yS6kXpZTy89fQY0UVl1IaKsTGWAqlqUf3g6hwe/HAKP7oi0/jd/76MfzXv30iJKSIpVSiYI4tpfExZ+qx4vLlw+MA5AmlrN8MV1ywJDGf2PFdIQ2UkU7sHGqS4AqmJKP2bINYSn0/JqKKshpuGfeg7XhwXR8edDzdXAfj9b8Mc90V0H0Xt5ZexFtPfhZv1+/DJdYB9DROwSfkJke4cSmy6Qo3RrjJQhN0PYVwM7SIuJ+RWEpNU09YuulrcYxfrVCWUgUFBQUFBQUFhQUDQ9dgA6lFnBUU5hqmULOpShRkxS4SWe3WcEsDrXPGFs6targBQF+YNjnXoBY8VgeMKdw++rbt+My/7sR7X7tJuq9IqFWL8fJV07ScCrdZWkoFQsI0dFCuTEZ8BXXe4tfMDkpTSrOICEOicBORWcNN0qcshZthaJGqriGp4RYpE3uKqcqlw6emo9/3HJnA8TMzEZFWMHWphTq2lAZt+b4fqQAp0iylh8MabwCwY/1g4hpGNdwSllK+vlg9JM6oPbtcTFpKNUENJkspZci6B23H48avUCzAfMMvoHnoeUw89BWUxvfjMn0XLuvdBez+IaYP98JcdwWsHa9FkVhK6fOIkYtpx2N9EslLLaWGm6nr0fWZltjOLSOpcCuoGm4JKMJNQUFBQUFBQUFhwSCylGaoUhQU5hJ04WzoGnoJ4UbJuNnO0HZTStNQlVhK0xRBFH0Va34It5DImZxpRkqbgbAO3dXbluLijYsiNZEIcUG/YWU/tq4dxPJF1eDzFqEJhq5ljm2u0ARR0Sa8ZmNObXelgsGpj5gdc4oo3DL7nUvhlr6/7IxdmlIqbGNoWqRI4lJKQ8KMJaT29xQ4izAFI1MZTo3VuNAEehkSCreQ5Ks3+eRNhrT5XCEErGUaSUtp2H9G+rB2LDN5XHZ+EeHGQhOEGm4y8q9o8Qo3qoSTwXE9zg5qhKEQxTUXYXj1hXCPvYT7v/4NLHGOYkVhCkZ9EvZL98J+6V7cUl6DWmEl/JkB2KXFURtUJSiCnadlGUmFmyYnmw0jJrSnU0ITghAKLZoLylKahCLcFBQUFBQUFBQUFgxiS+nCscQpvLogqp4oocWTDLOj3Pgabp23Q5NKN67oR1/FwkUbF7Xc70Nv2or/+rdP4I4b1nd+8Bxg4zkyEai8qiWTU8KkkW1AknDTNQ3vuGlDRA61Uhy2Iu7zKdx0gYQVUkrDXylR5Xk+R6jM1B34vs8p3KyMOnuUFOlNScnNDk2QWUq9mHCTKdxkllKmcAvJtP6eIgnB4IkUkXA7PVYnNdzkYxbVcAvJIma5NfQgnIT1N03h9pNvvABfe2Af3nnzhmg/ijillCncgnb6qgUcPzMTWZwZIdpfLeDYSJAGW2IKN4FIk417qWgk5lKWAtEmgQ3itpqmwVyxDfcYkzh8ZgofeN0G3LpiBvaL98LZ9ziGagfxgZ6D8A48gsMz18PCGtgwcyvcTFMMTdCkisighhsj3CQKt+geNCKSkoYoxISbspQqKCgoKCgoKCgoLAhECjdlKVU4S6B2Pl1QqtA6SV2t4TYbhRtRSy0bKuOPf/HGXO1tXNmPz/zqLZnETzfASA5mq2T12/JAVLCJPHwrS2lWnTSADyegQ2YaeqTMkdZwk6SUUjiuxyncXM9H0/Eia161bHHqrGS/qcItxVKacW6yjzzPB8sp1TQ+VdXQY0spDRCwBcJtoKfAWYTPTNQx0FuErmmR7XSwt4jRyQZOjdUiK2fBlIcmFASFGyMke8oWPN/H5EwwXmmE24rhKn7ujgvJefDbNSPCjdVw06I+AsBo2OfR8PyG+uL0XBaaYJE5podEpajqEoMHDEPPJEQd1yN9SldWAoBumDBXboe5cju8qTN46Z5/g3/4WawxR7Dm1P349/19+NupG7MVbqSGm6gWDPqe7INBLKUS0WFMuBViwk1ZSpNQXx0qKCgoKCgoKCgsGKQlsykozBeyVE+tCJx2wNe06rwdqsATlUutMNdkGxCHEYxEhJvcIimDqGATVUOtCbcWCjehPhcDVyhfINiCGm5J8ojCdrxEauRM3YmUQpWSif6McaBzsLeaYinNODVOvcYUaZ4fqY10wWprEKtkjQtNCC2lJOyCEUQzDQe/9ucP4mv37wMAjIbbbF4VJNWeHs9QuCUspcFYMetipWRy6btZ9kyKNEupGJowGJK+Y1MNOK6Ho6eD+nMbV8Ypu+VCUuHG2qf9KYXEHH02iKSsiKCGmx9tK4MsjEPvGcLptW/AH028Gd+rvh11oxdLjQl8vO9bWHL4HvienHSzo1p6EkupLleCUkupDGxc6DbKUpqEItwUFBQUFBQUFBQWDNgipdVCWUFhrkAXzuz39752E7asHsDNl66IPpu9wi3+fXYKNxokMJsezQ3YYn6UFN7PiyB8IFlsn4Eq4GSn3o6llF4PS0imNAT7pSyllMIHbzEFgPHpRkSyVEsWLNPgrh3fr/j4PSVLem5ZhA7tH1MpeZ4fWSdFdZ2h6zHh1mihcBOO+8L+UW6bTSFpdWqsFhNuosJNCE0IyEBeAUgJtzSFmwixb8y2aUfkVtDOAFG4HRuZgeP6KBdNrFhUifYtSUITWL/pvGGWaF4Fma1wo6EJZsq5pSV2B7ZNDS9jHe5b/VE82VgLQ/Ox9vg9mPm3/wZv4iS3vUeIVstKppRqGj+/2W+moUcppTKYROHGQAnyiHBzXt2WUkW4KSgoKCgoKCgoLBgwgkMp3BTOFgyJwu2NV6/BJ3/8co6o0GZdw41aSjtvR1S4LTSIC3xGduSBpmkoFogKTXguUEUNUxpxx27LUhq3zRNuOlcQ39TFlFL5MShxBQCnxuphe1pU6yptLAxBQVeV1HHLTCml5CELOfBjwq1cNHlLqREr3Oqk30ylxxRu/UThxnDo5BRm6k5EMG5eNRCc7zgNTeBTW1nf6fVr2G5kTawWzY4IN/HvBuu/m2IpHZtq4OCJSQDAmiU9HHmUFpoA8AEbbDtT50narL9hPuJaeWmBEGbKl09s7tSbLmb8Ij4/fTO+MHUjbL0I78RuTH/5N9B8/nvwnYAApdbmgqknxlIXUkqZLTSo4ZY+7q0UbiwJ1lYKNwUFBQUFBQUFBYWFAWUpVTjbMCUWsug1fdnNGm6zaKyH1HBbiHeNSBi0o3AD+LpQ4mOhVfhCK4Ub/Zxea0ociOSJKSrcUogvRvYwEuf0WA1AYJdk5F7aWIiJqbI6bnlDExjB4ro84caNq65FNtqZRqzMm67b+OzXduJIaLkc7CkmLJAN28Urh8cABGTQysVVaAhsoqfHg3Nmdc7EvlMlWNP2iOVWULjltJTmDU1gltLRyQYOnZwCAKxe2sMputh84gk3hP2mCreQoGpD4QbEtfLS7LLs+oi2Tva6brvh+Wl4vLkBP1zxMzCWXwA4DTQe/FtM/e2voP7g36E5HiveAkup8EzTeVUvm6+G3sJSamYTblGarSLcFBQUFBQUFBQUFBYGjJRv9RUU5guiuoiCvp7tDKXCqNkI01YtqQIIFrsLUeEmkkft1HAD+EW8eD3oZ2VJCEHLGm6kb3ToLKGGm6HzZEqrGm4U/WENtlPjLKU1JpLSxsIU2uytJLfLtpTGv7M6faKllLZJa7jRmltHTk3j4RdOQANw8yUrsGxRRVrH8Nm9I+H5BAq4wb6A0GKJnwXT4NSJ9HemomrYLqZrocKtbKKnMntLadN24fl+ZG1l82WgNzj3sakmUbj1CvMp+F3X4gTXyFJKxoDNOz40IVvhBiBS86XVcLvjxvW4/do1uGgDnzjMiMB60+Gu1bjWg/Jb/iOK1/8EtN7FQHMG9vN3w//G72KHdRim7idCYABEIRAMzBZqGBpHyvL7xOfLWUolKaWvdoWbSilVUFBQUFBQUFBYMEirW6OgMF+gC2CR+OAIt1lOUd5S2nljpYKJT3/8pkyL4dmEOIbtKtyKQkokRbloYPOqfnieD8vUcVTYt2VKKVUzcnXPBIVbjhpua5f24kBI3lD0Vws4OVrDqVDhVi3HS3A6FpapR4qsNIUb3SbreksVbp6PWqheKxWNiAgMzkHPDNC4ZNMwfur2rWHfksd9bk9AuDGr5uL+Ms5MNKLPC5bOkUN0ShQsA7WGi6btYiZUuFVLFmdn7DQ0wXE8NJouWBWxyMobjrvjenjp4BgAYM3SHu6YVDFpmToc142/EJIo3MyE7biFwi28Fmnntn55H9Yv70u8z6zT9abL2UWbjgdN11G48PWwdrwW7uHn0Xj8X+Cd2oef7b0Hdd9C/YFj6LW2oQAbTQRziiasBuRiSLiRlFIRlqlHc4zWbStKUkpd99Vdw00RbgoKCgoKCgoKCgsGSuGmcLZBSRpx0czPy9nNUT4MYFZNcaqphQaRPBpso4YbkE24aZqGT/745QCAP/7SM4l909RDcd/knxcSNdxaK9z+449fhhNnavgf//hUlLYJAH0hscUspbzCLR6LUsGICbcUhdtgbxEnR2vSbSjoMLFzsV0PjVDpVS6a6KvG/aA13GSgllbZcU8LCbTDAyXsOkT6YBnwvJh44RRVIdHXsF0upbRE1FIdK9wcL6qVpmuxbdY0dPRWLEzO2NF+yxdV4ftxH8ukJqBl6KjBjUgmPqU0qXAzBVWkDDVmKc15btHxQiKw0XS5JFyW9AoAmqbDXH0xjOVbMfKDL8Df+zBKmg175/ewHt/DHw4Bo24Fu5wVcE+uhWEw0jAm3MyMlFJq8S1ZMaUks5S+2hVuylKqoKCgoKCgoKCwYEC/aVdQOBswJaEJDN1VuNHfz9/5Tsdw6WAZQ32ltvanChqZakjTNGha0ioHtK7hRokDj5AtmZZSXQgACF+UCibWLutNEChMSXY6spRShVusMitJ7HgMvWE9s0FC0IkBEhR0nNi5MPUYEFhK+6jCjZBRMlD7adZcZQTiksEK937B1Ln+ytSEAeEW9LGnZKG3HB+zU8LNdtzIRlsq8JZrOpY71g/BCgMFqiUTpqFx58yOH9eey67hZgjpujKwfuWtTxcdj5Ba0+SaMtsshWYWML7jTnxy9L34O/fNMFZfBNcKLOiDxgyuLe7GzFc/hXUn74UGDwapPWfo6SmldI4XCvR3I7HNq72Gm1K4KSgoKCgoKCgoLBjoSuGmcJZBFVmiJbGVRbEdBEQR4PuzJ+8WMig5ccmm4bb3zwpNoJCRa60tpfE+PlFgsWNqCMihhKWU1usSOmUJNlVW/N8N268QhRsldcrEwigq8y7ZNIyHdh7HdRcuw65DY4n+iuAtpcG5TNXs8LUO09DRR2u4taFwE9FTtqK2GeG2dLDMbVO0DE71xwVUhIRNEJoQK9yoEnA2KaUsnEBMsR3oLeJgGJhw9bYlAIJx+8R7L0XTdrmagGwM5SmlwXa0rlsuhVsLS2kaCpYePTemZrIJNwCwbQ8+dBwy16By+4/hwP4z+LMvPoJVxhlcV96Ny619WHPiXvx873J81b0FphEQckFoQoqllFO4ZYcm2K9yS6lSuCkoKCgoKCgoKCwYsIWMquGmcLaQGZrQZWaMtXc+K9zomF28cVHGlnLQQuxZqi4ZwdGK9KCEnEsIrMHeIpYOlrFl9UCwnWgp1dLnCFfLy9RQEcIchvpiZVWVJHFShZvY7w0r+vAHP389brhoWfRellVP5wi3oD+MnCmHx+lL1HBrn3Ab6CngP7z/Mmxe1Q/T0LF5dT8AYNmQoHCzDKkqEECkogpCE8IabmWLC03IXcNNuI8cx4tqpZWFFFt2LAC4bPPi6Pf1y/twwZpBbls2Nqx9jnBKSSlt9Tes1iI0IQ2apkXHnKw1o/epvZSCvc/G2TR1zPhFvOwsxz/Ub0HpNT8LV7dwgXUMv1b8It7a/DquKuxBWaunhibQucKnlPKkI8CHcLwaoRRuCgoKCgoKCgoKCwaqhpvC2UaWpZS+7gZHFhBt/qwTTxcyRibq0e+MwGoHWTXcKCgpU7B0NG2vJVFDSRFaY6xg6vjUR6+JiFCxPhdXw03oEj2mZegol/glNyWjlg2VsXK4CtPUOUVVWr8pQWinECyAPHGVqcfYcfjQBC0zNEGWksreX7WkB//fT1wB2/GiYy0RFG4FS6h7RzpYJJZSmqLaQ8jIvIS0I6j+mrYb1UqjhCYAbFzZjz1HJ9BXsaQJtxQR4SYJTZCmlOp5FG6McGtfA1UqmKg13EglB6QTbrYTbGNZcf06Bl3TYG2+Hi+dLqP05D9go3US6919WN+zD97Ig3Ce2IaLrSV4zl7NPaU4wo2Ma0GicFOEm4KCgoKCgoKCgsICweKBYKE2PNBenScFhW4hKzSBq+HWBZpM1wG457fC7cqtS/CtRw7ixouWd0Qu5CfcCAlSMNG0m20R9y6p4RYkN8rngVifS7StUjLCMnVUirw6jBJuhq7jdz5yNQDgL776PHm/db+zCDepwi1UdDGCqE8g3LJruMkVbvR9et6lghmRnkCgrkpTBbIkzEYzJpDKRRMVQlQ2UuySIsR6YbYbK9xKAql2x43rUS1buOni5S3bZYo21m1qH40UbuQ9I4fCjYU5dEa4JcnRNEtprHALjiNangHAri7FZyffhB1DdVxZOoBlU7uwwhxD4eQL+OneF7DfGca99W3Y2VyFJiypwq1g8fdFTLj9/+3deXyU5b338e/s2ZiEQAiEQCFRAoFAQDTwBCNEVFAWqwh5TgsiCujBpdj2iJbihks5p4raKotoUatWRY8VEBdKRZHDU2tdqp62EJTFSlmzEjKZmeePZO7MlkxIJgvJ5/16+TJzzz13rpn8MvPKl991XV17SimBGwAAADqMWYVnacLIvurTIy7yyUArMJtr1+zyeL1hNk3wuxGFjKx+SmnLr9VRpack6NFbzm800GlMQODWyCX8A48Yh1UlFdURN03w5/HLavqlJgRe2z9IMJvC7lLqY7MEhl1xfmuHmUz1/6gQ/PjgRfcjOd0Ot8YCN4/X2/iU0tiGO9wa0j3BoUN1O6o21hXom3JbUl5tbFwR57AGhDcNhUnB3EEdbi6Xp8EOt1iHVVP/z4AmXdfXHeZ7DgGbJtSN3xowpdQUcfp5pW/TBOvp//LHxYTGOA2u4RZmSqmPb4i+97kTlh76LD5d67/N0uQhDl2UvE+uL7dqgPWI5ia8rwqPXduqhuqg+f8Y1/B1uAXvaMqU0loEbgAAAOgwrBaz0nrGt/cw0MVZLCZ5akIDN//gJRoZme+P8s6+K2/wH+On9Vh70zrcLOF2jjyNDjePx6s7556rbw6VKTdoc4eAjTRCOtyC1nAL6HCzBGySkJIY26Tpok0JCpu6hpsv6KwICtz815arOOlqNHBLaKjDLbbhzRS6d6sP3ExBG0/4h2++KbdH6qYem00mo+vNp+pU0wK34HDHVeMxuubCdYU1lc0SHLiFW8PNb/0yszli7VW1YEppuCmwDa7hVhfE+X6+/sFg/SZFdfeZzcZ4Tsb0lHX0ebrzQ6cuiPlKI+1fq6elXFPi/qKDp47IeypbJke88bsdGrgxpVRi0wQAAAAACJDVP0k9E2MCFriXgqaURiEk812ik+dtLRLY4da0Ndx8GwOcTpjh8Xr1vd7dVDAiLeRn6/99a7u1wt8X/D2D13BLTW64czegQ6oJu+E22uHmNybf2my+3q/Yuo47/+dYUVVjdECFExym5GWnSpImjk5v8DFJ3QJ/d/xfUv/wzRf8HS2pMsbnG1t6Sm2n4XnZvRr8Pv6Cpy+63G4j2AreNOF0+MIqX+BuCZq+LDW+zl84LVnDLXgjDql2l1dvXYdgaWW1/rr3qDwer1+HW+iU0uA1Ci0Wk/HcfNOMy7yx2nhylJaXXK7nyvNV5bWqb81+VfxuiU59skn97CVKSrCHbIji+z41jdRpV0CHGwAAAAD4WXzViLoppYF/DAffbinfH7qdeQ23lvLvdmrqGm4xYUKQSDyehteaCgxTGu9w8w80aqeU1v/J3djalIFddJHH7bA1XIv+QwruXAvXHVUeocMt2Pyp2bp6UpbxOoeT3C3wuTY0DTe+rgPQt7mG//h+NuccHSutUp8eTet6dnsCw51q/ymljhZ0uNW9NqagjjCpvsPNGjQlOOKmCS1Ywy3cz9Dj9crt8erdj/brpW27JUnzp2QbnW82W+iUUtUFdAP7OOWMtysno4cRfFotJtmsZtVu6yJ5ZdafqjN10N1d1yd/qMSqY6r+fy9Lku4fPUmOvPyA8ViMKaVdew03OtwAAAAAwI8paNF843iU/3oaNzxNWf2SWLOwEf7dVY0Fk4FruIVO84skeP2vwGsHBmwN7bgphW6aEOsX9CQ2suaZNahDqiELpmXrrPREzRh/VoPn+F4nU5hrheuOqqg6vcDNbDI1GrZJ0sXn9lO3OJvG5fQxHmM83u+5+tYjK62oDhmfw2Zpctgmhelwq/EYmxO0pMPN1/1X/xzqv0/9LqV+U0ob6XDzHfV1njX2s25IuJ+hVNup+HJd2CZJh0tOqrpul1K7MaW0fpy+mu+RGKOHb8zX9HEDjfFYzGaZTCZj51GLuXabmG/dyXo79Ro5zp8rS7+c2ufy2RZVvfeUvNWVxrVtTCmVRIcbAAAAADSJo5Fpd80xY3xmVK/XGTV10wRfUGAy1Qck0epwMwd3uJkb7nCzBnW4+Qcx/hsVBPN1BJnUeCffmOzeGpPdu8H7pfoON4vFFLDuoBS+O6rG3fCmCc1dX9AZb9dDN+bXr1PYQEgZHB4F7yZ6OkJ2Ka1xG1M3W7SGm29Kad1zcNXU14ojzHqB1qAON4fNYuy0GuuwGhsm+F/7dIT7GUrSibJT8q/iipM1xjRTW5gppf4hsy+k7e6s7Uz0Tae328w65XLLZjXL4/GqusYjq9Um+5Dxsg8Zr+qv/qhT7/9GNX9/X+V7P5IlNVPWjHNl6ZUriQ43AjcAAAAAaIK+KfEaMzRViY0EJ4iugMCtCR1uNovZCBVOp3uoqR1uwTtQhqzh5t/hVjeO3LN6au8/S3XekNQGv4cvqLNYTC2eYmz3W8g+eHz+YU3+sN7a8dfvVDCiT4O7yDpaEFT5h42+YQT/DGODdtxsqHurKRrrcIvUkdcY37RmXyjqv2GFOcy6bsFdkDH2hgO3aEwptZhNcnu8OlF+KuB4ZZXL6PL0BW7+4wpX85PO669B6YnK7JsoqbaGyuSS1WKW1+wL3OrHbB8yXubEVFW9v17eku/kPvBXuQ/8VdYYp86xD9efqwfK4/FGXNOusyJwAwAAAIAmMJlMWjB1aHsPo0sJ2KW0kT/ajcXeLWb1S61dbL9vz4Qmfx+Pt2kdbr4Aw2wy1a3zF9zh5r9hQe25N12ZI7fH22i4Ur9wfcvnLSclOPR/Lzxb3bs5VFa3O6mPf1gz+5IsnTuklwb3764TdVM6g7WkM8yf7zUM/hkGB2yxLVhrLWQNtxpPfYdbC66bl91bB/5VofxhtdNjw20EYA1Ygy9wnb8Yu0UlFbVfB4dlzdo0ISb4NbOq/KQrJHCrqKoxXs9wm2KE6+q0Wc3K6t/duO0Lb21Ws/E7EtyVZ00bovir7pPn6H7VHPxSrq+2yVt2WHMSPtAY1265SofLkZRy2s+zMyBwAwAAAAB0SPYmdrhZ/braCkakKfesno1O4QzW9E0TfMGR5HGHBkj+U/Z8nUAmkylit50vaLNGqRPoonP7SZLe//TbgOP+gZbdZtHwzJ6SAsftL3iH0uZKdsZo6IDuSkmKDTju2zShfnzNjyjiY2w6rCrjtsfjVWWVb0pp86/bt2e8bp4x3LjtCrMuWXCNmEwmI5T1/95xQcFfc9Zw83+NrBazHDaLyk+6VFIeGJpWVLmMIDrc1NXGujp9/Hc39dZNWA1XKyazRZaUAbKkDJA95yJVfbJZlR/9XoNs38n1lzfkmDCv6U+wE2HTBAAAAABAh+SwhU5LDMcXVPmCt9MJ26TGO9wCFsQ3B07NCwncwkwpbQprFDvc/GV9r3vA7YYCLXvQrqeD+ydJkqaPGxiVcZhNJv24aKTmTBrc6HhaErjNn5qtzL5O/fvlw4xjZZXVddeN3vqLwWvFSUGBW1CN+HcJRqXDze8aNqvZ+NmFTimtMTZnaGjKcCQOvw43m7X+68aYLDbFjJqmB0um6Z2Tw+Q+e3yzvndnQIcbAAAAAKBDampnkrUZ67b5O51NE6T6brvgrrvgTROayhe0nc5GD03RKylWQwcm64u9xyQ1vFtncDg4f+pQuWrc6tW9dXfQtVnNslvNqq4LhlqyhlufHvH62ezRAVNLK6LQ4RYsXIeb/8+9fqdPk2rcgdOig9esa86mCQGBm8VkTBc9Udfh1sMZo6OlVaqocqlbXG0Hoc3WvMDN12EaWNeRw0uTyaQSk1MbT47SeGdas753Z0CHGwAAAACgQ/LvcAsXdPj4ps41p2NIavqmCb7vYyyWH2GX0qayGB160V9cfnxufeDRUAdZ8FjtNnOrh20+/iFUSzrcfCxmc+jmDFFai06S0lNC1wa0hFvnr+6Y/3OKRodbwJRSq9kI9I6W1k6nTUmq3Wm0IqDDrXnP39c9V9vh5pte2rQa9T23xn5vOzs63AAAAAAAHZJ/IOEKs1i9j2/ap//0z9PR9DXcWmlKaQsDw8aMOKunBvbpJrfH2+AOu7XrzJlVUxeOWJv5OjZHnMNqrD8WjcBNkqxWk6pd9T/TaHa4zRifqRi7RWOH9jaOWRrocKv93vVhV3AHX0vXcJPqp08fOl4pSeqZFCvtOyFXjcfo8GvplFKr3+651iZeq7aW3SG7x3YlBG4AAAAAgA7J5Nep1Fjg5guSEuNtDZ7TmMY63MzhNk2oO9SUXUqboj4wjH6Hm9Vi1s/mjG500wmpNpTxBW6WVui0a4j/xgnRCtxsVouqXbXPxWQKXaOuJeJjbJpVeHbAMf/Xy9LKa7j577haU+NRYlxt7fueb3I3h0wmyeutX9etOVNXJf9dSi0a3D9J+w6VKTMtsUmP9f0uhNvVtasgcAMAAAAAdHj2RnbMzOzr1KLvD9P3Urs169qNb5pgCvm6oQ43a5hdSpvC6IpqhQ43qfEdXn1sVrNUt+5+awR/DYmL8d/FM0qBm18AFmO3BgS3rcEaJpT1vYb+O72Gdrid/s/b/2fpcnvkDAqZ42Nsio+xqfykS1XVbkmN/+40xtcZZ7WYNHnM93RJXv8m1VLtY2ofW9OFp5SyhhsAAAAAoMO6elKW8nN6K/esng2eYzKZdE5Wr9rpdKdhVuFZkqT5U7IbPCfcpgmOuimKMUFBRsCU0mZsmmBtw6ArmM0vXGntgMpfXMAaZ9FZa80/yIqJ4vptDfGfymwJ2lgjIdYmi9kku9UcsntuczvPfFw1HiUmOAKOxcVYA0JMKTD0Ox3+u5RKTQtufQjc6HADAAAAAHRgF+T21QW5fVvl2pec118FI9IancpoNpmUGG/XyVM1RpDxw4sGad+hMvVNiQ8413/dttNZw21A725KiLVp6MDk03wG0ePrgmqtLruGRHvTBCkwyIrWNRvjP6U0uMMtPsamf798mCwWs7L6Jykhtrb7rPbclr3WNW6vnHGBIV6cw6p4v9fUZJJSTjOI9omPtRnXPF31gRtruAEAAAAA0OU0JZC57QejVO1yG4vvDx2YHDYcszazwy0lKVYrbx53Wh1E0WZrpy67uEZ28Wwu/9e+bTrc/AK3oDXcLBaTRg5KMe6/8Jx0vf7B3tpzo7BWXmJCUOAWYw1YF69XUmyzO+nGDk1VWWW1xuX0Oe3HGmu4deEON6aUAgAAAADQiN7JcerfhPXh/DuWTjfkaM+wTZJsNt+U0raNCXzhkMkUvXDM/7XvkxwXlWs2xmQyGaGb7/Xz3Q7udCwcVd+t6esga4ngDrdYR+CU0j494oMf0mTd4uy68oJMpTbjNfSFz105cKPDDQAAAACAKLC1IHBrb0aHWxvuUCrVb5oQG8XNDcoqXMbXF45Oj8o1I7GYTXJ7vMb0Uv8ON3/d4uz6+dWjVVHlCgnLmiN4XbjgDre0noGBm9lkanSTkGixMaWUwA0AAAAAgGgI2DShjTvFWsq3I2Vbr+Hmm1IazbXW/nXipPH1gN7OqF23MRaLWarxGJ1tedmp8nqljLTEkHMH9onemGxWs+IcVlWeqpEkxTlsio/173AL7E4zm03ytEEIZmFKKVNKAQAAAACIBv/uMOuZ1uFmbZ8ppd27OQL+Hw1XXpAhu82iO2afE7VrRpKUYJfJJCXWdZxdOuZ7uufa85QQhWmjwfr1SpBUv36br8vNJCnGYVGco+EOt+COu9biC5xdXThwo8MNAAAAAIAosJ7BHW42a+36aW29aUJGmlPzp2bre01YI6+ppp+foR9cmq3ysirV1LRN4POjq0aotKJaiQnRCw4bctOVOdq08xtdNLqfpNqQ77tjlYp1WEPWAuwdtP6apY3WCvR1SrqZUgoAAAAAAFrijF7DrZ2mlJpMJo0d2jvq1/UFiG0lJSlWKUmxbfK9eibG6upJg43bvg4333p4bk99yBg8VbftOtxqv4+rjQLPjujMegcAAAAAAKCDaskupe3Nbm2fTRPQcr5prL718M4fkaa0nvH6fkFGyLnmNupgNDrcPF03cKPDDQAAAACAKAjYNKGNO6xaymZrnzXc0HLBHW7OOLuWX5cX9lxLGwVuxhpudLgBAAAAAICWsFnNslrMsphNirGdYYFbXUDSVoEMose3E2nPxMhTWhPjW3+NOak+uK1hDTcAAAAAANASVotZN0wfKrfHK4f9zArc7HUBIR1uZ56RZ6foR1eNUEaaM+K5C6Zm68mNX+qysQNadUy+qck17FIKAAAAAABaauSglPYeQrPYWMPtjGU2mzQ8s0eTzk1NjtPP5oxu5RH5d7h13cCN6BoAAAAAgC5uxFk9ldUvSeOG92nvoaATqO9wY0opAAAAAADoonolxeq2H4xq72Ggk7Ba6XCjww0AAAAAAABRw5RSAjcAAAAAAABEEbuUErgBAAAAAAAginolxUqSEhPs7TyS9tPhArc9e/bommuuUW5urvLz87VixQpVV1dHfJzX69WaNWs0fvx4DR8+XLNmzdInn3zS+gMGAAAAAACAIXtAd9097zwVFZ7d3kNpNx0qcCspKdHVV18tl8ulxx57TIsXL9ZLL72kBx98MOJj165dq0cffVRz587V6tWrlZKSonnz5mn//v1tMHIAAAAAAABIkslkUr9eCbJZO1Ts1KY61C6lL774oioqKvSrX/1KSUlJkiS32627775bCxcuVGpqatjHnTp1SqtXr9a8efM0d+5cSdI555yjSZMmad26dbrrrrva5gkAAAAAAACgy+tQUeP27ds1duxYI2yTpMmTJ8vj8WjHjh0NPu7jjz9WeXm5Jk+ebByz2+266KKLtH379tYcMgAAAAAAABCgQwVuxcXFysjICDjmdDqVkpKi4uLiRh8nKeSxmZmZ+vbbb1VVVRX9wQIAAAAAAABhdKgppaWlpXI6nSHHExMTVVJS0ujj7Ha7HA5HwHGn0ymv16uSkhLFxMQ0a0zWTjTf2FK3La/v/0AwagSRUCOIhBpBJNQIIqFGEAk1gkioEUTSFjXSoQK3jsZsNql79/j2HkbUOZ2x7T0EdHDUCCKhRhAJNYJIqBFEQo0gEmoEkVAjiKQ1a6RDBW5Op1NlZWUhx0tKSpSYmNjo46qrq3Xq1KmALrfS0lKZTKZGH9sYj8er0tLKZj22I7JYzHI6Y1VaelJut6e9h4MOiBpBJNQIIqFGEAk1gkioEURCjSASagSRNLdGnM7YJnfFdajALSMjI2SttrKyMh0+fDhkfbbgx0nS3r17NXjwYON4cXGx0tLSmj2dVJJqajrfL6fb7emUzwvRQ40gEmoEkVAjiIQaQSTUCCKhRhAJNYJIWrNGOtSE5oKCAn344YcqLS01jm3ZskVms1n5+fkNPm7UqFFKSEjQm2++aRxzuVx6++23VVBQ0KpjBgAAAAAAAPx1qA63oqIiPfvss1q0aJEWLlyoQ4cOacWKFSoqKlJqaqpx3tVXX61vv/1W77zzjiTJ4XBo4cKFeuyxx5ScnKxBgwbphRde0IkTJ3Tttde219MBAAAAAABAF9ShArfExEStX79e9957rxYtWqT4+HjNmDFDixcvDjjP4/HI7XYHHJs/f768Xq+eeuopHTt2TEOGDNG6devUr1+/tnwKAAAAAAAA6OJMXq/X296D6Kjcbo+OHato72FEjdVqVvfu8Tp+vIJ57AiLGkEk1AgioUYQCTWCSKgRREKNIBJqBJE0t0aSk+ObvGlCh1rDDQAAAAAAADjTEbgBAAAAAAAAUUTgBgAAAAAAAEQRgRsAAAAAAAAQRQRuAAAAAAAAQBQRuAEAAAAAAABRROAGAAAAAAAARBGBGwAAAAAAABBFBG4AAAAAAABAFBG4AQAAAAAAAFFE4AYAAAAAAABEEYEbAAAAAAAAEEUEbgAAAAAAAEAUmbxer7e9B9FReb1eeTyd6+WxWMxyuz3tPQx0YNQIIqFGEAk1gkioEURCjSASagSRUCOIpDk1YjabZDKZmnQugRsAAAAAAAAQRUwpBQAAAAAAAKKIwA0AAAAAAACIIgI3AAAAAAAAIIoI3AAAAAAAAIAoInADAAAAAAAAoojADQAAAAAAAIgiAjcAAAAAAAAgigjcAAAAAAAAgCgicAMAAAAAAACiiMANAAAAAAAAiCICNwAAAAAAACCKCNwAAAAAAACAKCJwAwAAAAAAAKKIwK0L2LNnj6655hrl5uYqPz9fK1asUHV1dXsPC23gm2++0bJlyzR9+nRlZ2drypQpYc97+eWXdckllygnJ0fTpk3Ttm3bQs4pKyvTHXfcofPOO08jR47UzTffrH/961+t/RTQyt58803dcMMNKigoUG5urqZPn65XXnlFXq834DxqpOt677339MMf/lBjxozRsGHDdOGFF+qBBx5QWVlZwHl/+MMfNG3aNOXk5OiSSy7Rhg0bQq5VXV2tX/ziF8rPz1dubq6uueYaFRcXt9VTQRuoqKhQQUGBsrKy9Pnnnwfcx/tI1/Xqq68qKysr5L//+q//CjiPGsFrr72myy+/XDk5OcrLy9N1112nqqoq434+a7qu2bNnh30fycrK0qZNm4zzeB/p2rZu3aqrrrpKI0eO1Lhx43TLLbdo//79Iee1VZ2YvMF/VaFTKSkp0WWXXaYBAwZo4cKFOnTokB588EFNmzZNy5Yta+/hoZW9++67uvfeezVixAjt3btXXq9XGzduDDhn06ZN+vGPf6zrr79eY8aM0ebNm7Vhwwb99re/VW5urnHetddeq927d+u2226Tw+HQypUrZTabtWHDBlmt1jZ+ZoiWWbNmqW/fvpo4caK6d++uDz/8UE8++aQWLVqkG2+8URI10tW9/vrr+tvf/qYRI0YoKSlJ//jHP/TYY49p6NCheuqppyRJH330kebMmaMZM2bo0ksv1f/8z/9o1apVWrlypSZNmmRca9myZdq8ebOWLFmi1NRUrVq1Svv379emTZvUrVu39nqKiKL//M//1H//93/ryJEjeuWVV5STkyOJ95Gu7tVXX9Xtt9+uJ598MuB3PTU1VX369JFEjUB64okntHbtWl1//fXKzc3V8ePHtXPnTv30pz9VfHw8nzVd3O7du1VeXh5wbP369Xr77bf1/vvvKzk5mfeRLm7Xrl2aO3euLr/8ck2dOlUnTpzQI488Io/HozfeeEMxMTGS2vjzxotObdWqVd7c3Fzv8ePHjWMvvviid8iQId7vvvuu/QaGNuF2u42vb7vtNu9ll10Wcs7FF1/svfXWWwOOzZo1y3vdddcZtz/++GPvoEGDvO+//75xbM+ePd6srCzvpk2bWmHkaCtHjx4NObZ06VLvqFGjjPqhRhDsd7/7nXfQoEHG58i8efO8s2bNCjjn1ltv9U6ePNm4/c9//tM7ZMgQ74svvmgcO378uDc3N9e7Zs2athk4WtXu3bu9ubm53hdeeME7aNAg72effWbcx/tI17ZhwwbvoEGDwn7m+FAjXduePXu82dnZ3j/+8Y8NnsNnDYIVFhZ658+fb9zmfaRr+/nPf+4tLCz0ejwe49jOnTu9gwYN8v7pT38yjrVlnTCltJPbvn27xo4dq6SkJOPY5MmT5fF4tGPHjvYbGNqE2dz4r/j+/fv19ddfa/LkyQHHL730Uu3cudOYerx9+3Y5nU7l5+cb52RkZGjIkCHavn179AeONpOcnBxybMiQISovL1dlZSU1grB8nykul0vV1dXatWtXQHeBVFsje/bs0YEDByRJH3zwgTweT8B5SUlJys/Pp0Y6ieXLl6uoqEgDBw4MOM77CCKhRvDqq68qPT1dF1xwQdj7+axBsI8//lgHDhzQ1KlTJfE+Aqmmpkbx8fEymUzGMV9Xq7duYmdb1wmBWydXXFysjIyMgGNOp1MpKSmsZQCjBoL/OMrMzJTL5TLmuxcXF2vgwIEBb15S7ZsOddT5/PnPf1ZqaqoSEhKoERjcbrdOnTqlL774Qr/+9a9VWFio9PR07du3Ty6XK+SzJjMzU1L9+0xxcbF69OihxMTEkPOokTPfli1b9Pe//12LFi0KuY/3EfhMmTJFQ4YM0YUXXqjVq1fL7XZLokYgffrppxo0aJAef/xxjR07VsOGDVNRUZE+/fRTSeKzBiE2btyouLg4XXjhhZJ4H4F0xRVXaM+ePfrtb3+rsrIy7d+/Xw899JCys7M1atQoSW1fJwRunVxpaamcTmfI8cTERJWUlLTDiNCR+GoguEZ8t333l5aWhl3zgjrqfD766CNt3rxZ8+bNk0SNoN6ECRM0fPhwXXHFFUpJSdEvf/lLSS2vEafTSY2c4U6ePKkHH3xQixcvVkJCQsj9vI8gJSVFN910k37xi19o7dq1uuCCC7Ry5Urdd999kqgRSIcPH9YHH3yg119/XXfeead+/etfy2Qyad68eTp69CifNQhQU1OjN998U4WFhYqLi5PE+wik0aNH61e/+pV++ctfavTo0Zo4caKOHj2qtWvXymKxSGr7OmFFQACAJOm7777T4sWLlZeXpzlz5rT3cNDBrFmzRidPntTu3bv1xBNP6Prrr9fTTz/d3sNCB/DEE0+oR48euvLKK9t7KOigzj//fJ1//vnG7XHjxsnhcGj9+vW6/vrr23Fk6Ci8Xq8qKyv1yCOPaPDgwZKkESNGqLCwUM8995zGjRvXziNER7Jjxw4dO3ZMU6ZMae+hoAP5+OOP9R//8R+aOXOmxo8frxMnTujxxx/XggUL9PzzzxubJrQlOtw6OafTqbKyspDjJSUlIa3W6Hp8NRBcI6WlpQH3O53OkF2BJOqoMyktLdX8+fOVlJSkxx57zFj/jxqBz+DBgzVy5EhdddVVevzxx7Vr1y698847La6R0tJSauQMdvDgQT311FO6+eabVVZWptLSUlVWVkqSKisrVVFRwfsIwpo8ebLcbre++uoragRyOp1KSkoywjapdu217Oxs7d69m88aBNi4caOSkpICgljeR7B8+XKNGTNGS5Ys0ZgxYzRp0iStWbNGX375pV5//XVJbV8nBG6dXLg5xmVlZTp8+HDIGgjoenw1EFwjxcXFstls6tevn3He3r17jcUmffbu3UsddQJVVVVauHChysrK9OSTTwa0T1MjCCcrK0s2m0379u1T//79ZbPZwtaIVF9DGRkZOnLkSEgbfri1RnHmOHDggFwulxYsWKBzzz1X5557rtGxNGfOHF1zzTW8jyAiagRnnXVWg/edOnWKzxoYqqqq9O6772rSpEmy2WzGcd5HsGfPnoDQXpJ69+6t7t27a9++fZLavk4I3Dq5goICffjhh0ZiK9UubGw2mwN23EDX1K9fPw0YMEBbtmwJOL5582aNHTtWdrtdUm0dlZSUaOfOncY5e/fu1ZdffqmCgoI2HTOiq6amRj/60Y9UXFysJ598UqmpqQH3UyMI59NPP5XL5VJ6errsdrvy8vL01ltvBZyzefNmZWZmKj09XVLtFDKz2ay3337bOKekpEQffPABNXIGGzJkiJ555pmA/26//XZJ0t13360777yT9xGEtXnzZlksFmVnZ1Mj0IQJE3TixAl99dVXxrHjx4/riy++0NChQ/msgeEPf/iDKisrjd1JfXgfQVpamr788suAYwcPHtTx48fVt29fSW1fJ6zh1skVFRXp2Wef1aJFi7Rw4UIdOnRIK1asUFFRUcgf1uh8Tp48qffee09S7ZtNeXm58eZy3nnnKTk5WTfddJN+8pOfqH///srLy9PmzZv12Wef6bnnnjOuM3LkSI0bN0533HGHbrvtNjkcDj388MPKysrSxRdf3C7PDdFx9913a9u2bVqyZInKy8v1ySefGPdlZ2fLbrdTI13cjTfeqGHDhikrK0sxMTH63//9X61bt05ZWVmaOHGiJOmGG27QnDlzdNddd2ny5MnatWuXNm7cqIcffti4Tu/evTVjxgytWLFCZrNZqampWr16tbp166aioqL2enpoIafTqby8vLD3DR06VEOHDpUk3ke6uGuvvVZ5eXnKysqSJG3dulUvvfSS5syZo5SUFEnUSFc3ceJE5eTk6Oabb9bixYvlcDi0Zs0a2e12/du//ZskPmtQ64033lBaWprOOeeckPt4H+naioqKdP/992v58uUqLCzUiRMnjHVmJ0+ebJzXlnVi8gb3yKHT2bNnj+6991795S9/UXx8vKZPn67Fixcb6S06rwMHDhhbZQd75plnjD+SXn75Za1du1bffvutBg4cqFtvvVUTJkwIOL+srEwPPPCA3nnnHdXU1GjcuHFaunQpwe0ZrrCwUAcPHgx739atW41/MaZGuq41a9Zo8+bN2rdvn7xer/r27auLLrpI1157bcCOlFu3btXKlSu1d+9epaWlacGCBZoxY0bAtaqrq/Xwww/r9ddfV0VFhUaNGqWlS5cqMzOzrZ8WWtGuXbs0Z84cvfLKK8rJyTGO8z7SdS1fvlzvv/++vvvuO3k8Hg0YMEBXXXWVZs+eLZPJZJxHjXRtx44d0wMPPKBt27bJ5XJp9OjRuv322wOmm/JZ07WVlJQoPz9fV199tX7605+GPYf3ka7L6/XqxRdf1AsvvKD9+/crPj5eubm5Wrx4ccjvf1vVCYEbAAAAAAAAEEWs4QYAAAAAAABEEYEbAAAAAAAAEEUEbgAAAAAAAEAUEbgBAAAAAAAAUUTgBgAAAAAAAEQRgRsAAAAAAAAQRQRuAAAAAAAAQBQRuAEAAKBVvPrqq8rKytLnn3/e3kMBAABoUwRuAAAAnYQv4PL/b+zYsZo9e7bee++9Zl1z1apVevfdd6M8UgAAgM7N2t4DAAAAQHTdfPPNSk9Pl9fr1dGjR/Xaa69pwYIFWrVqlSZMmHBa11q9erUuueQSTZw4sZVGCwAA0PkQuAEAAHQyBQUFysnJMW7PmDFD+fn52rhx42kHbgAAADh9TCkFAADo5JxOpxwOh6zW+n9rXbdunYqKipSXl6fhw4friiuu0JYtWwIel5WVpcrKSr322mvGFNUlS5YY9x86dEh33HGHxo0bp2HDhqmwsFB33nmnqqurA65TXV2tBx54QGPGjFFubq4WLVqkY8eOte6TBgAAaEd0uAEAAHQy5eXlRqB19OhRPfvss6qsrNS0adOMc5555hkVFhZq6tSpcrlc2rRpk2655RatXr1a48ePlyStWLFCS5cu1fDhwzVz5kxJUv/+/SXVhm0zZsxQWVmZZs6cqYyMDB06dEhvvfWWqqqqZLfbje+1fPlyOZ1O3XjjjTp48KDWr1+ve+65RytXrmybFwQAAKCNEbgBAAB0MnPnzg24bbfbdf/99ys/P9849tZbbykmJsa4/YMf/EBXXHGFnn76aSNwmz59uu666y7169dP06dPD7jmQw89pCNHjuill14KmL56yy23yOv1BpyblJSkp556SiaTSZLk8Xj07LPPqqysTN26dYvGUwYAAOhQCNwAAAA6mWXLlmngwIGSpCNHjuj3v/+9li5dqvj4eF188cWSFBC2lZSUyO1265xzztGmTZsiXt/j8ejdd9/VhAkTAsI2H1+w5jNz5syAY6NHj9ZvfvMbHTx4UIMHD27WcwQAAOjICNwAAAA6meHDhwcEYVOmTNHll1+ue+65R+PHj5fdbte2bdv0xBNP6KuvvgpYcy04LAvn2LFjKi8v19lnn92k8aSlpQXcdjqdkqTS0tImPR4AAOBMQ+AGAADQyZnNZuXl5emZZ57RN998o5KSEt1www0699xzdeeddyolJUU2m00bNmzQxo0bW+X7hxM89RQAAKCzIHADAADoAtxutySpsrJSb731lhwOh9atWxewucGGDRuadK3k5GQlJCToH//4R6uMFQAA4EwX/p8bAQAA0Gm4XC7t2LFDNptNmZmZslgsMplMRggnSQcOHNDWrVtDHhsXFxcy9dNsNmvixInatm2bPv/885DH0LkGAAC6OjrcAAAAOpnt27eruLhYUu16a2+88Ya+/vprLViwQAkJCbrgggv09NNP67rrrtOUKVN09OhRPf/88+rfv7/+9re/BVxr6NCh2rlzp55++mn16tVL6enpGjFihG699Vbt2LFDs2fP1syZM5WZmanDhw9ry5Ytev7554112gAAALoiAjcAAIBO5tFHHzW+djgcysjI0F133aWioiJJ0tixY3Xfffdp7dq1uv/++5Wenq6f/OQnOnjwYEjgtmTJEi1btkwrV65UVVWVvv/972vEiBFKTU3VSy+9pEceeURvvPGGysvLlZqaqoKCgoAdUAEAALoik5eefwAAAAAAACBqWMMNAAAAAAAAiCICNwAAAAAAACCKCNwAAAAAAACAKCJwAwAAAAAAAKKIwA0AAAAAAACIIgI3AAAAAAAAIIoI3AAAAAAAAIAoInADAAAAAAAAoojADQAAAAAAAIgiAjcAAAAAAAAgigjcAAAAAAAAgCgicAMAAAAAAACiiMANAAAAAAAAiKL/D9T7RUsD+GhhAAAAAElFTkSuQmCC\n"
+          },
+          "metadata": {}
+        }
+      ],
+      "source": [
+        "%matplotlib inline\n",
+        "plt.figure(figsize=(15,8))\n",
+        "plt.title(\"Training loss\")\n",
+        "plt.xlabel(\"Batch\")\n",
+        "plt.ylabel(\"Loss\")\n",
+        "plt.plot(train_lossv, label='original')\n",
+        "plt.plot(np.convolve(train_lossv, np.ones(101), 'same') / 101,\n",
+        "         label='averaged')\n",
+        "plt.legend(loc='best')\n",
+        "plt.show()"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "Let's visualize the loss trend on the training and evaluation dataset per epoch.\n",
+        "\n",
+        "As said before, the training loss is decaying, but the validation loss is increasing after the second epoch. This is a signal of overfitting: the model is not really learning from the training set, but rather memorizing it, which hurts its capacility to generalize on the validation set."
+      ],
+      "metadata": {
+        "id": "x601NrqszrIw"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "# Calculate epoch-level losses → lists w/ the avg loss for each epoch\n",
+        "# len(dataloader): number of batches to process the entire dataset in one epoch\n",
+        "  #for i in range(0, len(lossv), len(dataloader): we iterate over the entire loss vector, w/ a step equal to the n. of batches in one epoch (aka step = one epoch)\n",
+        "  #lossv[i:i + len(dataloader)]: we slice the loss vector to select the batch losses for one epoch → over this slice, we calculate the avg → avg loss for the epoch\n",
+        "epoch_train_loss = [np.mean(train_lossv[i:i + len(train_dataloader)]) for i in range(0, len(train_lossv), len(train_dataloader))]\n",
+        "epoch_eval_loss = [np.mean(eval_lossv[i:i + len(validation_dataloader)]) for i in range(0, len(eval_lossv), len(validation_dataloader))]\n",
+        "\n",
+        "# Plot\n",
+        "plt.figure(figsize=(10, 6))\n",
+        "plt.plot(range(1, len(epoch_train_loss) + 1), epoch_train_loss, label='Training Loss', color='blue')\n",
+        "plt.plot(range(1, len(epoch_eval_loss) + 1), epoch_eval_loss, label='Validation Loss', color='orange')\n",
+        "plt.xlabel('Epoch')\n",
+        "plt.ylabel('Loss')\n",
+        "plt.title('Training and Validation Loss (Epoch Level)')\n",
+        "plt.legend()\n",
+        "plt.show()"
+      ],
+      "metadata": {
+        "id": "vNnBW7gmzzHY",
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 573
+        },
+        "outputId": "51d1b26f-b2f4-4c87-f6d0-114cb2a6b61d"
+      },
+      "execution_count": 31,
+      "outputs": [
+        {
+          "output_type": "display_data",
+          "data": {
+            "text/plain": [
+              "<Figure size 1000x600 with 1 Axes>"
+            ],
+            "image/png": "iVBORw0KGgoAAAANSUhEUgAAA1cAAAIsCAYAAAAeUFNGAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjguMCwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy81sbWrAAAACXBIWXMAAA9hAAAPYQGoP6dpAACbzUlEQVR4nOzdd3xT1f/H8Vd2m5RCCxSVoYIW+cqWIXuj7B+CgiKiooCCiKAsJ4JsRJaK4gQRGSJ7isoQEByoiAucqGwopG3m/f1RKdQyCm1Jmr6fjwcPzT03N5/0JGnePfecazIMw0BERERERESyxRzqAkRERERERCKBwpWIiIiIiEgOULgSERERERHJAQpXIiIiIiIiOUDhSkREREREJAcoXImIiIiIiOQAhSsREREREZEcoHAlIiIiIiKSAxSuREREREREcoDClYhEnMGDB9O4ceOLuu+UKVMoW7ZsDlcUXv7880/Kli3L+++/f8kfu2zZskyZMiX99vvvv0/ZsmX5888/z3vfxo0bM3jw4BytJzuvlfxk+fLl1KhRA7fbHepSsqxx48b07Nkz1GXkiv++bo8cOULlypX55JNPQliViIDClYhcQmXLls3Sv61bt4a61HxvxIgRlC1blt9+++2s+0ycOJGyZcvy/fffX8LKLty+ffuYMmUKu3btCnUp6U4G3Ndeey3UpZxXIBBgypQp3HnnnbhcrvTtjRs3Put7uHv37iGsOGeULVuWZ599NtRlZElcXBwdO3Zk0qRJoS5FJN+zhroAEck/xo4dm+H2okWL2LRpU6btZcqUydbjDB8+HMMwLuq+DzzwAD169MjW40eCNm3aMHPmTJYsWUKfPn3OuM/SpUtJTEzkuuuuu+jHadeuHa1atcJut1/0Mc5n//79TJ06leLFi1OuXLkMbdl5reQXH330Eb/88gudOnXK1FauXDnuueeeTNsTEhIuRWlymttvv52ZM2eyefNmatWqFepyRPIthSsRuWTatWuX4faOHTvYtGlTpu3/lZKSQnR0dJYfx2azXVR9AFarFatVH42VKlXiyiuvZNmyZWcMV19++SV//vknAwYMyNbjWCwWLBZLto6RHdl5reQXCxYsoGrVqhQrVixTW7Fixc77/pVLo0yZMiQmJrJw4UKFK5EQ0mmBIhJWunbtSuvWrfn222/p0qULlSpV4vnnnwdg7dq19OjRg7p161K+fHmaNm3KtGnTCAQCGY7x3/kIp5+C9d5779G0aVPKly9Phw4d+PrrrzPc90xzrk6eHrR27Vpat25N+fLladWqFevXr89U/9atW7nllluoUKECTZs2Zc6cOVmex7V9+3b69u1Lw4YNKV++PA0aNGDkyJGkpqZmen5VqlRh3759PPjgg1SpUoUbb7yRMWPGZPpZJCUlMXjwYG644QaqVavGoEGDOH78+HlrgbTRqz179rBz585MbUuXLsVkMtG6dWu8Xi+TJk3illtu4YYbbqBy5crccccdbNmy5byPcaY5V4Zh8OKLL1K/fn0qVapE165d+emnnzLd9+jRo4wZM4Y2bdpQpUoVqlatyn333ZfhNMWtW7fSsWNHAIYMGZJ+2trJ+WZnmnOVnJzM6NGjadCgAeXLl+emm27itddeyzTCdSGvi4t16NAhhg4dSu3atalQoQJt27Zl4cKFmfZbtmwZt9xyS/rPoU2bNrz11lvp7T6fj6lTp9K8eXMqVKhAzZo1uf3229m0adM5H9/j8bBhwwZq16590c/h5Ov1jz/+oHv37lSuXJm6desyderUTD/TrP7sIW3ku2PHjlSqVInq1avTpUsXNm7cmGm/7du307FjRypUqECTJk344IMPLvq5/FcwGOTNN9+kVatWVKhQgdq1a/PUU09x7Nix9H169uxJkyZNznj/Tp06ccstt2R6XrfccgsVK1akRo0aPPLII/z9999Zqqd27dp89NFHGo0VCSH9eVZEws7Ro0e5//77adWqFW3btqVw4cIALFy4EKfTyT333IPT6WTLli1MnjyZEydOMGjQoPMed+nSpbjdbjp16oTJZGLGjBk89NBDrF279rwjGJ9//jmrV6/mjjvuwOVyMXPmTPr27ctHH31EXFwcAN999x333XcfRYsW5aGHHiIYDDJt2jTi4+Oz9LxXrlxJamoqt99+O4UKFeLrr79m1qxZ/PPPP0yePDnDvoFAgO7du1OxYkUGDhzI5s2bef311ylZsiR33HEHkBZSHnzwQT7//HM6d+5MmTJlWLNmTZZ+VpAWrqZOncrSpUu5/vrrMzz2ihUrqFatGldccQWHDx9m3rx5tG7dmltvvRW32838+fO57777mDdvXqZT8c5n0qRJvPTSSzRo0IAGDRqwc+dO7r33Xnw+X4b9/vjjD9auXcvNN99MiRIlOHjwIO+99x533nkny5Yto1ixYpQpU4a+ffsyefJkOnXqxA033ABA1apVz/jYhmHwwAMPpIeycuXKsWHDBsaOHcu+ffsYOnRohv2z8rq4WKmpqXTt2pXff/+dLl26UKJECVauXMngwYNJSkqiW7duAGzatIn+/ftTq1YtHn30UQD27NnDF198kb7P1KlTmT59OrfeeisVK1bkxIkTfPvtt+zcuZM6deqctYZvv/0Wn8/H//73vzO2+/1+Dh8+nGm70+kkKioq/XYgEOC+++6jUqVKPPbYY2zYsIEpU6YQCAR4+OGHgQv72U+dOpUpU6ZQpUoV+vbti81mY8eOHWzZsoW6deum7/fbb7/x8MMP07FjR9q3b8+CBQsYPHgw119/Pddee21Wu+KsnnrqKRYuXMgtt9xC165d+fPPP3nnnXf47rvvePfdd7HZbLRo0YJBgwbx9ddfU7FixfT77t27l6+++oqBAwemb3vppZeYNGkSLVq0oGPHjhw+fJhZs2bRpUsXPvjgA2JjY89Zz/XXX8+bb77JTz/9RGJiYrafn4hcBENEJESGDRtmJCYmZth25513GomJica7776baf+UlJRM25588kmjUqVKhsfjSd82aNAgo1GjRum3//jjDyMxMdGoUaOGcfTo0fTta9euNRITE41169alb5s8eXKmmhITE43rr7/e+O2339K37dq1y0hMTDRmzpyZvq1nz55GpUqVjH/++Sd926+//mr873//y3TMMznT85s+fbpRtmxZY+/evRmeX2JiojF16tQM+/7f//2f0b59+/Tba9asMRITE41XX301fZvf7zfuuOMOIzEx0ViwYMF5a+rQoYNRv359IxAIpG9bv369kZiYaMyZMyf9mKf//A3DMI4dO2bUrl3bGDJkSIbtiYmJxuTJk9NvL1iwwEhMTDT++OMPwzAM49ChQ8b1119v9OjRwwgGg+n7Pf/880ZiYqIxaNCg9G0ejydDXYaR1tfly5fP8LP5+uuvz/p8//taOfkze/HFFzPs99BDDxlly5bN8BrI6uviTE6+JmfMmHHWfd58800jMTHRWLRoUfo2r9drdOrUyahcubJx/PhxwzAMY8SIEUbVqlUNv99/1mO1bdvW6NGjxzlrOpO5c+caiYmJxg8//JCprVGjRkZiYuIZ/02fPj19v5Ov1+HDh6dvCwaDRo8ePYzrr7/eOHTokGEYWf/Z//rrr8Z1111n9O7dO1P/n/6aOVnftm3b0rcdOnTIKF++vDF69OjzPvfExERj2LBhZ23ftm2bkZiYaCxevDjD9pPvj5Pbjx8/fsbHfPXVVzO8t//880+jXLlyxksvvZRhvx9++MH43//+l2H7f1+3J33xxRdGYmKisWzZsvM+PxHJHTotUETCjt1uz3SqDJDhL+EnTpzg8OHDVKtWjZSUFPbs2XPe47Zs2ZKCBQum365WrRqQNgJyPrVr16ZUqVLpt6+77jpiYmLS7xsIBNi8eTNNmjTJMDflyiuvpF69euc9PmR8fsnJyRw+fJgqVapgGAbfffddpv1vv/32DLdvuOGGDKfXrV+/HqvVmmE/i8XCnXfemaV6ANq2bcs///zDtm3b0rctXboUm83GzTffnH7MkwtSBINBjh49it/vp3z58mes+1w+/fRTfD4fd955JyaTKX37yRGY09ntdszmtF9jgUCAI0eO4HQ6ufrqqy/4cU9av349FouFrl27Zth+7733YhhGplP+zve6yI7169dTtGhRWrdunb7NZrPRtWtXkpOT0/skNjaWlJSUc57iFxsby08//cSvv/56QTUcPXoUIMP75nSVKlXijTfeyPSvVatWmfbt0qVL+v+bTCa6dOmCz+dj8+bN6c83Kz/7tWvXEgwG6d27d3r/n37c011zzTXp73OA+Ph4rr766hzpn5UrV1KgQAHq1KnD4cOH0/9df/31OJ3O9FVPY2JiqF+/PitWrMhwut7y5cupXLkyV1xxBQBr1qwhGAzSokWLDMcrUqQIV155ZZZWUT05snXkyJFsPz8RuTg6LVBEwk6xYsXOuHrcTz/9xAsvvMCWLVs4ceJEhraszCO6/PLLM9w++YUxKSnpgu978v4n73vo0CFSU1O58sorM+13pm1n8tdffzF58mTWrVuXYc4GkOn5OhyOTKcbFixYMMP99u7dS9GiRTMsnw1w9dVXZ6kegFatWjF69GiWLl1KzZo18Xg8rFmzhvr162f4wr1w4UJef/11fvnllwyn75UoUSLLjwVpPwOAq666KsP2+Pj4TF/wg8Egb7/9NrNnz+bPP//MMN+sUKFCF/S4J+3du5eEhARiYmIybD+5guXevXszbD/f6yI79u7dy5VXXpkpQJys5eTP6o477mDFihXcf//9FCtWjDp16tCiRQvq16+ffp++ffvy4IMPctNNN5GYmEjdunVp165dlld6NM4yhycuLi5L87HMZjMlS5bMsO3k6/DkzzSrP/vff/8ds9mcpVVFz9Y//31/XYzffvuN48ePn3XxiEOHDqX/f8uWLVm7di1ffvklVatW5ffff2fnzp0ZTnX89ddfMQyD5s2bn/F4F7LQzn9DpohcOgpXIhJ2Th/BOSkpKYk777yTmJgY+vbtS6lSpXA4HOzcuZPx48cTDAbPe9yzrUp3ti+OOXXfrAgEAtxzzz0cO3aM++67j9KlS+N0Otm3bx+DBw/O9Pwu1Qp7hQsXpnbt2qxevZqnnnqKdevW4Xa7adOmTfo+ixYtYvDgwTRt2pTu3btTuHBhLBYL06dPz5ERgrN5+eWXmTRpEh06dODhhx+mYMGCmM1mRo4ceckm9Of26yIrChcuzAcffMDGjRtZv34969ev5/333+f//u//GDNmDADVq1dnzZo1fPjhh2zatIn58+fz1ltvMWzYMG699dazHvtkSD127BiXXXbZpXg6OSo33yfBYJDChQszfvz4M7af/sePRo0aER0dzYoVK6hatSorVqzAbDanj/6ePJ7JZOLVV189Y91Op/O8NZ0Mjdmd7yciF0/hSkTyhM8++4yjR48ydepUqlevnr799NPgQqlw4cI4HI4zXnT3XBfiPenHH3/k119/ZcyYMfzf//1f+vbzreZ2LsWLF2fLli243e4Mo1e//PLLBR2nTZs2bNiwgfXr17N06VJiYmIyrLC3atUqSpYsydSpUzP8xfy/i3BkxclTpH799dcMIx2HDx/ONNqwatUqatasyciRIzNsT0pKyvDl8kL+il+8eHE2b97MiRMnMoygnDzttHjx4ll/MtlUvHhxfvjhB4LBYIbRq5O1nPxZQdopko0bN6Zx48YEg0GeeeYZ3nvvPR588MH0kdNChQrRoUMHOnTogNvt5s4772TKlCnnDFelS5cGTq24ebGCwSB//PFHhlHTk6/Dkz/TrP7sS5UqRTAYZPfu3Re8WEpOKlWqFJs3b6Zq1apn/IPQ6ZxOJw0bNmTlypUMGTKE5cuXU61atQynEJcqVQrDMChRosQFjS6f7uTnYXavFSgiF09zrkQkTzj55fL0EQGv18vs2bNDVVIGFouF2rVr8+GHH7Jv37707b/99hsbNmw47/3P9PwMw+Dtt9++6Jrq16+P3+/n3XffTd8WCASYNWvWBR2nadOmREdHM3v2bNavX0/z5s1xOBzp7Sf/yn567Tt27OCrr7664Jpr166NzWZj1qxZGY53+rLipz/uf0eIVqxYkeHnD6RfIy0rp+rVr1+fQCDAO++8k2H7m2++iclkynCqXW6rX78+Bw4cYPny5enb/H4/M2fOxOl0pv+R4b/za8xmc3oQ8nq9Z9zH5XJRqlSp9PazKV++PDabjW+//Tbbz+f0n6lhGLzzzjvYbLb00+qy+rNv2rQpZrOZadOmZRrRvZQjhi1atCAQCPDiiy9mavP7/Zleby1btmT//v3MmzeP77//nhYtWmRob968ORaL5YxL1BuGkaV5VDt37qRAgQI5shKiiFwcjVyJSJ5QpUoVChYsyODBg+natSsmk4lFixaF1fVc+vTpw8aNG7n99tu5/fbbCQaDzJo1i2uvvZZdu3ad876lS5emVKlSjBkzhn379hETE8OqVauyNXencePGVK1alQkTJrB3716uueYaVq9eneXrXJ3kcrlo0qQJS5cuBchwSiBAw4YNWb16Nb1796Zhw4b8+eefzJkzh2uuuYbk5OQLeqz4+Hjuvfdepk+fTs+ePWnQoAHfffcd69evz3SqU8OGDZk2bRpDhgyhSpUq/PjjjyxZsiTT3J5SpUoRGxvLnDlzcLlcOJ1OKlasmGk/SPuZ1axZk4kTJ7J3717Kli3Lpk2b+PDDD+nWrVuGxStywubNm/F4PJm2N23alE6dOvHee+8xePBgdu7cSfHixVm1ahVffPEFQ4cOTR/deeKJJzh27Bg33ngjxYoV46+//mLWrFmUK1cufQSjVatW1KhRg+uvv55ChQrxzTffsGrVqvMubuJwOKhbty6bN29OXzL9dPv27WPRokWZtrtcLpo2bZrhOBs2bGDQoEFUrFiRDRs28PHHH9OrV6/00+ey+rO/8sor6dWrFy+++CJ33HEHzZs3x263880335CQkJDtC1uf7ttvvz1jeKpRowY1atSgU6dOTJ8+nV27dlGnTh1sNhu//vorK1eu5PHHH89w2l+DBg1wuVyMGTMGi8XCTTfdlOGYpUqVol+/funv16ZNm+Jyufjzzz9Zu3Ytt912G927dz9nvZ9++imNGjXSnCuREFK4EpE8IS4ujpdffpkxY8bwwgsvEBsbS9u2balVq9Z5v3BcKuXLl+fVV19l7NixTJo0icsvv5y+ffuyZ8+e865maLPZePnllxkxYgTTp0/H4XDQrFkzunTpQrt27S6qHrPZzEsvvcTIkSNZvHgxJpOJxo0bM3jw4AynHmZF27ZtWbp0KUWLFuXGG2/M0HbLLbekX2Nq48aNXHPNNYwbN46VK1fy2WefXXDd/fr1w263M2fOHLZu3UrFihV5/fXX6dmzZ4b9evXqRUpKCkuWLGH58uX873//Y/r06UyYMCHDfjabjdGjR/P888/zzDPP4Pf7GTVq1BnD1cmf2eTJk1m+fDnvv/8+xYsXZ+DAgdx7770X/FzOZ8OGDWcc2SxevDiJiYnMnDmT8ePHs3DhQk6cOMHVV1/NqFGjMqym2bZtW+bOncvs2bNJSkqiaNGitGjRgoceeih9RLRr166sW7eOTZs24fV6ueKKK+jXr1+W3jsdOnTgoYce4u+//860QMSuXbsyXKfp9PpPD1cWi4UZM2bwzDPPMG7cOFwuF3369KF3797p+1zIz/7hhx+mRIkSzJo1i4kTJxIdHU3ZsmUv+r1yNjt27GDHjh2Ztj/88MNUq1aNZ599lvLlyzNnzhwmTpyIxWKhePHitG3bNtO11BwOB40bN2bJkiXUrl07/fp9p+vRowdXXXUVb775JtOmTQPgsssuo06dOpkudv1fu3fv5scff8x0LTYRubRMRjj92VdEJAI9+OCD/Pzzz6xevTrUpYhcsEAgQMuWLWnRogX9+vW74PsPHjyYVatW8eWXX+Z8cZLuueeeY/v27bz//vsauRIJIc25EhHJQampqRlu//rrr6xfv54aNWqEqCKR7LFYLDz88MPMnj0bt9sd6nLkDI4cOcL8+fPp16+fgpVIiOm0QBGRHNS0aVPat29PyZIl2bt3L3PmzMFms3HfffeFujSRi9ayZUtatmwZ6jLkLOLi4jQyKBImFK5ERHJQvXr1WLZsGQcOHMBut1O5cmX69++f6aK4IiIiEnk050pERERERCQHaM6ViIiIiIhIDlC4EhERERERyQEKVyIiIiIiIjlAC1qcg2EYBIPhMSXNbDaFTS2Sc9SvkUd9GnnUp5FJ/Rp51KeRKVz61Ww2ZelSBwpX5xAMGhw+HPprelitZuLiXCQlJeP3B0NdjuQQ9WvkUZ9GHvVpZFK/Rh71aWQKp36Nj3dhsZw/XOm0QBERERERkRygcCUiIiIiIpIDFK5ERERERERygMKViIiIiIhIDlC4EhERERERyQFaLTAHBINBAgF/Lh7fRGqqBa/XQyAQ+qUoJWfkZr9aLFbMZv3tRERERORSUrjKBsMwSEo6TErKiVx/rIMHzQSDWlo00uRmv0ZHxxAbG5+lazKIiIiISPYpXGXDyWAVExOH3e7I1S+xFotJo1YRKDf61TAMvF4PJ04cAaBgwcI5enwREREROTOFq4sUDAbSg1VMTGyuP57Vag75xdMk5+VWv9rtDgBOnDhCgQJxOkVQRERE5BLQN66LFAgEgFNfYkXCzcnXZm7OBxQRERGRUxSusknzWSRc6bUpIiIicmkpXImIiIiIiOQAzbnK5+rWrXbefYYOfZqWLdtc1PH79OmB0+lk7NgXLuh+HTu2oXbtuvTvP+iiHvdCffHFdvr27cWMGW9z3XX/uySPKSIiIiKRReEqn3v55Tcy3O7V6x46duxE06Y3p28rXrzERR9/wIDBWCwXPkA6cuQ4ChTI/YVCRERERERyisJVPle+fIVM2xISLjvj9pM8nlQcjqgsHf/qq0tfVF2Jiddd1P1EREREREJFc67knF57bTrNmtXju+++pWfPe2jcuDYLFswD4KWXpnDXXZ1o1qwe//d/LXj66aEcPHgww/379OnBwIH9Mh1v9+6feeCB7jRpUoeuXW9j69bNGe7XsWMbnn9+TPrt5557hq5db+OLL7Zzzz130LRpXe6//y6+/35XhvudOHGCZ599kmbN6tO6dTOmT5/Gu+/OytLpj+eTlHSMkSOH0apVExo3rkOvXvfy1VdfZNjn66+/onfv+7nppgY0a1afu+7qxIoVS8/a3qXLbRnaRURERCTv0siVnJfP52PYsCe47bY76NmzN7GxBQE4cuQwXbveQ5EiRTl69Ahz5rxDnz49mDVrLlbr2V9afr+fZ599go4dO3P33ffxzjtv8cQTA5k/fwkFCxY66/0OHz7EpEnj6dLlbmJiYpg+fSpDhz7K3LmL0h9v5MhhfPHFNh58sC+XXXYZixd/wA8/7DrrMbMqEAgwYEBf/v57Lw888BBxcYWZP38OjzzSm5deep3rriuH232CgQP7UbFiZZ555jlsNju//rqH48ePA5yx/ffff01vFxEREZG8TeEqhxkGJCfn/HGtVvCf53JFTifkxurbfr+fHj0epEmT5hm2Dx36dPr/BwIBypevSPv2Lfnii+3UqHHjWY/n8/no1asPtWrVBaBUqSu59da2bNnyKTfd1PKs90tKSmLKlFcoXboMAFFRUfTt24udO7+lUqXK/PLLHtav/4gnnhjGzTe3AqBmzdrccUfHi37uJ23evJFdu3YyYcIUatas9e+xa9Gp0/8xc+brPPfcOP7443dOnDhBz559KFPmGgCqVauRfowztd944426OLSIiIhIhFC4ykGGAa1bO9m2zRKSx69Rw8+SJSm5ErBOBqHTbd68ibfeeo1fftmN2+1O3/7HH7+dM1yZzWaqVauZfvvyy6/A4XCwf//+c9ZQpEjR9GAFp+ZzHTiwD4Dvv/8OgLp1G2R4rDp16vHee++c89jns2PHV7hcrvRgBWC1WmnQoBFr1qwC4IorSuByuRg/fhQdO3amatVqxMXFpe9/pvaiRQtnqy4RERGRSGNx/4z9wHLsRzdCmdshrkOoS8oyhascZjIZoS4hx0VFReF0OjNs27VrJ4MH96devQbceWc3ChWKx2Qy0bPn3Xg83nMez+FwYLPZMmyz2Wx4vZ5z3i8mJibDbas17Rheb9rjHTx4EKvVmmm/0wPOxTp+PIm4uPhM2+PiCpOUdAyA2NhYJk6cxmuvvcKIEU8RCASoWLEyjzwykDJlrjlje6VKVejX77H0kSwRERGRfMcIYj22DceB5dgPLMfq/uFUmyNa4Sq/MplgyZKUXDot0Hze08dy67RA0xkOun79x8TExPDss6Mxm9PWRfnnn79z/sEvQJEiRfD7/Zw4cSJDwDpy5Ei2jx0bG8uRI4czbT9y5FD6HDSA//2vPBMmTMbjSeWLL7YzbdokhgwZwNy5i7LULiIiIpIvBFKwH/4Y+4HlOA6swOw9dQaTYbLii6uH/7JWOP93H7jPcZwwo3CVw0wmcLly/rhZmXN1KXk8qVit1gzBa/XqFSGsCMqWLQfAhg0f06JFawCCwSCbNm3I9rErVqzM7Nkz+eyzLemnPPr9ftav/5iKFStl2t/hiKJWrbrs3fsnkyZNwOPx4HA4MrX//fdfTJw4LlO7iIiISKQxeQ9hP7gSx/5l2A+twxQ8NSIRtMbiLdwMb9GWeIs0w7AVwmo147S7wJ130pXClVyU6tVrMnfuu0ycOJb69Rvx7bdfs2rV8pDWVLp0GerXb8SkSePxeFIpVuxyFi9eiNfrOePo25l8/vk2/v77rwzbLr+8OLVq1aVcuet59tkn6dWrD/HxhZk//z0OHTpI1673AvDppxtZunQR9es3pFixyzh8+BDz58+lQoVKOByOM7bPmzcnvV1EREQk0pycP+U4sAzr0a2YOHUmViCqBN6iLfAUbYUvri6Y7SGsNGcoXMlFqVWrLg888BALFsxl+fIlVKhQibFjX+D2228JaV1DhjzFxIljmTZtEna7nZtvbk3p0mVYsGBulu7/0ktTMm1r3bodgwc/yfjxk5g2bRIvvjiZ1NQUEhOv4/nnp3LddWkjZiVKlMBsNvHKKy9y9OgRYmMLUqPGjfTs2fus7TVr3kiPHr1z7gcgIiIiEkrnmj8F+ApUTBudKtoKf4GKuTOnJYRMhmFE3goMOSQQCHL48JmHIX0+L4cO/U3hwpdjs+V+ys7KnCs5s96978dsNjNlyvRQl5JJbvbrpX6NSlp/xsW5OHLErfdrhFCfRib1a+RRn4ZYFuZPeYq2wFu0JcHoUlk+bDj1a3y8C4vFfN79NHIlEeXjjz9k375/KF36GjyeVNasWcmOHV8ycuT4UJcmIiIiEjHOP3+qKd6irdLnT+UXClcSUaKjnaxatZw//vgDv99HqVJX8dRTw6lfv2GoSxMRERHJ09KvP3VgObajWyJ+/tTFULiSiFKzZq0MF/oVERERkYuUPn9qBfYDy/Ld/KmLoXAlIiIiIiJpcmn+VH6hcCUiIiIiko9p/lTOUbgSEREREclnNH8qdyhciYiIiIhEOs2fuiQUrkREREREIpHmT11yClciIiIiIhFC86dCS+FKRERERCQPS5s/lXa6n+ZPhZY51AVIaA0c+AidO7c/a/v8+XOoW7cae/f+maXj1a1bjdmzZ6bf7tOnBwMH9jvv/W6+uSGvvTY9S49x0k8//cBrr00nNTU1w/bly5dQt241jh49ekHHu1h///0XdetW46OP1l6SxxMREZF8zghiPfoZrp+eIe7T6sR/WpWYnx7HfvRTTATxFaiIu/RgjtRcz+G6Ozlx3QR8hRsrWF0CGrnK55o1u4lhw55g166dlCt3fab2tWtXc/31FShevMRFHX/AgMFYLLmT4X/66UfeeONVOnToRFRUVPr2WrXq8vLLbxATE5MrjysiIiJyyZ13/lRdPEVbav5UiClc5XP16jUkOtrJmjUrM4Wrv//+i2+//Zp+/R696ONffXXp7JZ4weLi4oiLi7vkjysiIiKSk9LnTx1Yjv3gh5o/lQcoXOVzUVFR1KvXgHXr1tKnzyOYzadGmdauXYXFYqFJk+YcPHiQV16ZxpdffsGhQwdJSEigUaOm3HPP/djtZx9i7tOnB06nk7FjX0jftmHDx7z00hT++edvypS5hv79B2W636efbmTu3Nn8/PNPeL1errzyKrp378mNN9YG0k79GzlyGACtWzcF4LLLLmf+/CXpbUuXrqVQoUIAJCUdY+rUF9i0aT0pKakkJpalV68+VK5cNVOtLVq05pVXXuTgwQOUK3c9gwY9cdEjdyd5PB5eeWUaa9eu5vjxJEqVuop77rmfJk2apO+zZ89uXnxxEt99txOPJ5WEhGK0bt2OLl26ZaldRERE8r5zzp9yFMeb0FLzp8KYwlVOMww47a8KOccMgeB5dnFe1DUJmjW7idWrV/Dll59zww3V07evWbOSatVqEhcXz+7dPxMbW5CHHnqEAgUK8Mcfv/P6669w6NBBhg59OsuP9dNPP/DEE4OoWbM2Dz30CH/99RdPPTUEr9eXYb+//95LnTr1uf32rpjNJrZs+ZTHHnuYSZNeomrVatSqVZdu3brz1luvMWHCFFyuGOx22xkfMxAIMGBAX/7+ey8PPPAQcXGFmT9/Do880puXXnqd664rd1p9P3LkyEx69XqIYDDAlCkTefbZJ5k+/Y0L/Klm9OyzT7B162Z69HiQUqWuYuXKZTzxxEBstuepXbseAIMG9Sc+Pp7Bg58kJiaGP//8gwMHTg35n69dRERE8iAjiPXY9rTRqbNef6rFv9efqqTrT4U5haucZBgU2tYc27GtIXl4X6EbOVpt1QW/6apXv5FCheJYu3ZVerjas+dn9uzZzR133AVAmTLX0KdPv/T7VKhQiaioaJ577mn69x+UYc7Tucya9SYJCZcxatR4LBYLAA6Hg9Gjh2fYr0OHTun/HwwGqVKlGr/8sofFixdStWo14uLi0keTypYtlz5CdSabN29k166dTJgwhZo1awFQs2YtOnX6P2bOfJ3nnhuXvu+JE8d5/fV30k8rTElJYeTIYezfv4+EhGJZeo7/9fPPP/HJJx/x6KND+L//6wDAjTfW5p9//ua116ZTu3Y9jh49yt9/7+XhhwdQt259AKpWrZZ+jPO1i4iISB6i+VMRS+Eqp+XBvyZYrVYaNWrK2rWr6N9/EDabjTVrVhEVFUX9+o0AMAyDefPeZfHihfz11194vZ70+//115+ULn1Nlh7ru+92UqdO/fRgBdCoUZNM4Wr//n288sqLbN/+GYcOHcQwDCAtSF2oHTu+wuVypQerk8+5QYNGrFmzKsO+11yTmGG+1lVXXf1vPfsvOlzt2PElAI0bN82wvXHjZkyZ8jwpKSkULFiQyy67nOnTp3L8eBI33FA9w+Odr11ERETCm+ZP5Q8KVznJZEobOcqF0wKtFjP+XDotENJODVy4cB5bt35K3boNWLt2NXXq1MfpdAIwd+5spk2bxB133EXVqtUoUKAAu3Z9x/PPj8Hr9Wb5cQ4dOphpsYm0U/oc6beDwSCDB/fnxIkT3HdfT4oXL0l0dDQzZrzMvn3/XPBzO348ibi4+Ezb4+IKk5R0LMO2AgUKZLhts6Wdanh6mLyYx7darcTGFsywPT4+HsMwOHHiONHR0Tz//FReeeVFnn9+DCkpKZQtW46HHnqEypWrYjKZztkuIiIi4cecvBvH/uWaP5WPKFzlNJMJLK6cP67VDJwnXGVDhQqVuPzyK1izZhWFCsWnn4J20kcffUidOvXp1atP+rZff/3lgh+ncOEiHDlyJMM2t/tEhvDy559/8OOPPzBq1Hjq1WuYvt3jubiAExsby5EjhzNtP3LkUKbAkxtiYwvi9/tJSkoiNjY2ffvhw4cxmUzExKQFulKlrmTEiDH4/X6++WYHr7wyjUGDHmHhwhU4nc7ztouIiEiIZZg/tRyr+/sMzZo/Ffl0EWEBwGQy0bTpTWzatJ4lSxZSsGDB9JX5ADye1PRRnJNWr15xwY9Trtz1bNq0gUAgkL7to48+zLDPyRBltZ56vH/++ZtvvtmRYb+T7ecbVapYsTJut5vPPtuSvs3v97N+/cdUrFjpgp/DhapYsTJAposMf/TRWhITyxIdHZ1hu9VqpUqVG+jS5W7cbjcHDx64oHYRERG5hAIp2A+sIOa7vsSvL0vctqY4f30eq/t7DJMVb3xDjpcdy6G633L0xo0kl3kcf2xlBasIpZErSdes2U3MnPkGy5cvoV27W7BaT708qlevybx5c1iw4D1KlrySVauW8+eff17wY9x5Zzfuv78bQ4Y8Svv2Hfnrr73MmTMrw2mBV155FQkJxXj55akEg0FSUpJ57bXpFC2akOFYV111FQDvvz+PevUaEhUVRZkymed+1apVl3LlrufZZ5+kV68+xMcXZv789zh06CBdu957wc/hbHbu/DbTtvj4wlSqVIUGDRoxdepEPB4PpUpdyerVK/j2268ZO/Z5IG3Ri6lTJ9KkSXOKFy/BiRMnmDnzDS6//AqKFy9x3nYRERG5dDR/Ss5G4UrSlS59DWXKXMvu3T/RrNnNGdruvvt+jh49yowZ0wFo2LAJ/fo9yqBBj1zQYyQmXsezz47m5Zen8Pjjj3H11WV45pmRDBhw6nRDu93Oc8+N5fnnx/Dkk4NJSChGt2738sUX2/n+++8yHOvee3uwdOkiZs9+m4SEYsyfvyTTY1osFsaPn8S0aZN48cXJpKamkJh4Hc8/PzXDMuzZNWfOrEzbbrihBpMmvchTTw1n+vRpvPPOmyQlpV3nasSIMdSr1wC/P0jhwoUpXLgwM2e+wcGDB3C5YqhUqTJPPTUci8Vy3nYRERHJXZo/JVlhMk4uwyaZBAJBDh92n7HN5/Ny6NDfFC58OTZb7r+BrFYzfn/uzbmS0MjNfr3Ur1FJ68+4OBdHjrj1fo0Q6tPIpH6NPLnSp+eZP+WPqYAnoaXmT+WicHqvxse7sFjOP6NKI1ciIiIiInDa9adWYD+wAot3X3qTrj8lWaFwJSIiIiL5luZPSU5SuBIRERGRfOW886eKtsCT0ApfXD3Nn5ILonAlIiIiIpEtff7UCuwHlmn+lOQahSsRERERiTyBFOyHP8F+YLnmT8klo3CVTVpsUcKVXpsiIpLfmLwHcfyzQvOnJGQUri7SyWsLeb2eDBfAFQkXXq8HAItFb3MREYlc5uTdOA6tgM9XUnD/Rs2fkpDSt66LZDZbiI6O4cSJIwDY7Q5MuXh+bjBoIhDQSESkyY1+NQwDr9fDiRNHiI6OwWw+/zUZRERE8oxzzJ8yoflTEloKV9kQGxsPkB6wcpPZbCYY1IUOI01u9mt0dEz6a1RERCRPO8/8KX98XWxX3cKxAk3x2kqEsFDJ7xSussFkMlGwYGEKFIgjEPDn2uNYLCYKFnRy7FiyRq8iSG72q8Vi1YiViIjkaRdy/SlLdDxxcS6CR9zg1x+jJXQUrnKA2WzGnIvn8FqtZqKiokhJCeDXB0bEUL+KiIhkdOr6U8uxHd2s+VOS5yhciYiIiEhoGEGsSZ+nX9BX15+SvE7hSkREREQunUAq9sMfZ+H6Uy0IRl8ZwkJFLpzClYiIiIjkqlPzp1ZgP/QhpoA7vS1oKYC3SDO8RVv+e/2puBBWKpI9ClciIiIikuPMybvTwtT+ZZo/JfmGwpWIiIiIZJ/mT4koXImIiIjIRdL8KZEMFK5EREREJMs0f0rk7BSuREREROScNH9KJGsUrkREREQkI82fErkoYReudu/ezYgRI/jyyy9xuVy0a9eOfv36Ybef+68gjRs3Zu/evZm2f/311zgcjtwqV0RERCQypM+fWvHv/Kl/0ps0f0oka8IqXB07doxu3bpx1VVXMWXKFPbt28fo0aNJTU3lqaeeOu/9b7rpJu69994M284XykRERETyq7T5U6twHFiu+VMiOSCswtWcOXNwu91MnTqVQoUKARAIBBg2bBg9e/akWLFi57x/kSJFqFy5cu4XKiIiIpJHmZP3pIUpzZ8SyXFhFa7Wr19PrVq10oMVQIsWLXj66afZtGkTt9xyS+iKExEREcmLNH9K5JIJq3C1Z88eOnTokGFbbGwsRYsWZc+ePee9/5IlS5g7dy42m41q1arx6KOPUrZs2dwq95I5cgR+/hnKlAl1JSIiIpInnHP+lAVfXF28RVviKdpS86dEclBYhaukpCRiY2MzbS9YsCDHjh07530bN25MxYoVueKKK/jjjz94+eWXueOOO/jggw8oWbLkRddktZov+r45pXfvKFauhCZNohg/3sOVVxqhLklygMVizvBfyfvUp5FHfRqZIrVfTd5D2A6swrZvKbaDGedPGZYC+Io2w1usNf6ip+ZPmf/9l9dFap/md3mxX8MqXGXHE088kf7/1apVo06dOrRo0YLXXnuNZ5555qKOaTabiItz5VCFF+/OO+Gjj+DDDy3Uru3kmWfgkUfAZgt1ZZITYmOjQ12C5DD1aeRRn0amiOjX47vhz0WwdxEc2AjGqflTOEtA8bZQoh2mhAbYLQ4ifQZVRPSpZJKX+jWswlVsbCzHjx/PtP3YsWMULFjwgo6VkJDADTfcwM6dOy+6nmDQICkp+aLvn1PatDHz9dfR3HdfgA0bLAwaBG+/HeCFF7zccEPw/AeQsGSxmImNjSYpKYVAQP0YCdSnkUd9GpnydL8aQSzHPse2bxn2/UuxnPjP/KkCFfAVa4UvoRWB2Mqn5k8l+QH/JS/3UsnTfSpnFU79GhsbnaURtLAKV6VLl840t+r48eMcOHCA0qVLh6Qmvz883qCJifDBB6m8846Zp5+OYudOC82bR9G9u48hQzwUKBDqCuViBQLBsHmdSc5Qn0Ye9WlkyjP9GkjFfvgT7AeWX9j8qYAB5K+pBHmmT+WC5KV+DasTGOvXr8+nn35KUlJS+raVK1diNpupU6fOBR1r3759fP7551SoUCGnywwZkwk6d/azaZObW2/1YRgmZsywU7eui+XLwyoni4iISDaYvIdw/DWb2B13UuSTqyn41a1E730Di/cfgpYCpBa7haTyMzjUYA/HblhCSqkHtDCFSBgIq2/knTt3ZubMmfTu3ZuePXuyb98+xo4dS+fOnTNc46pbt2789ddfrFmzBoClS5fy0Ucf0aBBAxISEvjjjz945ZVXsFgs3HPPPaF6OrmmSBGDadNSue02H489FsWvv5q5++5oWrTwMWqUhyuuyF9/pRIREYkEWb/+VF0wO0JYqYicTViFq4IFC/LWW28xfPhwevfujcvlomPHjjzyyCMZ9gsGgwQCgfTbJUqUYP/+/YwcOZLjx49ToEABbrzxRvr27ZutlQLDXYMGAT75xM3EiXamTrWzYoWNDRusDB3q4Z57fFgsoa5QREREzurf60/ZD6zAsX8ZVveuDM2nrj/VEn+Byrr+lEgeYDIMQ8McZxEIBDl82H3+HXOZ1WomLs7FkSPus55vumuXmQEDoti+PS1RVa0aYPz4VMqXzxvnp+ZHWelXyVvUp5FHfRqZQtqvFzt/Ss5J79XIFE79Gh/vynsLWsjFK1cuyNKlybz9to3hwx188YWFZs2c9Orl49FHPbhCv6K8iIhIvmTyHsJ+cFXaKX+HMl5/KmgpgLdIM7xFW+Itcur6UyKSNylcRRCzGe6+20eLFn4ef9zB4sU2pk2zs2SJlbFjU2ncOHD+g4iIiEi2af6USP6kcBWBihUzmDEjldWrfQwaFMXvv5vp3NnJLbf4ePZZDwkJOhNUREQkR2Vl/lTRFngTWmn+lEgEU7iKYM2bB6hd282YMQ5efdXG++/b+PBDK08/7eGOO3yYw2ohfhERkTxG86dE5D8UriJcTAwMH+6hY0cfAwZE8fXXFvr3j2LuXCvjx3tITNSkTxERkazS/CkROReFq3yiUqUgK1cmM2OGjdGjHWzZYqVRIwt9+3p5+GEvUVGhrlBERCQ8pc+fOrA8bf6UcWoOc8BxRfrolC++nuZPieRzClf5iNUKvXr5aNXKz5AhUaxebWXCBAcffGBj/PhU6tTRghciIiJp86e+wH5g+VnmT5XHU7Sl5k+JSCYKV/lQyZIGM2emsHSplaFDHezebaZ9eye33+7j6adTiY8PdYUiIiKXmOZPiUgOULjKp0wmaNPGT4MGfkaMcPDWWzbefdfG6tUWnn3WQ8eOfv0hTkREIprJewjHPys0f0pEcozCVT4XGwtjx6YtePHoo1F8/72F3r2jmTvXz9ixqVx9tZZtFxGRyGFO+R3HwWXw+XIKHtio+VMikqMUrgSAGjWCrF2bzIsv2pkwwc4nn1hp0MDFo496eeABLzZbqCsUERG5OBb3T9j3L8axbzG241+mbzeh+VMikrMUriSd3Q79+nlp29bHY49FsWGDlREjHCxYYGXChFSqVdOy7SIikgcYBpYT3+L4N1CdviCFgRl/fG1sV3XkWIFmeO0lQ1ioiEQahSvJpHRpg/nzU5g3z8rTTzvYtctCq1ZO7r7bx+OPe4iNDXWFIiIi/2EYWJO249i/BMe+RVhSfjnVZLLii2+AJ6EdnoRWWJzFiItzETziBr/+cCgiOUfhSs7IZILbbvPTpEmAYcMczJlj44037CxfbmXkSA+tW2vBCxERCTEjgO3I5rRT/vYvweLZe6rJHIW3cFM8CW3wFm2BYSsUujpFJN9QuJJzKlzYYPLkVG67LW3Biz17zHTvHs1NN/kZNSqVEiW04IWIiFxCQS+2w+vTTvnbvxSz7+CpJksM3iI34SnWFm/hZmCNCWGhIpIfKVxJltStG+Djj9288IKdKVPsrFplZcMGF0OGeLjvPh8WS6grFBGRiBVIwX5oHY79i7AfWInZfzS9KWgthDehFZ6EtnjjG4ElKnR1iki+p3AlWRYVBYMHe2nf3s+AAQ4++8zKk09GMX++jeefT6VCBZ23LiIiOcPkP4794Oq0U/4Ors54DSp7Ap6ENngS2uKLqwtmLWkrIuFB4UouWNmyQRYvTmHWLBvPPutgxw4LzZo56dHDx8CBHmJ0FoaIiFwEk+8w9gMrcOxbjP3wOkxBT3pbIKrkv4GqHf5CNcCkUyZEJPwoXMlFMZvhrrt83HSTnyefdPDBBzZeftnO0qVWxoxJpVmzwPkPIiIi+Z7Jsw/H/qU49i/GdmQDJsOf3uZ3lsGb0A5PQlv8sVV0DSoRCXsKV5ItxYoZvPJKKp06+Rg4MIo//jDTpYuTtm19PPech2LFtOCFiIhkZE75498FKRZjPboFE6d+V/hjyuNJaIunWFsCrnIKVCKSpyhcSY5o0iTA+vVuxo1zMH26jcWLbXz8sZUnnvBw110+zOZQVygiIqFkcf/875Lpi7AlfZmhzRd7A55i7fAktCHoLBOiCkVEsk/hSnKMywXPPOOhQwcfAwZE8dVXFgYOjGLePBsTJqRy3XVa8EJEJN8wDCwnvsOxf1HaCNWJ7041YcJXqDbeYm3TAlVUiRAWKiKScxSuJMdVqBBkxYpkXn/dxsiRDrZts9CkiZM+fbz06+clOjrUFYqISK4wDKxJX+DYvxj7vkVYU/acajJZ8cXXx5PQDk/RVhiOhBAWKiKSOxSuJFdYLHD//T5atvQzZIiDlSttTJyYtvDF+PGp1KunBS9ERCKCEcB2dMu/p/wtwZL656kmswNv4SZp16Aq2gLDFhfCQkVEcp/CleSq4sUN3norlWXL/Awd6uCXX8x06ODkttt8DBvmoXBhLXghIpLnBH3YjqzHsW8xjgNLMXsPnGqyxOAt0hxvQls8RZqDVdfnEJH8Q+FKcp3JBK1b+6lf38/IkQ7eeMPG3Lk21q618MwzHjp18msxKBGRcBdIxX5oHY79i7AfWIHZfzS9KWgthLdoy7QRqsKNwRIVujpFREJI4UoumdhYGD3aQ8eOaQte7NploW/faObN8zNuXCqlS2sUS0QkrPhP4Di4Gvv+xdgPrsYcOJHeFLQXxVO0DZ5ibfDF1QezLYSFioiEB4UrueSqVQuydm0yL71kZ8IEOxs2WGnQwMUjj3jp08eL3R7qCkVE8i+T7wj2AyvSFqU49CGmoCe9LRBVAk9CG7wJ7fAVqgkmSwgrFREJPwpXEhI2G/Tt66Vt27SLD3/8sZXRox0sXGhl/HgPNWtqwQsRkUvF5NmP48BSHPsXYzu8HpPhT2/zR5fGW6wdnoS2+GOr6qK+IiLnoHAlIXXVVQbvvZfCggVWnnrKwQ8/WGjTxknXrl6eespDwYKhrlBEJDKZU//8d8n0JdiOfoqJU6dm+2Oux5PQBk9COwIx/1OgEhHJIoUrCTmTCTp29NOkiZ9hwxzMnm1n5kw7q1ZZee45D23basELEZGcYE7enbbC3/7F2JI+z9Dmi62atiBFQhsCrmtDVKGISN6mcCVhIy4OXnjBw223+Xn0UQc//2zh/vujee89P2PGpFKypBa8EBG5IIaBxb0Lx75FOPYvwXri21NNmPAVqoU3oQ2ehLYEo0uGsFARkcigcCVhp3btAB99lMykSXYmT7azdq2VevVcDBzooUcPH1a9akVEzs4wsCZ9mXbK3/5FWJN3n2oyWfDF1cdTrB2eoq0wHMVCWKiISOTR11QJSw4HDBzopX37tFGszZutPPNMFAsW2JgwIZXKlYOhLlFEJHwYAWxHt2LfvxjH/iVYUv841WR24I1vjKdYW7xFW2DY4kNYqIhIZFO4krB27bVBFi5M4d13bQwb5uCbbyzcfLOT++7zMXiwh5iYUFcoIhIiQR+2Ixtw7F+CY/8SzN796U2GxYWnSHO8CW3xFmmOYS0QwkJFRPIPhSsJe2YzdOnio3lzP08+6eD992288oqdZcusjBqVys03a9l2EcknAqnYD3+UdsrfgeWYfUfSm4LWgniLtsCT0A5v4cZgiQ5hoSIi+ZPCleQZRYsavPxyKrfdlnZtrN9/N3PXXU5atfIxcqSHyy/XghciEoH8J7AfWoNj32LsB1dhDpxIbwraivy7ZHobfPH1wayrsIuIhJLCleQ5jRsHWL/ezYQJdl580c6yZTY++cTKE094uPtuH2ZzqCsUEckek+8I9gMr00aoDn2IKZia3hZwFMeT0AZvQlt8cbXAZAlhpSIicjqFK8mTnE548smTC15E8cUXFgYPjmLevLQFL/73Py14ISJ5i8l7AMf+ZTj2L8J2+BNMhj+9LRB9ddoKfwlt8MfeACb9FUlEJBwpXEmeVr58kGXLknnzTRvPPefg888tNG3q5MEHvQwY4CVaUw5EJIyZU/di378k7aK+Rz7FxKk/DPld5fAUa4snoR2BmOvR1dRFRMKfwpXkeRYLdO/uo2VLP0OGOFi+3MbkyQ4WLbIxblwqDRtqwQsRCR/m5D3/rvC3CNux7RnafAWqpC2ZntCWgOvaEFUoIiIXS+FKIsbllxu8+WYqK1akhazffjNz221OOnTw8eyzHooW1YIXIhIChoHF/T2OfYtw7F+C9cQ3p5ow4S9047+LUrQlGF0qhIWKiEh2KVxJxGnRwk+9en5GjXIwY4aNBQtsrFtn5emnU7n9dr/OrBGR3GcYWI9/lbbC3/7FWJN/OtVksuCLq//vohStCTouC2GhIiKSkxSuJCLFxMBzz3no2NFH//5R7NxpoV+/aObO9TN+fCrXXKNRLBHJYUYQ67HP0keoLKm/n2oy2fEWboynWDu8RW7GsBcOYaEiIpJbFK4kolWpEmTNmmSmT7cxbpyDTz+10rChi379vDz0kBeHI9QVikieFvRhO7Ixbcn0/UuxePelNxlmJ94izdPmUBVpjmGNDWGhIiJyKShcScSzWqF3bx9t2vgZNCiKDz+0Mnasg4ULrUyY4OHGG7XghYhcgKAH+6F1aav8HViG2XfkVJO1IN6iN+NJaIe3cGOwOENYqIiIXGoKV5JvlCplMHt2CosWWXn8cQc//WShbVsnd97p5amnPBQqFOoKRSRs+d3Y961KG6E6sApz4Hh6U9BWGE9CazwJbfHFNwCzPYSFiohIKClcSb5iMsH//Z+fhg39DB/uYOZMO7Nm2Vm50sqIER7at9eCFyKSxuQ7in3favhmKYX+WokpmJreFnBcjjehDZ6EdvgK1QKzfp2KiIjCleRThQrBhAkebr3Vz6OPOvjxRwu9ekXz3nt+xo5N5corteCFSH5k8h7EsX9Z2jWoDn+CyfClbQcC0VfhSWiHJ6EN/oLVwGQObbEiIhJ2FK4kX7vxxgAffpjM1Kl2Jk6089FHVurXd/Hoo1569fJis4W6QhHJbebUv9LmT+1fjO3IJkwE09sCMddhuepWkgq2wBN9PRraFhGRc1G4knzP4YABA7z83//5ePTRKDZtsjJ8uIMFC6w8/3wqVasGz38QEclTzMm/4Ni/JG2E6ti2DG2+ApXxFmuLJ6EtpoLXERfnInDEDX59FoiIyLkpXIn8q0wZg/ffT+G996w8/XQU331noUULJ927+xgyxEOBAqGuUESyw3Li+3+XTF+M7fjXGdp8BWviKZZ2yl8w+sr07folKSIiF0K/N0ROYzJB585+mjZ18/TTDubNszFjhp1ly6yMGuWhZUt/qEsUkawyDKzHd2DfvxjH/sVY3T+eajJZ8MXVw5PQBm/R1gSjLg9hoSIiEikUrkTOoEgRg2nTUrntNh+PPRbFr7+aufvuaFq08DFqlIcrrtCCFyJhyQhiPbYNx75FOPYvwZL626kmkx1v4UZ4E9riKdoSw144hIWKiEgkUrgSOYcGDQJ88ombiRPtTJ1qZ8UKGxs2WBk61MM99/iwWEJdoYgQ9GM7ugnHvkXY9y/F4v0nvckwO/EWaZY2QlXkJgxbwRAWKiIikU7hSuQ8oqNh6FAv7dv7GTAgiu3bLQwdGsX8+TbGj0+lfHlNche55IIe7Ic+Tjvl78AyzL7Dp5qssXiL3IynWDu8hZuAxRnCQkVEJD9RuBLJonLlgixdmsxbb9kYMcLBF19YaNbMSa9ePh591IPLFeoKRSJcwI394Ic49i/CfnAVZn9SelPQFo+naGu8xdrijW8AZkcICxURkfxK4UrkApjNcM89Plq08PP44w6WLLExbZqdJUusjB2bSuPGgVCXKBJRTL5j2A+uxLF/CfaDazAFU9LbAo7L8Sa0xpPQDl+h2mDWrzQREQkt/SYSuQiXXWbw2muprF7tY9CgKH7/3Uznzk7at/cxfLiHhAQteCFysUzeQzgOLMO+bxH2wx9jMnzpbYGoK/H8ew0qf8HqYDKHsFIREZGMFK5EsqF58wC1a7sZM8bBq6/aWLjQxrp1Vp5+2sMdd/gw63ufSJaYU//GfmAJjn2LsR3ZiIlTcxn9rrJpC1IktMNfoGLaNRNERETCkMKVSDbFxMDw4R46dvQxYEAUX39toX//KObOtTJ+vIfERC14IXIm5pRfcexbgmP/ImzHPsvQ5itQKW3J9IS2BGLKhqhCERGRC6NwJZJDKlUKsnJlMjNm2Bg92sGWLVYaNbLQt6+Xhx/2EhUV6gpFQs9y4gcc+xdj378Y2/EdGdp8BWvgSWiHJ6E1QefVIapQRETk4ilcieQgqxV69fLRqpWfwYOjWLPGyoQJDj74IG3Z9jp1tOCF5DOGgfX412lLpu9fjNX9w6kmzPji6uIp1hZv0dYEo64IYaEiIiLZp3AlkgtKljSYNSuFJUusDB3qYPduM+3bO7n9dh9PP51KfHyoKxTJRUYQ67FtOPYvxrF/CZaUX081mWx44xviLdYOT9FWGPbCoatTREQkhylcieQSkwnatvXToIGfESMcvPWWnXfftbF6tYVnn/XQubPmYkkECfqxHf007RpU+5di8fyd3mSYo/EWaYonoS3eIjdj2AqGsFAREZHco3AlkssKFoRx4zzcequPRx+N4vvvLfTuHc28eQFmzECjWJJ3Bb3YD3+Mfd9iHAeWYfYdOtVkKYC36M3/BqqmYNFVtkVEJPIpXIlcIjVqBFm7NpkXX7QzYYKdjz+2UL48DBxoo2dPDzZbqCsUyYJAMvZDH+LYtwj7wZWY/UnpTUFbPJ6irfAmtMFbuBGYHSEsVERE5NJTuBK5hOx26NfPS9u2PgYNiuaTTyw8+6ydefMsTJiQSrVqOlVQwo/Jn4T9wEoc+5dgP7gGUzA5vS1gvwxvQms8xdrhK1QHzPq1IiIi+Zd+C4qEQOnSBu+/n8qyZS769TPYtctCq1ZO7r7bx+OPe4iNDXWFkt+ZvIdwHFiOff9i7Ic+wmR409sCUaXwJLTFU6wd/oLVwaSrZYuIiIDClUjImEzQtSvUqpXME0/Yee89G2+8YWf5cisjR3po3dqPyRTqKiU/MXv+wb5/CY79S7Ad2YDJOHXpAL/zWjzF2uFNaIu/QCX04hQREclM4UokxAoXhilTUrntNh+PPRbFnj1muneP5qab/IwalUqJEkaoS5QIZk75Dcf+JWnXoDq6FROnXm++AhXxJrTBk9COQMx1IaxSREQkb1C4EgkT9eoF+PhjNy+8YGfKFDurVlnZsMHFkCEe7rvPh8US6golUljcP+LYvxj7vsXYjn+Voc1XsDqehHZ4EloTdJYOTYEiIiJ5lMKVSBiJioLBg720b+9nwAAHn31m5ckno5g/38aECalUrKgFL+QiGAaWE9/g2Lc4bYTK/f2pJsz44uqkLZme0JpgVPEQFioiIpK3KVyJhKGyZYMsXpzCrFk2nn3WwY4dFpo3d9Kjh4+BAz3ExIS6Qgl7RhDrse3/nvK3CEvKr6eaTDZ88Q3+HaFqiWEvGro6RUREIojClUiYMpvhrrt83HSTnyefdPDBBzZeftnO0qVWxoxJpVmzwPkPIvmLEcB25FPs+xfj2L8Ei+evU03mKLyFm+Ip1hZvkZsxbIVCV6eIiEiEUrgSCXPFihm88koqnTr5GDgwij/+MNOli5O2bX0895yHYsW04EW+FvRiO/wJjv2Lcexfhtl38FSTJQZvkZvSVvkr0gwsrhAWKiIiEvkUrvIA84kf4K/VODxgJQrDEoVhcYI57b+G+T+3LdEY5mgwR2m55AjSpEmA9evdjB3r4JVXbCxebOPjj6088YSHu+7yYdalhvKPQAr2Qx/i2L8I+4GVmP3H0puCtjg8RVvhTWiDN74RWKJCWKiIiEj+onCVBzi/HwIHVuO8iPsa5uj0sGVYouHk7Uyh7LR9Tvv/tP+eHtyiMMxp/+Xf/xoWJ5jsCnKXgMsFw4Z56NjRx4ABUXz1lYWBA6OYNy9twYvrrtOCF5HK5E/CfnA1jn2LsR9cjSmYnN4WsBfDm9AaT0JbfHF1wWwLYaUiIiL5l8JVHpBSZjC2glfhST4G/mRMgRQIpGAKpmD6978Zbhu+9Puagv+25zIDc8ZQdnL0LENQ+zeI/Se8ZQ5z0XBa+PvvyJy+OEKFCkFWrEjmtddsjBrlYNs2C02aOOnTx0u/fl6io0NdoeQEk/cQ9oMrcexbhP3QOkyGN70tEFUST0JbPAlt8ReqASat1S8iIhJqJsMwNGHjLAKBIIcPu0NdBlarmbg4F0eOuPH7szAyEfRnDlyBZEzBVPj3v2e7bQokZwpuaWEuFVMwGdO//+XkMbn0IyWGyYJhdkL6KNrpoezUyFr6Phbn2cPc6aN5p43qYY7699TK3Pv7wwX361ns3WtiyBAHK1emhc6rrw4yblwq9etrwYtLLSf61OTZ9+8Kf0uwHVmPyTjVj37nNXgT2uEp1hZ/gcoaLb4Ecup9KuFF/Rp51KeRKZz6NT7ehcVy/jkYYTdytXv3bkaMGMGXX36Jy+WiXbt29OvXD7vdnuVjvPnmm4waNYqGDRsyffr0XKw2TJmtGOYCYC1AriZnwwDDd+bRs0DKvyHsv6HsP0HuZLALpGTe9t8Q+O+zMRkBTIHjEDiem88u7SmabOmjZ5wpgP1nhC3DiFt6wDtzmDPZXRBdGPwGGA4wXdykqeLFDd56K5Vly/wMHergl1/MdOzo5LbbfAwb5qFwYf39JNyZU37/d0GKJViPbkl/rQP4YyrgSWiDp1g7Aq7rFKhERETCWFiFq2PHjtGtWzeuuuoqpkyZwr59+xg9ejSpqak89dRTWTrGgQMHmDZtGoULF87lagWTCUx2DLMdg4K5+1iGAUHPqZG0/4ysZd52WigLpJ7lfmltnBb+Tu6b/hQNHyb/MeDY2WvLpriTT9HsyDzCdqb5cqfPdTst2HWoGk2LRdG8Nz+Wxctj+f0LJz1ui+L+nhZatLGnj+JpoZPwYHH/lLZk+r7F2I5/maHNV7Dav6f8tSHoLBOiCkVERORChVW4mjNnDm63m6lTp1KoUCEAAoEAw4YNo2fPnhQrVuy8xxg3bhyNGzfmr7/+Ou++koeYTP+GgygMW9z5988OI5gW5ALJmUPZ6adKpge1U6Nv/w19mUPgyZG5f7cFPaeeYtCTdtt/9KJLjwUerpz2L4ON/3mK5ujTFic5faGTM4W5tH35z+mVZ7+fFjo5I8PAcmInjv2LcOxbjNW961QTZnxxtfEmtEkLVFElQlioiIiIXKywClfr16+nVq1a6cEKoEWLFjz99NNs2rSJW2655Zz33759O2vXrmXlypUMGDAgl6uViGUynxo1ysWHsVrNxBWM4sihQwS87jOEsv+cTnlyZC3DfLn/zo3L+P8pJ1IJepOJtqdgt55poZMjufgMwcB0zsVJMix08t99zjSn7qwLpoTpQieGgTVpO479S7DvW4w1Zc+pJpMVX3yDf0eoWmPYi4awUBEREckJYRWu9uzZQ4cOHTJsi42NpWjRouzZs+cs90oTCAQYPnw4vXr1IiEhITfLFMk5ZgtYXRjkXpD75RcTAwdGsXEDRNtTqPi/4zz79DGqVDhxhpG5cy10cjLgnWuhk39v/7sIgwkDAm5MATf4DuXSM0yTeaGT0xc1OX1FytMXOjnLfLmTt8+ysuU5FzoJBrAe2oDj70U49i/B4tl7qkZzFN7CTfAktMVb9ObcH4UVERGRSyqswlVSUhKxsbGZthcsWJBjx84952X27NmkpKRw991352hNVmvor8x6cmWSrKxQInnHperXa6+F99/3MH++hccfj+HTLwrQtN0VdOvm45lnvBSMT9svR8Nd0PfvfLeTi52cGnU7tYjJyfluGRc64b8jdhm2n2FbiBY6OTUn7lRYwxINyT9SIHX/qX0tMfgSbsJbrB2+os3BGgOAFk7PG/T5G5nUr5FHfRqZ8mK/hlW4uliHDh1i8uTJjBkz5oJWFTwfs9lEXJwrx46XXbGxunhRJLpU/dqjB3TsCI89Bq+/Dm+9ZWPlShuTJsFtt+XG1KhCOX3AzAwDgl4IJIM/5d//pl0qIMO2QMp/tp9p23n2DWRc6AS/D5M/6cx12eOgeFso2QHT5c2wW6LIuU8mCQV9/kYm9WvkUZ9GprzUr2EVrmJjYzl+PPNfnY8dO0bBgmdfjW7SpEmULVuWatWqkZSU9mXH7/fj9/tJSkrC6XRitV74Uw0GDZKSki/4fjnNYjETGxtNUlIKgYCu3RApQtGvJhOMHw/t25vp39/BTz+Z6dwZXnvNz/jxXkqWzKvLttv//ffv54Tl3385mWgMI33U7fTTIU+OqJmCqZiNVJyFriApqhoB49+xqaQAEPrr5cnF0edvZFK/Rh71aWQKp36NjY3Oe9e5Kl26dKa5VcePH+fAgQOULl36rPf75Zdf2LZtG9WrV8/UVr16dV599VXq169/UTWF+oJlpwsEgmFVj+SMUPRrzZpB1q3zM2mSncmT7axZY6VWLQsDB3ro0cPHRfwtIp9wgNkBZ/lstVrNOONcBMLgYoeSs/T5G5nUr5FHfRqZ8lK/htVXqPr16/Pyyy9nmHu1cuVKzGYzderUOev9hg4dmj5iddLIkSOJioqif//+lC1bNlfrFsmLHA4YONBL+/Z+Hn3UwebNVp55JooFC2xMmJBK5cp540NMREREJFyEVbjq3LkzM2fOpHfv3vTs2ZN9+/YxduxYOnfunOEaV926deOvv/5izZo1AJQrVy7TsWJjY3E6ndSsWfOS1S+SF117bZCFC1N4910bw4Y5+OYbCzff7OS++3wMHuwhJibUFYqIiIjkDWG19EbBggV56623sFgs9O7dmwkTJtCxY0cGDx6cYb9gMEggEAhRlSKRx2yGLl18bNzo5pZbfASDJl55xU69ei5WrtS6diIiIiJZYTIMI6/OYM91gUCQw4dDPxHdajUTF+fiiOZxRJRw7td16ywMHBjF77+n/f2lVSsfI0d6uPxyfVycSzj3qVwc9WlkUr9GHvVpZAqnfo2Pd2VpQYuwGrkSkfDQuHGA9evdPPSQB4vFYNkyG3XquHjtNRsaNBYRERE5M4UrETkjpxOefNLLmjXJVK0a4MQJE0OGRNG6tZPvvtNHh4iIiMh/6RuSiJxT+fJBli1LZtSoVGJiDD7/3ELTpk5GjLCTknL++4uIiIjkFwpXInJeFgt075624EXLlj78fhOTJzuoX9/Fxx9rwQsRERERULgSkQtwxRUGb76ZyltvpXD55UF++83Mbbc5eeCBKA4cMIW6PBEREZGQUrgSkQvWooWfTZvc3H+/F5PJYMECG3Xrupg924rWHxUREZH8SuFKRC5KTAw895yHlSuTuf76AEeOmOjXL5r27aP5+WeNYomIiEj+o3AlItlSpUqQNWuSefrpVJxOg08/tdKwoYtx4+x4PKGuTkREROTSUbgSkWyzWqF3bx+ffOKmcWM/Xq+JceMcNG7sZMsWLXghIiIi+YPClYjkmCuvNHj33RSmT0+hSJEgP/1koW1bJ/37Ozh6NNTViYiIiOQuhSsRyVEmE7Rv7+fTT9107eoFYNYsO7Vru3j/fS14ISIiIpFL4UpEckWhQjBhgofFi5NJTAxw8KCZXr2i6dw5mt9+04IXIiIiEnkUrkQkV914Y4APP0xm0CAPdrvBRx9ZqV/fxZQpdny+UFcnIiIiknMUrkQk1zkcMGCAl08+cVOnjp+UFBPDhzto1szJF1/oY0hEREQig77ViMglU6aMwfvvpzB5cgpxcQbffWehRQsnQ4Y4OH481NWJiIiIZI/ClYhcUiYTdO7sZ9MmN7fe6sMwTLz2mp26dV0sX24NdXkiIiIiF03hSkRCokgRg2nTUpk7N5mrrgry999m7r47mm7dovjrLy14ISIiInmPwpWIhFTDhgE++cTNww97sFoNVqywUbeuixkzbAQCoa5OREREJOsUrkQk5KKj4fHHvaxdm0y1agFOnDAxdGgUrVo5+fZbfUyJiIhI3qBvLSISNv73vyBLlyYzZkwqBQoYfPGFhWbNnAwb5sDtDnV1IiIiIuemcCUiYcVshnvu8bFpk5s2bXwEAiamTbPToIGLdessoS5PRERE5KwUrkQkLF12mcFrr6Uya1YyxYsH+f13M507O+nZM4r9+7XghYiIiIQfhSsRCWvNmwfYsMFNz55ezGaDhQtt1KnjYuZMG8FgqKsTEREROUXhSkTCXkwMDB/uYdWqZCpUCHDsmIkBA6Jo1y6aH3/Ux5iIiIiEB30rEZE8o1KlIKtWJTNsWCpOp8HWrVYaNXIyZoyd1NRQVyciIiL5ncKViOQpVis88ICPDRvcNGvmx+czMWGCg0aNXGzapAUvREREJHQUrkQkTypZ0mDWrBRmzEghISHI7t1m2rd38vDDURw+HOrqREREJD9SuBKRPMtkgrZt/Wza5KZbNy8A776btuDFvHlWDCPEBYqIiEi+onAlInlewYIwbpyHpUvdXHddgEOHzPTuHc1tt0Xzyy9atl1EREQuDYUrEYkYNWoEWbs2mSFDPDgcBp98YqVBAxeTJtnx+UJdnYiIiEQ6hSsRiSh2OzzyiJdPPnFTr56f1FQTzz3noGlTJ9u26SNPREREco++aYhIRCpd2mD+/BSmTEkhPj7Irl0WWrd2MmiQg6SkUFcnIiIikUjhSkQilskEnTr52bQpmU6dfBiGiTfesFOnjoslS7TghYiIiOQshSsRiXiFCxtMmZLKggXJlC4dZN8+M927R3PXXdH8+acWvBAREZGcoXAlIvlGvXoBPv7YTf/+Hmw2g1WrrNSt62L6dBuBQKirExERkbxO4UpE8pWoKBg82Mu6dcnUqOEnOdnEk09GcfPNTr7+Wh+JIiIicvH0TUJE8qWyZYMsXpzCuHGpxMYa7NhhoXlzJ0895eDEiVBXJyIiInmRwpWI5FtmM3Tr5mPTJjft2vkIBk28/LKd+vVdrFljCXV5IiIikscoXIlIvlesmMGrr6Yye3YyJUsG+fNPM126OLnvvij27dOCFyIiIpI1ClciIv9q2jTA+vVuHnjAi8VisHixjTp1XLz5po1gMNTViYiISLhTuBIROY3LBcOGeVi9OpnKlQMkJZkYODCKNm2cfP+9PjJFRETk7LL1TeGvv/5i+/btGbZ9//33DBw4kH79+rF27dpsFSciEioVKgRZsSKZESNScToNtm2z0KSJk1Gj7KSkhLo6ERERCUfZClcjRoxg6tSp6bcPHjzIXXfdxZo1a9i+fTsPPfQQq1evznaRIiKhYLFAjx5pC17cfLMPn8/ExIkOGjZ0sX69FrwQERGRjLIVrr7++mtq166dfvuDDz4gNTWVRYsWsX79emrVqsXrr7+e7SJFREKpeHGDt95K5fXXU7jssiC//GKmY0cnffpEceiQFrwQERGRNNkKV8eOHaNw4cLptz/++GOqV69OqVKlMJvNNGvWjD179mS7SBGRUDOZoHVrPxs3urn3Xi8mk8HcuTbq1HEyZ44Vwwh1hSIiIhJq2QpX8fHx/PXXXwAkJSXx1VdfUa9evfT2QCCA3+/PXoUiImEkNhZGj/awbFky5coFOHzYTN++0XTsGM3u3RrFEhERyc+s2blz7dq1mTlzJjExMWzduhXDMGjSpEl6+88//8zll1+e7SJFRMJNtWpB1q5N5qWX7Iwfb2fDBit161oYOhTuuQeiokJdoYiIiFxq2Rq5GjBgAKVLl2bMmDFs2rSJgQMHUrJkSQC8Xi8rVqygVq1aOVKoiEi4sdmgb18vn3zipkEDPx6PiaefhqpVnbz8sk2rCoqIiOQzJsPI/kyB48eP43A4sNvt6dtSU1P59ddfueyyyyhUqFB2HyIkAoEghw+7Q10GVquZuDgXR4648ft1JdNIoX6NLIYBixfbGD06it2707ZddlmQfv283Hmnj9M+HiUP0fs0MqlfI4/6NDKFU7/Gx7uwWM4/LpUjV8QsUKBAhmAFEBUVxXXXXZdng5WIyIUwmaBDhwC7dsGkSR5KlAjyzz9mBg+OolYtF7NnW9EUVBERkciWrXC1efNmZsyYkWHb/PnzadiwIbVr12bkyJEEAoFsFSgikpfYbNC1q5/Nm92MGpVKQkKQP/4w069fNHXrupg/34o+FkVERCJTtsLVlClT+P7779Nv//DDDzz99NPEx8dTo0YNZs6cyWuvvZbtIkVE8hqHA7p39/HZZ26eeSaVwoWD7Nlj5sEHo2nY0MmSJVaCOnNFREQkomQrXO3evZvy5cun3160aBExMTG88847vPDCC9x6660sWrQo20WKiORVTic8+KCPbdvcDB3qoWBBgx9+sNC9ezTNmjlZs8aia2SJiIhEiGyFq5SUFGJiYtJvb9iwgbp16xIdHQ1AhQoV0q+DJSKSn8XEQL9+XrZvP0H//h5cLoNvvrHQpYuTli2dfPKJQpaIiEhel61wdfnll/PNN98A8Ntvv/HTTz9Rt27d9PZjx45lWuhCRCQ/K1gQBg/2sn27mz59PERHG3z+uYVbb3XSvn00W7ZYQl2iiIiIXKRshas2bdowd+5cevXqRffu3SlYsGCGiwjv3LmTq666Krs1iohEnMKFDZ56ystnn7m5/34vdrvBp59aadvWSadO0Xz5ZY4s5ioiIiKXULZ+e/fq1YsePXrwzz//cPnllzNt2jRiY2MBOHr0KJ999hmNGzfOkUJFRCJRsWIGzz3nYetWN127erFaDT76yMpNN7m4664ovv1WIUtERCSvyJGLCEcqXURYcpP6NfLkRJ/++quJCRMczJtnJRg0AdC2rY+BA70kJup1cqnpfRqZ1K+RR30amcKpXy/pRYQB3G43u3fvZvfu3bjdoQ8kIiJ50VVXGUyZksqGDcm0b+8DYPFiG/XrO+ndO4pffjGFuEIRERE5m2yHq6+//pquXbtSo0YNWrduTevWralRowZ33XVX+mIXIiJyYa69Nsj06al89JGbFi18BIMm5s2zUbu2iwEDHPz5p0KWiIhIuMnWaYE7duyga9eu2Gw2WrduTZkyZYC0618tW7YMn8/HzJkzqVixYo4VfCnptEDJTerXyJObffrll2bGjHGwbp0VALvdoGtXH/36eSlWTGd35xa9TyOT+jXyqE8jUzj1a1ZPC8xWuLr77rvZu3cvs2fPpmjRohnaDh48yO23306JEiV44403LvYhQkrhSnKT+jXyXIo+3brVwujRdjZtSgtZUVEG997ro08fL0WKKGTlNL1PI5P6NfKoTyNTOPXrJZlztWPHDjp16pQpWAEUKVKE2267ja+++io7DyEiIqepWTPAwoUpLFiQTLVqAVJTTbz4op3q1V2MGmXn6NFQVygiIpJ/ZStcmc1mAoHAWduDwSBms5YRFhHJafXqBVi2LJnZs5OpWDGA221i4kQH1arF8Pzzdk6cCHWFIiIi+U+2kk+VKlV455132Lt3b6a2v/76i9mzZ1O1atXsPISIiJyFyQRNmwZYsyaZN95I4brrAiQlmRg92kG1ai6mTbORnBzqKkVERPKPbM25+u677+jSpQuBQIBmzZpx1VVXAfDLL7/w4YcfYjabeffdd7nuuutyqt5LSnOuJDepXyNPqPs0EIBFi6yMHetgz560v50lJATp189L164+HI5LXlKeF+o+ldyhfo086tPIFE79ekkWtAD4+eefmThxIp9++ikpKSkAREdHU6dOHfr06UNcXBzFihXLzkOEjMKV5Cb1a+QJlz71+2H+fCvjxzv4/fe0XwTFiwd55BEvt9/uw2YLWWl5Trj0qeQs9WvkUZ9GpnDq10sWrk4KBoMcPnz43wePx2w289JLLzF58mR27dqVEw9xySlcSW5Sv0aecOtTrxdmz7YxcaKdv/9O+4Vw5ZVBHn3UQ8eOfiyWEBeYB4Rbn0rOUL9GHvVpZAqnfr0kqwVmOJDZTJEiRShSpIgWsRARCQN2O9x9t4+tW92MGJFKkSJBfvvNzEMPRVO/vpMPPrAS1HcQERGRHKMUJCIS4aKioEcPH9u2uXniCQ+FChn89JOFHj2iadzYyYoVVnLmHAYREZH8TeFKRCSfcLmgb18v27ef4LHHPBQoYPDddxa6dYvmppucrFtnUcgSERHJBoUrEZF8JjYWHnssLWQ9/LAHp9Pgq68sdO7spE2baDZt0mQsERGRi2G90Dvs3Lkzy/vu37//Qg8vIiKXSFwcPP64lx49fEyebOfNN2189pmV9u2t1KvnZ/BgD9Wra1KWiIhIVl1wuOrQoQMmkylL+xqGkeV9RUQkNIoWNRg+3MODD3p54QU7s2bZ2LDByoYNVpo18zNokIeKFRWyREREzueCw9WoUaNyow4REQmxyy83GDPGQ+/eXp5/3s5779lYs8bKmjVWWrXyMXCgl3LlFLJERETOJseucxWJdJ0ryU3q18gTaX26Z4+JceMcvP++FcMwYTIZtG/v57HHPJQpkz9+dURan0oa9WvkUZ9GpnDq10t+nSsREYkspUsbvPRSKp98kkzr1j4Mw8T779uoW9fFww9H8fvvOu1bRETkdApXIiJyTtddF+T111P58EM3zZv7CQRMvPuujVq1XAwc6ODvvxWyREREQOFKRESyqEKFILNmpbB8uZv69f34fCbefNNOjRounnzSwf79ClkiIpK/hV242r17N/fccw+VK1emTp06jB07Fq/Xe977PfroozRv3pzKlStTvXp1unTpwsaNGy9BxSIi+Uu1akHmz09h4cJkatb04/GYmD49LWSNGGHnyJFQVygiIhIaYRWujh07Rrdu3fD5fEyZMoVHHnmEuXPnMnr06PPe1+fzcffdd/Piiy8yduxYChUqRI8ePdi+ffslqFxEJP+pUyfA4sUpvPdeMlWqBEhONjF5soNq1WIYN85OUlKoKxQREbm0Lngp9tw0Z84c3G43U6dOpVChQgAEAgGGDRtGz549KVas2FnvO2nSpAy369evT5MmTVi0aBHVqlXLzbJFRPItkwkaNQrQsGEyq1ZZGD3awXffWRg3zsGrr9rp08dL9+5eXK5QVyoiIpL7wmrkav369dSqVSs9WAG0aNGCYDDIpk2bLuhYFouFAgUK4PP5crhKERH5L5MJbr45wLp1ybz6agrXXhvg6FETI0Y4qF7dxfTpNlJTQ12liIhI7gqrcLVnzx5Kly6dYVtsbCxFixZlz549572/YRj4/X6OHDnCa6+9xm+//UanTp1yq1wREfkPsxnatfOzfn0yU6emcOWVQQ4eNPPkk1HUrOnijTdsZGEarYiISJ4UVqcFJiUlERsbm2l7wYIFOXbs2HnvP3/+fJ544gkAnE4nEydOpEqVKtmqyWoNff48ecGyrFy4TPIO9WvkUZ+eYrXCHXcEufXWFGbPtjJ+vI29e80MGhTFtGl2HnvMR6dOfqxh9VsoM/VpZFK/Rh71aWTKi/0a5r/WLkyTJk247rrrOHLkCCtXrqRfv35MnTqVBg0aXNTxzGYTcXHhM1EgNjY61CVILlC/Rh71aUb9+sEDD8Crr8Jzz8Hvv5t56CEHkyc7eOYZ6NQJLJZQV3lu6tPIpH6NPOrTyJSX+jWswlVsbCzHjx/PtP3YsWMULFjwvPePj48nPj4eSFvQ4tixY4wbN+6iw1UwaJCUlHxR981JFouZ2NhokpJSCASCoS5Hcoj6NfKoT8+tSxdo3x5ef93KpEl2fvrJRJcuMHx4kCFDvLRuHcAUZpfKUp9GJvVr5FGfRqZw6tfY2OgsjaCFVbgqXbp0prlVx48f58CBA5nmYmXF9ddfz/r167NVk98fPm/QQCAYVvVIzlC/Rh716dnZ7dCrl5c77/Ty6qt2pk2z8/33Zrp1i6JixQCDBnlo2jT8Qpb6NDKpXyOP+jQy5aV+DasTGOvXr8+nn35K0mkXR1m5ciVms5k6depc8PE+//xzSpYsmZMliohIDoiJgUce8bJ9+wn69/fgchl8/bWFLl2ctGzpZP16C4YR6ipFREQuTFiFq86dO+NyuejduzcbN25kwYIFjB07ls6dO2e4xlW3bt1o1qxZ+u2PP/6Yfv368cEHH7B161ZWr15N37592bhxI7179w7FUxERkSwoVAgGD/ayfbub3r29REcbfP65hY4dndxySzRbtoT5ZCwREZHThNVpgQULFuStt95i+PDh9O7dG5fLRceOHXnkkUcy7BcMBgkEAum3S5YsidfrZcKECRw5coS4uDjKli3LzJkzqVGjxqV+GiIicoEKFzZ4+mkPvXp5mTTJzttv29i0yUrbtlYaNfIzeLCHKlXyxikhIiKSf5kMQydenE0gEOTwYXeoy8BqNRMX5+LIEXeeOd9Uzk/9GnnUpznnzz9NTJxo5913bfj9aROwbr7Zx6BBXq6//tL9bNWnkUn9GnnUp5EpnPo1Pt6VpQUtwuq0QBEREYASJQwmTPCwaZOb227zYTYbrFxpo1EjFz16RPHTT/r1JSIi4Ue/nUREJGxdfbXB1KmprF+fTLt2PgA++MBGvXpO+vSJ4pdfwmxZQRERydcUrkREJOwlJgZ59dVU1q1zc/PNPoJBE3Pn2qhTx8WAAQ7+/FMhS0REQk/hSkRE8ozy5YO8/XYqq1a5adzYj99vYuZMOzfe6GLoUAf79ilkiYhI6ChciYhInlOlSpA5c1JYvDiZ2rX9eL0mZsywU6OGi2HDHBw6pJAlIiKXnsKViIjkWTfeGGDhwhTmz0/mhhsCpKSYmDbNTrVqLkaPtnPsWKgrFBGR/EThSkRE8jSTCerXD7B8eTKzZydToUIAt9vE8887qFYthokT7Zw4EeoqRUQkP1C4EhGRiGAyQdOmAdauTeb111O47roAx46ZGDXKQfXqLqZNs5GcHOoqRUQkkilciYhIRDGZoHVrPx99lMxLL6VQunSQQ4fMDBsWRY0aLl57zYbHE+oqRUQkEilciYhIRLJYoEMHPxs3upk0KYWSJYPs329myJAobrzRxaxZNny+UFcpIiKRROFKREQimtUKt9/uZ/NmN2PGpHLZZUH27jXTv38UtWu7mDvXSiAQ6ipFRCQSKFyJiEi+YLfDPff42LrVzfDhqRQpEuS338z06RNN/fpOFi2yEgyGukoREcnLFK5ERCRfiY6Gnj19fPaZmyee8FCokMFPP1m4//5oGjd2snKlBcMIdZUiIpIXKVyJiEi+FBMDfft62b79BI895iEmxuC77yzcdZeTm292sm6dQpaIiFwYhSsREcnXYmPhscfSQlbfvh6cToMvv7TQubOTVq2i+OSTUFcoIiJ5hcKViIgIEB8PTzzh5bPP3PTs6cXhMNiyxULDhtC+fRTbt+tXpoiInJt+U4iIiJwmIcFg+HAPn33m5t57fdhs8MknFlq2dNGlSzTffKNfnSIicmb6DSEiInIGl19uMH68lx9+gDvu8GGxGKxZY6VJExf33hvF99/rV6iIiGSk3wwiIiLncPXVMHWql40b3dxyiw+TyWDpUhsNGjh54IEo9uwxhbpEEREJEwpXIiIiWVCmjMHLL6fy8cfJtGrlwzBMLFhgo04dF/36Ofj9d4UsEZH8TuFKRETkApQrF+SNN1JZu9ZNs2Z+AgETs2fbqVXLxaBBDv7+WyFLRCS/UrgSERG5CBUrBnnnnRSWLXNTr54fn8/EG2/YqVHDxZNPOjhwQCFLRCS/UbgSERHJhurVgyxYkMLChcnUqOHH4zExfbqd6tVdPPecnSNHQl2hiIhcKgpXIiIiOaBOnQBLlqQwZ04ylSsHSE42MWmSg2rVYhg3zs7x46GuUEREcpvClYiISA4xmaBx4wCrViXz9tvJ/O9/AY4fNzFuXFrImjzZjtsd6ipFRCS3KFyJiIjkMJMJbr45wLp1ybz6agrXXBPgyBETI0Y4qF7dxfTpNlJTQ12liIjkNIUrERGRXGI2Q7t2ftavT2bKlBSuvDLIwYNmnnwyipo1Xbz5pg2vN9RViohITlG4EhERyWVWK3Tq5OfTT91MmJDKFVcE+ftvMwMHRlG7tos5c6z4/aGuUkREskvhSkRE5BKx2aBrVx9btrgZOTKVokWD/P67mb59o6lXz8X771sJBkNdpYiIXCyFKxERkUssKgruu8/Htm1unn46lfj4ILt3m+nVK5pGjZwsW2bFMEJdpYiIXCiFKxERkRBxOqF3bx/bt7sZPNhDbKzBrl0W7rknmmbNnKxda1HIEhHJQxSuREREQiwmBvr397J9+wn69/fgchl8/bWFO+5w0qqVkw0bLKEuUUREskDhSkREJEwUKgSDB3vZts3Ngw96iYoy2L7dQocOTtq3j2brVoUsEZFwpnAlIiISZooUMXjmGQ/btrm57z4vdrvBpk1W2rRx0rlzNF99pV/fIiLhSJ/OIiIiYapYMYORIz1s2eKma1cvFovBunVWmjd30a1bFDt36te4iEg40aeyiIhImCtRwmDCBA+bNrm59VYfZrPBihU2GjVy0aNHFD/9pF/nIiLhQJ/GIiIieUTp0gbTpqWyfn0y7dr5APjgAxv16jl56KEofv3VFOIKRUTyN4UrERGRPCYxMcirr6aybp2bm2/2EQyaeO89G7VruxgwwMHevQpZIiKhoHAlIiKSR5UvH+Ttt1NZudJNo0Z+/H4TM2faqVnTxeOPO9i3TyFLRORSUrgSERHJ46pWDfLeeyksXpxMrVp+vF4Tr75qp0YNF8OGOTh0SCFLRORSULgSERGJEDfeGOCDD1KYNy+ZG24IkJJiYto0O9WquRg92s6xY6GuUEQksilciYiIRBCTCRo0CLB8eTLvvJNMhQoB3G4Tzz/voFq1GCZOtHPiRKirFBGJTApXIiIiEchkgmbNAqxZk8zrr6dQtmyAY8dMjBrloHp1Fy++aCMlJdRViohEFoUrERGRCGY2Q+vWfj7+OJmXXkrh6quDHDpk5plnoqhRw8Vrr9nweEJdpYhIZFC4EhERyQcsFujQwc+mTW5eeCGFkiWD7NtnZsiQKG680cWsWTZ8vlBXKSKStylciYiI5CNWK9xxh5/Nm92MGZPKZZcF2bvXTP/+UdSp42LePCuBQKirFBHJmxSuRERE8iG7He65x8fWrW6efTaVIkWC/Pqrmd69o2nQwMnixVaCwVBXKSKStyhciYiI5GPR0dCrl4/PPnPz+OMeChUy+PFHC/fdF02TJk5WrbJgGKGuUkQkb1C4EhEREWJi4OGHvWzffoJHH/UQE2Owc6eFrl2dtGjh5KOPFLJERM5H4UpERETSxcbCwIFpIeuhhzw4nQZffGGhUycn7dpFs3mzJdQlioiELYUrERERySQ+Hp580stnn7np2dOLw2GwZYuVdu2cdOwYzfbt+gohIvJf+mQUERGRs0pIMBg+3MPWrW7uvtuL1Wqwfr2Vli1d3HlnNN98o68SIiIn6RNRREREzuuKKwzGjvWwebOb22/3YTYbrF5tpUkTF927R/HDD/pKISKiT0IRERHJsiuvNJg0KZWNG93ccosPk8lgyRIb9es7eeCBKPbsMYW6RBGRkFG4EhERkQt2zTUGL7+cyscfJ9OqlQ/DMLFggY06dVw88oiDP/5QyBKR/EfhSkRERC5auXJB3ngjlTVr3DRt6icQMPHOO3ZuvNHFoEEO/vlHIUtE8g+FKxEREcm2SpWCzJ6dwrJlburV8+PzmXjjDTs1arh46ikHBw4oZIlI5FO4EhERkRxTvXqQBQtSeP/9ZGrU8JOaauLll+1Ur+5i5Eg7R46EukIRkdyjcCUiIiI5rm7dAEuWpDBnTjKVKgVITjbxwgsOqlWLYfx4O8ePh7pCEZGcp3AlIiIiucJkgsaNA6xencxbb6VQrlyA48dNjB2bFrKmTLHjdoe6ShGRnKNwJSIiIrnKZIIWLfx89FEyr7ySwjXXBDhyxMTw4Q6qV3fxyis2UlNDXaWISPYpXImIiMglYTbD//2fn/Xrk5kyJYVSpYIcPGjmiSeiqFnTxVtv2fB6Q12liMjFU7gSERGRS8pqhU6d/Gze7Gb8+FSuuCLI33+beeyxKGrXdjFnjhW/P9RViohcOIUrERERCQmbDe66y8eWLW5GjkylaNEgv/9upm/faOrVc7FwoZVgMNRViohkncKViIiIhFRUFNx3n49t29w89VQq8fFBdu8207NnNI0aOVm+3IphhLpKEZHzU7gSERGRsOB0Qp8+aSFr0CAPsbEGu3ZZuPvuaJo3d/LhhxaFLBEJawpXIiIiElYKFIABA7xs336CRx7x4HQa7Nhh4fbbnbRu7WTjRkuoSxQROSOFKxEREQlLhQrBkCFetm9388ADXqKiDLZts3DLLU5uuSWazz7T1xgRCS/6VBIREZGwVqSIwbBhHj77zE337l5sNoONG620bu3i9tuj2bFDX2dEJDzo00hERETyhMsuMxg1ysOWLW7uvNOLxWLw4YdWmjVz0a1bFN99p681IhJa+hQSERGRPKVkSYPnn/ewaZObW2/1YTIZrFhho1EjJz17RvHzz6ZQlygi+ZTClYiIiORJpUsbTJuWyvr1ybRt68MwTCxcaKNuXRcPPRTFr78qZInIpaVwJSIiInla2bJBZsxI5cMP3dx8s49g0MR779moXdvFo486+OsvhSwRuTQUrkRERCQiVKgQ5O23U1m50k3Dhn78fhNvv22nZk0XTzzhYN8+hSwRyV0KVyIiIhJRqlYNMnduCosXJ1Orlh+Px8Qrr9ipUcPFs8/aOXw41BWKSKRSuBIREZGIdOONAT74IIV585K54YYAKSkmpk51ULmykyFD4I8/NJIlIjlL4UpEREQilskEDRoEWL48mVmzkilfPsCJEyZGj4YqVaLp2jWadessBIOhrlREIoHClYiIiEQ8kwmaNw+wdm0yM2em0rgxBIMmVq2y0rmzk5o1XUydauPQIY1micjFU7gSERGRfMNshlatAnz4IWzZkkyPHl5iYw1++83Ms89GUbmyi969o9i+3YxhhLpaEclrFK5EREQkX0pMNBgxwsOOHSeYODGVChUCeDwm5s2z0bKliyZNnMycacPtDnWlIpJXhF242r17N/fccw+VK1emTp06jB07Fq/Xe8777N+/n7Fjx9KuXTuqVKlC/fr1GTBgAHv37r1EVYuIiEhe5XJBly4+1q5NZsUKN506+XA4DL791sKAAVFUrBjD0KEOfvwx7L42iUiYCatPiWPHjtGtWzd8Ph9TpkzhkUceYe7cuYwePfqc99u5cydr1qyhRYsWvPjiiwwePJgff/yRW2+9lcNab1VERESywGSCG24IMmVKKjt2nOCZZ1K56qogx4+bmDHDTt26Ltq3j2bxYis+X6irFZFwZA11AaebM2cObrebqVOnUqhQIQACgQDDhg2jZ8+eFCtW7Iz3u+GGG1ixYgVW66mnU7VqVRo2bMgHH3zAvffeeynKFxERkQgRHw8PPuijVy8fn3xi4Y03bKxebWXTprR/xYoF6dLFx113+bjiCk3OEpE0YTVytX79emrVqpUerABatGhBMBhk06ZNZ71fbGxshmAFcNlllxEfH8/+/ftzq1wRERGJcGYzNGoU4O23U9m+3U3//h6KFg2yb5+Z5593cMMNLrp1i+Ljj7Wcu4iEWbjas2cPpUuXzrAtNjaWokWLsmfPngs61i+//MKhQ4coU6ZMTpYoIiIi+VSJEgaDB3v58ks3r76aQu3afgIBEytW2LjtNie1a7t46SUbR46EulIRCZWwOi0wKSmJ2NjYTNsLFizIsWPHsnwcwzAYMWIECQkJtGrVKls1Wa2hz58WiznDfyUyqF8jj/o08qhPI1N2+9VqhQ4dgnTo4GHXLi9vvmnj3Xet7Nlj5umnoxg1ykH79n66d/dTtaqGsy4FvVcjU17s17AKVzllypQpbNmyhRkzZuB0Oi/6OGazibg4Vw5Wlj2xsdGhLkFygfo18qhPI4/6NDLlRL/Wrp327/nnYfZsePFF2LHDxLvv2nj3XRvVqsEDD0DnzpCNrySSRXqvRqa81K9hFa5iY2M5fvx4pu3Hjh2jYMGCWTrG3LlzmTZtGs899xy1atXKVj3BoEFSUnK2jpETLBYzsbHRJCWlEAjoL2CRQv0aedSnkUd9Gplyq19vvRU6doRt28y8/rqNDz6wsH27ie7doX9/g9tv93PvvT6uuUYLYOQ0vVcjUzj1a2xsdJZG0MIqXJUuXTrT3Krjx49z4MCBTHOxzmTNmjU888wz9O3bl44dO+ZITX5/+LxBA4FgWNUjOUP9GnnUp5FHfRqZcqtfq1YNUrWqn2eeSRvBeustG7//bubll228/LKN+vX93H23j5tv9mMNq29ieZ/eq5EpL/VrWJ3AWL9+fT799FOSkpLSt61cuRKz2UydOnXOed+tW7fSv39/br31Vnr37p3bpYqIiIicU5EiBg895GXrVjezZyfTvLkfk8lg/Xor994bzQ03uBg3zs4//5hCXaqI5JCwCledO3fG5XLRu3dvNm7cyIIFCxg7diydO3fOcI2rbt260axZs/Tbu3fvpnfv3lx11VW0a9eOr776Kv3f77//HoqnIiIiIgKAxQJNmwaYNSuFbdvc9O3roUiRIH//bWbcOAdVqrjo3j2KDRssGDpjUCRPC6vB6IIFC/LWW28xfPhwevfujcvlomPHjjzyyCMZ9gsGgwQCgfTbO3bs4Pjx4xw/fpzbb789w77t27dn9OjRl6R+ERERkXMpVcrgiSe8PPaYl6VLrbz5po2tW60sWWJjyRIb114b4O67fdx2m48sTjcXkTBiMgz9jeRsAoEghw+7Q10GVquZuDgXR46488z5pnJ+6tfIoz6NPOrTyBRu/bpzp5k337Qxf74NtzvtFEGn0+CWW3zcfbePihVDX2O4C7c+lZwRTv0aH+/K0oIWYXVaoIiIiEh+c/31QcaN8/D11ycYPTqVcuUCJCebmDXLTtOmLlq0cDJnjpWUlFBXKiLno3AlIiIiEgYKFIB77/Xx8cfJLF6czC23+LDZDD7/3ELfvtFUrhzDM884+OUXLYAhEq4UrkRERETCiMkEN94Y4OWXU/nySzdDh3ooUSLIkSMmXnzRTs2aMXTqFM2KFVb8/lBXKyKnU7gSERERCVMJCQb9+nnZts3NzJnJNG6ctpz7Rx9Z6dYtmurVXUycaGffPo1miYQDhSsRERGRMGexwE03BZgzJ4UtW9z07u0lPj7I3r1mRo1KW869R48oPv1Uy7mLhJLClYiIiEgecvXVBk8/7eGrr9xMnZpCtWoB/H4TH3xg4//+z0n9+k5ee81GUlKoKxXJfxSuRERERPKgqCi47TY/y5cn8+GHbrp29eJ0Gvzwg4UhQ6KoWDGGRx918O23+roncqno3SYiIiKSx1WoEGTChLTl3EeOTOXaa9OWc3/7bTuNG7to1crJ/PlWPJ5QVyoS2RSuRERERCJEbCzcd5+PjRuTWbgwmbZtfVitBtu2WXjwwWgqV3YxfLid337TAhgiuUHhSkRERCTCmExQp06AGTPSlnMfNMjD5ZcHOXTIzJQpDmrUcHHHHdGsWWMhEAh1tSKRQ+FKREREJIIVK2YwYICXzz938+abKTRo4McwTKxda6VLFyc1ariYPNnOgQMazRLJLoUrERERkXzAaoWWLf3Mm5fCli0n6NXLS6FCBn/8YWbECAeVK7vo1SuKrVu1nLvIxVK4EhEREclnSpc2ePZZDzt2nGDy5BSqVAng85l4/30bbdo4adjQyZtv2jhxItSViuQtClciIiIi+VR0NHTu7GfVqmRWr3Zzxx1eoqIMdu2yMHBg2nLugwY52LVLXxlFskLvFBERERGhcuUgL7yQtpz78OGplCkT5MQJE2+8YadBAxdt20azcKEVrzfUlYqEL4UrEREREUlXqBD07Onj00/dzJ+fTKtWPiwWgy1brPTsmbac+8iRdv74QwtgiPyXwpWIiIiIZGIyQf36Ad54I5UvvnDz6KMeihULcvCgmRdecFC9uouuXaNZt85CMBjqakXCg8KViIiIiJzT5ZcbDBzo5Ysv3Lz2Wgr16vkJBk2sWmWlc2cnNWu6mDrVxqFDGs2S/E3hSkRERESyxGaDNm38LFiQwqZNbnr08BIba/Dbb2aefTaKypVd9O4dxfbtZi3nLvmSwpWIiIiIXLBrrw0yYkTacu4TJ6ZSoUIAj8fEvHk2WrZ00bSpk5kzbbjdoa5U5NJRuBIRERGRi+ZyQZcuPtauTWbFCjedOvlwOAy++cbCgAFpy7kPHergxx/1tVMin17lIiIiIpJtJhPccEOQKVNS2bHjBE8/ncpVVwU5ftzEjBl26tZ10b59NIsXW/H5Ql2tSO5QuBIRERGRHBUfD717+9iyxc2cOcncfLMPs9lg0yYr990XTdWqLkaPtvPXX1oAQyKLwpWIiIiI5AqzGRo3DvD226ls3+7mkUc8FC0aZN8+M88/7+CGG1zcfXcUH3+s5dwlMihciYiIiEiuK1HCYMgQL19+6eaV/2/vzuOjKu89jn9nkkxWslAhV0GQ8JKASAggYbMgaVwoLvgC2QpGNqEFI1iKQqEIeoViUSEolRBAEGTxYhQaQLBpuIKioIC1VNAoQiiBAiaZmSyTmXP/SMltGtY4ySz5vP+ReeacF7/JLw8zX59znllWop49K+R0mpSdHaTBg8PUs2e4li4N0oULnq4UqD3CFQAAAOqNxSINGFChrKwS7d5t05gx5YqIMJSXZ9bs2SHq2DFCaWkh+vxzPqbC9/BbCwAAAI9o29alefPKdPiwVS++WKrbbnOqtNSk9euDdO+94brnnjCtWxcou93TlQLXhnAFAAAAj4qIkFJTHcrJsWvrVpsGDnTIYjF08GCAJk8OVceOEZo1K1jffMMGGPBuhCsAAAB4BZNJSkpyaenSUh08aNPMmWVq0cKlwkKTXn/doh49IjRoUKi2bg1URYWnqwVqIlwBAADA69xwg6G0tHLt22fTunV23X13hUwmQ7t3B2r06FB16RKuP/zBotOnWc2C9yBcAQAAwGsFBEgpKU6tXVuiTz6xKS2tTDfc4NI//mHWggXB6tQpXI89Fqw//1kyDE9Xi4aOcAUAAACf0LKloZkzK7dzX7q0RElJldu5v/deoH72M6l791BlZASpsNDTlaKhIlwBAADApwQHSwMHVmjr1hLl5Ng0apRDERHSsWNm/fa3ldu5P/VUsA4f5qMu6he/cQAAAPBZ7du7tHBhufLzpRdfLFPbtk7Z7Sa9+aZFKSnh6tcvTBs2BKq01NOVoiEgXAEAAMDnRUZKY8ZUKDfXrvfes+vhhx0KCjJ04ECAnniicjv3Z58N1rffsgEG6g7hCgAAAH7DZJK6d3fq9ddL9fnnNs2YUabmzV26cMGk116zqFu3CA0ZEqpt29jOHe5HuAIAAIBfatrU0OTJ5fr0U5vWrLErOblyO/ecnEClpoaqa9dwvfyyRQUFrGbBPQhXAAAA8GsBAdK99zq1fn2JPv7YpokTyxUTYyg/36x58yq3c3/88RDt3RvAdu74UQhXAAAAaDBatTI0e3aZDh2yasmSEnXp4lRFhUlZWUEaMCBMvXuHKTMzSEVFnq4UvohwBQAAgAYnJEQaPLhC27bZ9cEHNo0cWa6wMENffRWg6dNDlJAQoalTg/XXv/JxGdeO3xYAAAA0aB06uLRwYeVq1gsvlOrWWyu3c1+92qLk5HD17x+mt98OVFmZpyuFtyNcAQAAAJKioqSxYx368EO73nnHrgcfdCgw0NCnnwboV78KVWJiuJ57zqLjx9kAA5dGuAIAAAD+jckk9erl1PLlldu5P/10mW680aVz58xKTw9WUlK4hg8P1c6dAXI6PV0tvAnhCgAAALiM2FhDv/51uQ4csGnlyhL16VMhwzBp165A/eIXYUpKCtfixRadPctqFghXAAAAwFUFBkr9+1do06YSffyxVRMmlCs62tCJE2Y9/3ywEhPDNWFCiPbtYzv3hoxwBQAAAFyHuDhDc+eW6eBBqxYtKlGnTk45HCZt3hykBx4I0113hWnVqiBZrZ6uFPWNcAUAAADUQliYNGxYhXbssOv9920aPrxcISGGjhwJ0LRpldu5P/10sI4c4SN3Q0GnAQAAgB8pMdGlV16p3M597txSxcW5ZLWatHKlRX36hOvBB0P1zjuBKi/3dKWoS4QrAAAAwE1iYqQJExzau9emTZvs6t/foYAAQx9/HKjx4yu3c3/hBYtOnGADDH9EuAIAAADczGyW+vRxauXKUn32mU1Tp5YpNtalf/7TrFdeCVbXruEaOTJUf/5zgFwuT1cLdyFcAQAAAHXoxhsNTZtWrs8+sykzs0Q//WmFXC6TduwI1NChYerWLVxLlgTp3DlWs3wd4QoAAACoB0FB0gMPVOh//qdEH35o07hx5YqMNHT8uFlz54YoMTFcEyeGaP9+M9u5+yjCFQAAAFDP2rRx6b//u3IDjJdeKlWHDk6VlZm0aVOQfv7zcKWkhGnNmiDZbJ6uFNeDcAUAAAB4SHi4NGKEQ7t22bVtm02DBzsUHGzoiy8C9OtfV27nPmNGsI4e5WO7L6BLAAAAgIeZTFKXLi4tWVKqQ4esmj27VC1bulRcbNLy5RbdeWe4Hn44VO+9FyiHw9PV4nIIVwAAAIAXadxYmjjRoX37bFq/3q777nPIbDa0Z0+gxo4NVefO4Zo/36JTp9gAw9sQrgAAAAAvZDZLyclOrV5dqv37bZoypUxNmrhUUGDWSy8Fq0uXcD32WIj+8he2c/cWhCsAAADAyzVvbmj69HJ9/rlNy5aVqEePCjmdJmVnB2nw4DD17BmupUuDdOGCpytt2AhXAAAAgI+wWKQBAyr07rsl2r3bptGjyxURYSgvz6zZs0PUsWOE0tJC9PnnfMz3BH7qAAAAgA9q29al+fPLdPiwVS++WKrbbnOqtNSk9euDdO+94brnnjCtWxcou93TlTYchCsAAADAh0VESKmpDuXk2LV1q00DBzpksRg6eDBAkyeHqmPHCM2aFaxvvmEDjLpGuAIAAAD8gMkkJSW5tHRpqQ4etGnmzDK1aOFSYaFJr79uUY8eERo0KFRbtwaqosLT1fonwhUAAADgZ264wVBaWrn27bNp3Tq77r67QiaTod27AzV6dKi6dAnXH/5g0enTrGa5E+EKAAAA8FMBAVJKilNr15bok09sSksr009+4tI//mHWggXB6tQpXGPGhOh//zdAhuHpan0f4QoAAABoAFq2NDRzZrkOHrRp6dISJSVVbue+ZUuQBg4M0513hikjI0iFhZ6u1HcRrgAAAIAGJDhYGjiwQlu3lignx6bU1HKFhRk6dixAv/1t5XbuTz0VrMOHiQrXi58YAAAA0EC1b+/Siy+W6YsvrJo3r1Rt2zplt5v05psWpaSEq1+/MG3YEKjSUk9X6hsIVwAAAEAD16iRNGaMQ7m5dr37rl0PP+xQUJChAwcC9MQTldu5P/tssL79lg0wroRwBQAAAEBS5XbuPXo49frrpfr8c5tmzChTs2YuXbhg0muvWdStW4SGDAnVtm1s534phCsAAAAANTRtamjy5HLt32/T6tV2JSdXpqmcnEClpoaqa9dwvfyyRQUFrGZdRLgCAAAAcFkBAdJ99zm1fn2J9u2zauLEcsXEGMrPN2vevMrt3B9/PER797KdO+EKAAAAwDVp1crQ7NllOnjQqvT0EnXp4lRFhUlZWUEaMCBMvXuHKTMzSMXFnq7UMwhXAAAAAK5LaKg0ZEiFtm2z64MPbBo5snI796++CtD06SHq0CFCU6cG669/bVhxo2G9WgAAAABu1aGDSwsXlunQIateeKFUt95auZ376tUWJSeHq3//ML39dqDKyjxdad0jXAEAAAD40aKipLFjHfrwQ7s2b7brwQcdCgw09OmnAfrVr0KVmBiu556z6Phx/90Ag3AFAAAAwG1MJunOO51avrxUn31m07RpZbrxRpfOnTMrPT1YSUnhGj48VDt3Bsjp9HS17kW4AgAAAFAn/uu/DE2dWq4DB2xaubJEffpUyDBM2rUrUL/4RZiSksK1eLFFZ8/6x2oW4QoAAABAnQoMlPr3r9CmTSX66COrxo8vV1SUoRMnzHr++crt3CdMCNG+fb69nTvhCgAAAEC9ad3a0HPPVW6AsWhRiRITnSovN2nz5iA98ECY7rorTKtW+eZ27oQrAAAAAPUuLEwaNqxC779v144dNg0b5lBIiKEjRwI0bVqI2rcP06pVnq7y+nhduPrmm280atQoJSYmqlevXlqwYIHKy8uvet7atWs1fvx4de/eXfHx8dq+fXs9VAsAAADgx+rUyaVFi0p16JBVc+eWKi7OJavVpC1bPF3Z9fGqcFVYWKjU1FQ5HA6lp6drypQp2rhxo+bPn3/Vc999911duHBBffr0qYdKAQAAALhbTIw0YYJDe/falJtbohUrPF3R9Qn0dAH/bv369bLZbFqyZImio6MlSU6nU3PmzNH48eMVGxt7xXPNZrNOnjyprKys+ikYAAAAgNuZzZVfThwVJV244Olqrp1XrVzt3r1bPXr0qApWktSvXz+5XC7t2bPniueazV71UgAAAAA0MF6VSPLy8hQXF1dtLDIyUk2aNFFeXp6HqgIAAACAq/OqywKLiooUGRlZYzwqKkqFhYUeqEgKDPR8/gwIMFf7L/wDffU/9NT/0FP/RF/9Dz31T77YV68KV97GbDYpJibc02VUiYwM9XQJqAP01f/QU/9DT/0TffU/9NQ/+VJfvSpcRUZGqvgS3xZWWFioqKioeq/H5TJUVGSv97/3PwUEmBUZGaqiohI5nS5PlwM3oa/+h576H3rqn+ir/6Gn/smb+hoZGXpNK2heFa7i4uJq3FtVXFyss2fP1rgXq75UVHjPBHU6XV5VD9yDvvofeup/6Kl/oq/+h576J1/qq1ddwNi7d2/t3btXRUVFVWPbt2+X2WxWr169PFgZAAAAAFyZV61cDR06VGvWrNHEiRM1fvx4FRQUaMGCBRo6dGi177hKTU3VqVOntHPnzqqxL774Qvn5+Tp//rwk6dChQ5Kkxo0bKykpqX5fCAAAAIAGx6vCVVRUlN544w0999xzmjhxosLDwzVo0CBNmTKl2nEul0tOp7Pa2Nq1a/XOO+9UPV7xr69zTkpK0po1a+q+eAAAAAANmskwDMPTRXgrp9Ol8+dtni5DgYFmxcSE68IFm89cb4qro6/+h576H3rqn+ir/6Gn/smb+tq4cfg1bWjhVfdcAQAAAICvIlwBAAAAgBsQrgAAAADADQhXAAAAAOAGhCsAAAAAcAPCFQAAAAC4AeEKAAAAANyA77m6AsMw5HJ5x48nIMAsp5PvbfA39NX/0FP/Q0/9E331P/TUP3lLX81mk0wm01WPI1wBAAAAgBtwWSAAAAAAuAHhCgAAAADcgHAFAAAAAG5AuAIAAAAANyBcAQAAAIAbEK4AAAAAwA0IVwAAAADgBoQrAAAAAHADwhUAAAAAuAHhCgAAAADcgHAFAAAAAG5AuAIAAAAANyBcAQAAAIAbBHq6gIbu+PHjyszM1KFDh3Ts2DHFxcVp69atVz3PMAxlZGRo3bp1On/+vNq1a6fp06crMTGx7ovGFdW2p8nJycrPz68xfvjwYQUHB9dFqbhG27Zt03vvvacvv/xSRUVFatmypUaOHKmBAwfKZDJd9jzmqXerbV+Zq94rNzdXGRkZ+vrrr2W1WhUbG6uUlBRNmjRJjRo1uuK5mzZt0vLly3Xq1Cm1atVKU6ZMUd++feupclxObXs6cuRIffLJJzXGs7Oz1bp167osGdfJZrOpX79+Kigo0Ntvv60OHTpc9lhfeF8lXHnYsWPHlJubq44dO8rlcskwjGs6LyMjQ4sXL9bUqVMVHx+vtWvXavTo0Xr33Xd1880313HVuJLa9lSS7r33Xo0ePbramMVicXeJuE6rVq1Ss2bN9MwzzygmJkZ79+7VrFmzdPr0aU2aNOmy5zFPvVtt+yoxV73VDz/8oISEBI0cOVLR0dE6duyY0tPTdezYMa1YseKy5/3pT3/SrFmzNGHCBHXv3l3Z2dmaNGmS1q5d61Uf2hqi2vZUkjp37qynn3662ljz5s3rslzUwmuvvSan03lNx/rE+6oBj3I6nVV/fvrpp43+/ftf9ZzS0lKjc+fOxsKFC6vGysrKjL59+xqzZ8+uizJxHWrTU8MwjL59+xpz5sypq7LwI5w7d67G2MyZM43OnTtX6/e/Y556v9r01TCYq75mw4YNRps2bYzTp09f9ph77rnHeOqpp6qNDRkyxBg7dmxdl4dauJaejhgxwnj88cfrsSrUxtdff20kJiYab731ltGmTRvj8OHDlz3WV95XuefKw8zm62/BZ599JqvVqn79+lWNWSwW3X333dq9e7c7y0Mt1Kan8G6NGzeuMdauXTtZrVbZ7fZLnsM89X616St8T3R0tCTJ4XBc8vkTJ07ou+++qzZXJennP/+5PvroI5WXl9d1ibhOV+spfMfzzz+voUOHqlWrVlc91lfeV/kU6IPy8vIkSXFxcdXGW7durVOnTqm0tNQTZcENtmzZottvv12dOnXSuHHj9NVXX3m6JFzGgQMHFBsbq4iIiEs+zzz1TVfr60XMVe/mdDpVVlamL7/8Uq+++qqSk5MveznYxbn6nx/uWrduLYfDoRMnTtR5vbi66+npRZ988okSExPVoUMHjRgxQp9++mk9VYtrsX37dh09elQTJ068puN95X2Ve658UFFRkSwWS40bpyMjI2UYhgoLCxUSEuKh6lBbycnJSkhI0E033aQTJ07oj3/8o4YPH66srCzvuY4YkqT9+/crOzu7xrX8/4556nuupa8Sc9UX9O3bVwUFBZKkn/70p1q4cOFljy0sLJRUOTf/3cXHF5+HZ11PTyWpa9eueuihh3TLLbfozJkzyszM1KhRo7RmzRp16tSpPkrGFZSUlGj+/PmaMmXKVf9n1kW+8r5KuAK8xMyZM6v+fMcdd6hXr17q16+fMjMz9eyzz3quMFRz+vRpTZkyRd26ddOjjz7q6XLgJtfTV+aq91u2bJlKSkr09ddfa+nSpZowYYJWrlypgIAAT5eGWrrenqalpVV7fNddd+n+++/Xa6+9poyMjPooGVewdOlS/eQnP9HAgQM9XYrbEa58UGRkpMrLy1VWVlYtvRcVFclkMikqKsqD1cFdmjZtqi5duujLL7/0dCn4l6KiIo0bN07R0dFKT0+/4v11zFPfcT19vRTmqvdp27atJKlTp07q0KGDHnroIe3cuVP33XdfjWMvzsXi4mI1adKkaryoqKja8/Cs6+nppYSFhalPnz7asWNHXZaJa5Cfn68VK1bo1VdfVXFxsSRV3edqt9tls9kUHh5e4zxfeV8lXPmgi9eafvvtt1X/2EiV16LedNNNXrEkCvib0tJSjR8/XsXFxdqwYcNVvzOHeeobrrev8D3x8fEKCgrS999/f8nnL87VvLy8avdy5OXlKSgoiEs9vdDVegrvdvLkSTkcDj3++OM1nnv00UfVsWNHbdy4scZzvvK+SrjyQZ07d1ZERIS2bdtW9cvlcDj0/vvvq3fv3h6uDu5SUFCgAwcO6KGHHvJ0KQ1eRUWFJk+erLy8PK1du1axsbFXPYd56v1q09dLYa56t0OHDsnhcFx284Obb75Zt9xyi7Zv366UlJSq8ezsbPXo0YPvL/NCV+vppdjtdv3lL3+54hfUon60a9dOq1evrjZ25MgRzZs3T3PmzLlsj3zlfZVw5WElJSXKzc2VVLlMarVatX37dklSUlKSGjdurNTUVJ06dUo7d+6UJAUHB2v8+PFKT09X48aN1aZNG7311lv64YcfNGbMGI+9FlSqTU+3bt2qnJwc9enTR02bNtWJEye0bNkyBQQEaNSoUR57Lag0Z84c5eTk6JlnnpHVatXBgwernrvttttksViYpz6oNn1lrnq3SZMm6fbbb1d8fLxCQkL097//XZmZmYqPj68KTjNmzFBWVpb+9re/VZ33xBNPaOrUqWrRooW6deum7OxsHT58WG+++aanXgr+pTY93b9/v5YvX667775bzZo105kzZ7Ry5UqdPXtWixYt8uTLgSov7+vWrdsln2vfvr3at28vST77vkq48rBz587pySefrDZ28fHq1avVrVs3uVyuGt9cPW7cOBmGoRUrVuj8+fNq166dMjMzuXzBC9Smp82bN9eZM2f0wgsvqLi4WI0aNVL37t2VlpZGT73Anj17JEnz58+v8dwHH3yg5s2bM099UG36ylz1bgkJCcrOztayZctkGIaaNWumRx55RGPGjKlagbrUXL3//vtVUlKijIwMLVu2TK1atdKSJUvYVc4L1KanTZo0kcPh0Msvv6wffvhBoaGh6tSpk+bMmaOEhARPvRRcJ199XzUZhmF4uggAAAAA8HV8iTAAAAAAuAHhCgAAAADcgHAFAAAAAG5AuAIAAAAANyBcAQAAAIAbEK4AAAAAwA0IVwAAAADgBoQrAADq0ObNmxUfH68vvvjC06UAAOpYoKcLAADgx9q8ebOmT59+2ec3bNigxMTE+isIANAgEa4AAH4jLS1NzZs3rzHeokULD1QDAGhoCFcAAL/Ru3dvdejQwdNlAAAaKO65AgA0CCdPnlR8fLwyMzO1atUq9e3bVwkJCRoxYoSOHj1a4/iPPvpIw4cPV2Jiou644w798pe/1DfffFPjuIKCAs2YMUN33nmnbr/9diUnJ2v27NkqLy+vdlx5ebnmzZun7t27KzExURMnTtT58+fr7PUCAOofK1cAAL9htVprBBaTyaSYmJiqx1lZWbLZbBo+fLjKysq0Zs0apaamasuWLbrhhhskSXv37tW4cePUvHlzTZo0SaWlpXrzzTc1bNgwbd68uerSw4KCAg0aNEjFxcUaPHiw4uLiVFBQoB07dqi0tFQWi6Xq733++ecVGRmpSZMmKT8/X2+88Ybmzp2rV155pe5/MACAekG4AgD4jccee6zGmMViqbZT3/fff6/3339fsbGxkiovJXzkkUeUkZFRtSnGggULFBUVpQ0bNig6OlqSlJKSoocffljp6en6/e9/L0l66aWX9M9//lMbN26sdjnik08+KcMwqtURHR2tFStWyGQySZJcLpfWrFmj4uJiNWrUyG0/AwCA5xCuAAB+43e/+51atWpVbcxsrn4FfEpKSlWwkqSEhAR17NhRubm5mj59us6cOaMjR45o7NixVcFKktq2bauePXsqNzdXUmU42rVrl/r27XvJ+7wuhqiLBg8eXG3sjjvu0KpVq5Sfn6+2bdvW+jUDALwH4QoA4DcSEhKuuqFFy5Yta4zdcsst2rZtmyTp1KlTklQjpElS69at9eGHH8put8tut8tqterWW2+9ptpuuummao8jIyMlSUVFRdd0PgDA+7GhBQAA9eA/V9Au+s/LBwEAvouVKwBAg3L8+PEaY999952aNWsm6f9XmL799tsax+Xl5SkmJkZhYWEKCQlRRESEjh07VrcFAwB8BitXAIAGZdeuXSooKKh6fPjwYR06dEi9e/eWJDVt2lTt2rVTVlZWtUv2jh49qj179qhPnz6SKleiUlJSlJOTU23DjItYkQKAhoeVKwCA39i9e7fy8vJqjHfu3LlqM4kWLVpo2LBhGjZsmMrLy7V69WpFR0dr7NixVcdPmzZN48aN05AhQzRo0KCqrdgbNWqkSZMmVR331FNPac+ePRo5cqQGDx6s1q1b6+zZs9q+fbvWrVtXdV8VAKBhIFwBAPzG4sWLLzk+b948JSUlSZIGDBggs9msN954Q+fOnVNCQoJmzZqlpk2bVh3fs2dPLV++XIsXL9bixYsVGBiorl276je/+Y1uvvnmquNiY2O1ceNGLVq0SFu2bJHValVsbKx69+6tkJCQun2xAACvYzK4bgEA0ACcPHlSP/vZzzRt2jSNGTPG0+UAAPwQ91wBAAAAgBsQrgAAAADADQhXAAAAAOAG3HMFAAAAAG7AyhUAAAAAuAHhCgAAAADcgHAFAAAAAG5AuAIAAAAANyBcAQAAAIAbEK4AAAAAwA0IVwAAAADgBoQrAAAAAHADwhUAAAAAuMH/ATZsEBXHP+4nAAAAAElFTkSuQmCC\n"
+          },
+          "metadata": {}
+        }
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "IQLpN-Q1jvW7"
+      },
+      "source": [
+        "## Evaluation\n",
+        "\n",
+        "For a better measure of the quality of the model, let's see the model accuracy, precision, recall and F1 score for the two data sets (tweets and news headlines)."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "#Redefine the evaluate function → classification report + confusion matrix\n",
+        "def evaluate(loader):\n",
+        "  model.eval()\n",
+        "\n",
+        "  n_correct, n_all = 0, 0\n",
+        "\n",
+        "  all_predictions = []\n",
+        "  all_labels = []\n",
+        "\n",
+        "  for batch in loader:\n",
+        "    batch = tuple(t.to(device) for t in batch)\n",
+        "    b_input_ids, b_input_mask, b_labels = batch\n",
+        "\n",
+        "    with torch.no_grad():\n",
+        "      outputs = model(b_input_ids, token_type_ids=None,\n",
+        "                      attention_mask=b_input_mask)\n",
+        "      logits = outputs[0]\n",
+        "\n",
+        "    logits = logits.detach().cpu().numpy()\n",
+        "    predictions = np.argmax(logits, axis=1)\n",
+        "\n",
+        "    labels = b_labels.to('cpu').numpy()\n",
+        "    n_correct += np.sum(predictions == labels)\n",
+        "    n_all += len(labels)\n",
+        "\n",
+        "    #Update preds and labels for the classification report\n",
+        "    all_predictions.extend(predictions)\n",
+        "    all_labels.extend(labels)\n",
+        "\n",
+        "  print('Accuracy: [{}/{}] {:.4f}'.format(n_correct, n_all,\n",
+        "                                          n_correct/n_all))\n",
+        "\n",
+        "  report = classification_report(all_labels, all_predictions, digits= 4)\n",
+        "  print(\"Classification Report:\\n\", report)\n",
+        "\n",
+        "  # Create confusion matrix and plot\n",
+        "  conf_matrix = confusion_matrix(all_labels, all_predictions)\n",
+        "  plt.figure(figsize=(8, 6))\n",
+        "  sns.heatmap(conf_matrix, annot=True, fmt='d', cmap='Blues',\n",
+        "              xticklabels=[str(i) for i in range(conf_matrix.shape[1])],\n",
+        "              yticklabels=[str(i) for i in range(conf_matrix.shape[0])])\n",
+        "  plt.title('Confusion Matrix')\n",
+        "  plt.xlabel('Prediction')\n",
+        "  plt.ylabel('Gold')\n",
+        "  plt.show()"
+      ],
+      "metadata": {
+        "id": "JVFFeXBAMHc_"
+      },
+      "execution_count": 32,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 33,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 781
+        },
+        "id": "mDIYn1Mqjz-2",
+        "outputId": "fa861e07-323c-4d43-a3cc-d3b5259b2b30"
+      },
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "------Test set 1 (Tweets):------\n",
+            "Accuracy: [975/1263] 0.7720\n",
+            "Classification Report:\n",
+            "               precision    recall  f1-score   support\n",
+            "\n",
+            "           0     0.7842    0.7598    0.7718       641\n",
+            "           1     0.7601    0.7846    0.7722       622\n",
+            "\n",
+            "    accuracy                         0.7720      1263\n",
+            "   macro avg     0.7722    0.7722    0.7720      1263\n",
+            "weighted avg     0.7724    0.7720    0.7720      1263\n",
+            "\n"
+          ]
+        },
+        {
+          "output_type": "display_data",
+          "data": {
+            "text/plain": [
+              "<Figure size 800x600 with 2 Axes>"
+            ],
+            "image/png": "iVBORw0KGgoAAAANSUhEUgAAApgAAAIsCAYAAABWatmqAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjguMCwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy81sbWrAAAACXBIWXMAAA9hAAAPYQGoP6dpAABMIklEQVR4nO3deVxV1f7/8TegKCIHxJQSNcGKNDEwzQHEWRP1eistKrXMTCsq6VcXNDX1etPMKcdyzMrUm5WVkWMpaaZZlpmaw8E5hzRmCVB+f/j13E7HYYEbAX09e5zHvWfvtddZ+9zHzY/vtfY6bvn5+fkCAAAALOJe3AMAAADAtYUCEwAAAJaiwAQAAIClKDABAABgKQpMAAAAWIoCEwAAAJaiwAQAAIClKDABAABgKQpMAAAAWIoCE8AV27dvnx5//HHdddddCgkJ0apVqyzt/9ChQwoJCdFHH31kab+lWc+ePdWzZ8/iHgYAXBAFJnCNOHDggIYOHao2bdooNDRUDRo0UExMjObNm6fs7Owi/eyEhATt2rVLcXFxGjNmjOrVq1ekn3c1JSQkKCQkRA0aNLjg97hv3z6FhIQoJCREs2fPLnD/x44d0+TJk7Vjxw4rhgsAJUKZ4h4AgCu3Zs0aPf/88/L09FTXrl112223KTc3V99//71ef/117dmzR//+97+L5LOzs7O1ZcsW9e/fXz169CiSzwgMDNTWrVtVpkzx/CurTJkyys7O1pdffqno6Ginc5999pnKlSunP//8s1B9Hz9+XFOmTFFgYKDq1KljfF1hilkAuFooMIFS7uDBg4qLi1O1atU0b948Va1a1XHukUce0f79+7VmzZoi+/xTp05Jkmw2W5F9hpubm8qVK1dk/V+Op6enGjRooM8//9ylwFy6dKlatmyp5cuXX5WxnD59Wl5eXvL09LwqnwcAhcEUOVDKzZo1S1lZWfrPf/7jVFyed/PNN+vRRx91vM/Ly9PUqVPVtm1b1atXT61bt9b48eOVk5PjdF3r1q3Vr18/bd68Wd26dVNoaKjatGmjJUuWONpMnjxZrVq1kiSNGTNGISEhat26taRzU8vn//tfTZ48WSEhIU7H1q9fr4ceekgNGzZUeHi4OnTooPHjxzvOX2wN5oYNG/Twww8rLCxMDRs21FNPPaW9e/de8PP279+vhIQENWzYUHfddZcGDhyo06dPX+qrddK5c2clJSUpLS3NcWzr1q3at2+fOnfu7NI+JSVFr732mrp06aLw8HA1aNBATzzxhHbu3Olos3HjRnXr1k2SNHDgQMdU+/n77Nmzpzp37qxt27bpkUce0Z133un4Xv6+BjM+Pl6hoaEu99+nTx81atRIx44dM75XALhSFJhAKffVV1+pRo0aatCggVH7wYMHa9KkSapbt64GDhyoRo0a6a233lJcXJxL2/379+v5559XRESEEhIS5Ovrq4SEBO3evVuS1K5dOw0cOFDSuQJszJgxGjRoUIHGv3v3bvXr1085OTl67rnnFB8fr9atW+uHH3645HXffPONnnjiCZ08eVKxsbF67LHHtGXLFj300EM6dOiQS/sBAwYoMzNTL7zwgjp27KiPPvpIU6ZMMR5nu3bt5ObmphUrVjiOLV26VMHBwapbt65L+4MHD2rVqlVq2bKlEhIS1KdPH+3atUs9evRwFHu1a9fWc889J0l68MEHNWbMGI0ZM0aNGjVy9JOSkqK+ffuqTp06GjRokBo3bnzB8b388svy9/dXfHy8zpw5I0lauHCh1q1bp8GDBysgIMD4XgHgSjFFDpRiGRkZOnbsmNq0aWPUfufOnfr444/VvXt3jRw5UtK5aXR/f3/NmTNH3377rZo0aeJon5ycrPnz56thw4aSpI4dO6pFixb66KOPFB8fr9tvv10VK1bUqFGjVLduXXXt2rXA97B+/Xrl5uZq5syZ8vf3N75uzJgx8vX11aJFi+Tn5ydJatu2re69915NnjxZr732mlP7OnXq6NVXX3W8T0lJ0eLFi/XSSy8ZfV7FihXVsmVLLV26VN26ddPZs2eVmJiomJiYC7YPCQnR8uXL5e7+v7/Hd+3aVR07dtTixYv1zDPP6IYbblBUVJQmTZqksLCwC35/J06c0PDhwy/6OefZbDb95z//UZ8+fTRjxgx17txZr732mtq2bVuo/10A4EqQYAKlWEZGhiTJ29vbqP3atWslSb1793Y6/vjjjzudP++WW25xFJeS5O/vr6CgIB08eLDQY/6782s3V69erbNnzxpdc/z4ce3YsUP33nuvo7iUpNtvv13NmjVzuQ9JLgVaw4YNlZKS4vgOTXTp0kWbNm3SiRMn9O233+rEiRPq0qXLBdt6eno6isszZ87ojz/+UIUKFRQUFKTt27cbf6anp6fuu+8+o7aRkZF68MEHNXXqVD377LMqV66cRowYYfxZAGAVCkygFKtYsaIkKTMz06j94cOH5e7urpo1azodr1Klimw2mw4fPux0/KabbnLpw9fXV6mpqYUcsavo6Gg1aNBAgwcPVrNmzRQXF6fExMRLFptHjhyRJAUFBbmcq127tv744w9lZWU5Ha9WrZrT+/OFbUHupUWLFvL29lZiYqI+++wzhYaG6uabb75g27Nnz+rtt99W+/btFRoaqiZNmqhp06b69ddflZ6ebvyZAQEBBXqgJz4+Xn5+ftqxY4cGDx6sypUrG18LAFZhihwoxSpWrKiqVas61kSacnNzM2rn4eFRmGFd8jPOrw88r3z58po/f742btyoNWvW6Ouvv1ZiYqIWLVqkOXPmXNEY/uqvU9V/lZ+fb9yHp6en2rVrpyVLlujgwYOKjY29aNs333xTb7zxhu6//349//zz8vX1lbu7u1599dUCfWb58uWN20rSjh07dPLkSUnSrl27CnQtAFiFBBMo5Vq1aqUDBw5oy5Ytl20bGBios2fPav/+/U7Hf//9d6WlpSkwMNCycdlsNqcnrs87nz7+lbu7u5o2baqBAwcqMTFRcXFx+vbbb7Vx48YL9n0+jUxOTnY5Z7fbValSJVWoUOEK7+DCunTpou3btyszM1OdOnW6aLvly5ercePGevXVV9WpUydFRkaqWbNmLt+JabFvIisrSwMHDtQtt9yiBx98ULNmzdLWrVst6x8ATFFgAqXcE088oQoVKmjw4MH6/fffXc4fOHBA8+bNk3RuileS4/15c+fOdTpvhZo1ayo9Pd1pW57jx49r5cqVTu1SUlJcrj2/4fjft046r2rVqqpTp46WLFniVLDt2rVL69evt/Q+/q5x48Z6/vnnNWTIEFWpUuWi7Tw8PFySyi+++MJluyAvLy9JumAxXlBjx47Vb7/9ptGjRyshIUGBgYFKSEi46PcIAEWFKXKglKtZs6bGjh2ruLg4RUdHO37JJycnR1u2bNGyZcscD4ncfvvtuvfee7Vo0SKlpaWpUaNG+vnnn/Xxxx+rbdu2Tk+QX6no6GiNHTtWsbGx6tmzp7Kzs7VgwQIFBQXpl19+cbSbOnWqNm/erBYtWigwMFAnT57U+++/rxtvvFF33XXXRfv/17/+pb59++rBBx9Ut27dlJ2drffee08+Pj6XnLq+Uu7u7nr66acv265ly5aaOnWqBg4cqPDwcO3atUufffaZatSo4dSuZs2astlsWrhwoby9vVWhQgXVr1/fpd3lbNiwQe+//75iY2N1xx13SJJGjRqlnj17auLEifrXv/5VoP4A4EpQYALXgDZt2ujTTz/V7NmztXr1ai1YsECenp4KCQlRQkKCHnjgAUfbkSNHqnr16vr444+1atUq3XDDDerXr5/lRVmlSpU0ZcoUjR49Wq+//rqqV6+uF154Qfv373cqMFu3bq3Dhw/rww8/1B9//KFKlSrp7rvv1rPPPisfH5+L9t+sWTPNmjVLkyZN0qRJk1SmTBk1atRIL730UoGLs6LQv39/nT59Wp999pkSExNVt25dvfXWWxo3bpxTu7Jly2r06NEaP368hg0bpry8PI0aNapA95CRkaGXX35ZdevWVf/+/R3HGzZsqF69emnu3Llq3769wsLCrLo9ALgkt/yCrDYHAAAALoM1mAAAALAUBSYAAAAsRYEJAAAAS1FgAgAAwFIUmAAAALAUBSYAAAAsRYEJAAAAS123G617hRfdL30AKF6H1k0s7iEAKCKVvYuvdCnK2uH0lilF1ndxIMEEAACApa7bBBMAAKBA3MjlTPFNAQAAwFIkmAAAACbc3Ip7BKUGCSYAAAAsRYIJAABggjWYxigwAQAATDBFboxSHAAAAJYiwQQAADDBFLkxvikAAABYigQTAADABGswjZFgAgAAwFIkmAAAACZYg2mMbwoAAACWIsEEAAAwwRpMYxSYAAAAJpgiN8Y3BQAAAEuRYAIAAJhgitwYCSYAAAAsRYIJAABggjWYxvimAAAAYCkSTAAAABOswTRGggkAAABLkWACAACYYA2mMb4pAAAAWIoEEwAAwAQJpjEKTAAAABPuPORjilIcAAAAliLBBAAAMMEUuTG+KQAAAFiKBBMAAMAEG60bI8EEAACApUgwAQAATLAG0xjfFAAAACxFggkAAGCCNZjGKDABAABMMEVujG8KAAAAliLBBAAAMMEUuTESTAAAAFiKBBMAAMAEazCN8U0BAADAUiSYAAAAJliDaYwEEwAAAJaiwAQAADDh5l50L4tkZmYqKipKISEh+vnnnx3He/bsqZCQEJfX3r17na5PT0/XoEGDdPfddys8PFzPPfecjh8/XuBxMEUOAABgohRMkU+bNk1nzpy54LkGDRooPj7e6Vj16tWd3g8YMEB79uzRsGHDVK5cOU2cOFF9+/bVhx9+qDJlzMtGCkwAAIBrwN69e/X+++8rPj5er7zyist5m82msLCwi16/ZcsWrVu3TrNnz1ZkZKQkKSgoSNHR0VqxYoWio6ONx8IUOQAAgIkSPkU+cuRIxcTEKCgoqFDXJyUlyWazKSIiwnEsODhYderUUVJSUoH6osAEAAAo5ZYtW6Zdu3bpmWeeuWibTZs2KSwsTKGhoerRo4e+++47p/N2u11BQUFy+9tSgODgYNnt9gKNhylyAAAAE0W40XqbNm0ueX716tUXPXf69GmNHj1acXFxqlix4gXbNGrUSF27dlWtWrV0/PhxzZ49W71799a7776r8PBwSVJaWpp8fHxcrvX19dW2bdsKcDcUmAAAAKXa9OnTVblyZd1///0XbfPcc885vW/ZsqU6d+6sadOmaebMmZaPiQITAADARBE+RX6phPJSDh8+rDlz5mjq1KlKT0+XJGVlZTn+MzMzU97e3i7XVahQQS1atNDy5csdx2w2m44ePerSNjU1Vb6+vgUaFwUmAABAKXXo0CHl5ubqySefdDnXq1cv3Xnnnfrvf/9r1FdwcLA2bNig/Px8p3WYycnJuu222wo0LgpMAAAAE0W4BrOw6tSpo3feecfp2I4dOzRq1CgNHz5coaGhF7wuKytLa9ascTofFRWladOmacOGDWrWrJmkc8Xl9u3b9cQTTxRoXBSYAAAAJkrgRus2m02NGze+4Lk77rhDd9xxhzZv3qxZs2apXbt2CgwM1PHjxzV37lydOHFCb7zxhqN9eHi4IiMjNWjQIMXHx6tcuXKaMGGCQkJC1L59+wKNiwITAADgGlalShXl5uZqwoQJSklJkZeXl8LDwzV8+HDVr1/fqe3EiRM1atQoDR06VHl5eYqMjNTgwYML9Cs+kuSWn5+fb+VNlBZe4bHFPQQAReTQuonFPQQARaSyd/FlY173ziqyvk9/XLAp6JKu5C0mAAAAQKnGFDkAAICJErgGs6QiwQQAAIClSDABAAAM/P03unFxJJgAAACwFAkmAACAARJMcxSYAAAAJqgvjTFFDgAAAEuRYAIAABhgitwcCSYAAAAsRYIJAABggATTHAkmAAAALEWCCQAAYIAE0xwJJgAAACxFggkAAGCABNMcBSYAAIAJ6ktjTJEDAADAUiSYAAAABpgiN0eCCQAAAEuRYAIAABggwTRHggkAAABLkWACAAAYIME0R4IJAAAAS5FgAgAAGCDBNEeBCQAAYIL60hhT5AAAALAUCSYAAIABpsjNkWACAADAUiSYAAAABkgwzZFgAgAAwFIkmAAAAAZIMM2RYAIAAMBSJJgAAAAmCDCNUWACAAAYYIrcHFPkAAAAsBQJJgAAgAESTHMkmAAAALAUCSYAAIABEkxzJJgAAACwFAkmAACAARJMcySYAAAAsBQJJgAAgAkCTGMkmAAAALAUCSYAAIAB1mCao8AEAAAwQIFpjilyAAAAWIoEEwAAwAAJpjkSTAAAAFiKBBMAAMAEAaYxEkwAAABYigQTAADAAGswzVFgolT7V58OGh7bRb/sOaKG3V91HHdzc1Of+yP0RLdI1a5RRZmn/9SPOw9q9Mxl+vanZEe7GcN7qOc/mly0/9rtX9aRE6lFeg8AzsnKytT78+bql21btf2Xn5WelqaXh41Up3/c69Ru5CuDlPjZJy7X16wVpIUfLb1o/8sTl2r44Hh5eXlp9frNlo8fwP9QYKLUCqzqp3/1aa+MrD9dzo2K+6ee79lG7y/dpBn//Vp+Pl7qc3+EVswcoNa9x2vzL/slSbM/XK8vN/7qdK2bmzT55RjtP3KK4hK4ilJTUjRn5nQF3HiTbr0tRD9s/u6ibT09PZUwZITTsYoVK160fVZWpqa+MU5eXl6WjRfXn9KQYGZmZqpjx446duyYFi9erNDQUMe5Dz74QLNmzdKRI0cUFBSkuLg4tWrVyun69PR0jRo1SqtWrVJubq6aN2+uwYMHq2rVqgUaBwUmSq1RL9yrTVv3ycPDXZX9vB3HPTzc1bdbc3208gf1GfKO4/iHK7do5+fDFRPd0FFgbtyarI1bk536bRYWLG+vclqYePE/3ABYr/INVfTZijWqfEMV7di+TX16PHjRth4eHrqnUxfjvt+e9ZYqeHurQcO79fWa1VYMF9eh0lBgTps2TWfOnHE5/vnnn2vIkCHq37+/mjRposTERMXGxmr+/PkKCwtztBswYID27NmjYcOGqVy5cpo4caL69u2rDz/8UGXKmJeNPOSDUimiQW3d2yZML4390OVc2TIequDlqeMn052OnziVrjNnzur0n7mX7PuBjg119uxZLfqCKTTgavL09FTlG6oYtz9z5owyMzIu2+7ggf1aNP8dPffCv1SmjMeVDBEo0fbu3av3339fzz77rMu5SZMmqVOnThowYICaNGmiESNGKDQ0VFOnTnW02bJli9atW6f//Oc/io6OVps2bfTGG2/o119/1YoVKwo0FgpMlDru7m4aH99dc5ds0C97jricz/4zV5u2JqvHP5oopmND1bixkurdWk0zR/TQH2lZmv3h+ov2XaaMu+5v10Df/pSsA7+dKsrbAHAFsrOz1a55Y7WLaqwOLZtq7Kh/Kysr84JtJ44drQYN71azyKirPEpca9zc3IrsZYWRI0cqJiZGQUFBTscPHjyoffv2qWPHjk7Ho6OjtWHDBuXk5EiSkpKSZLPZFBER4WgTHBysOnXqKCkpqUBjYYocpU7fbs1V8yZ/deo/5aJteg+ep3dHP665rz7mOGY/eEKte4/XvsMnL3pdu6Z1dUOlihox/eIPCgAoXpVvqKJHHn1cIbfX1dn8s9r4zTp99MFC7dn9q6bMeNtpGm/912u16dtv9M5C19kO4FqybNky7dq1S5MnT9Yvv/zidM5ut0uSS+FZu3Zt5ebm6uDBg6pdu7bsdruCgoJcCt7g4GBHH6ZKXIF54sQJrV+/Xna7XSkpKZIkPz8/BQcHKyIiQlWqmE+f4Nrj7+utIU910uiZy/T7HxefGsvI/FM77L9p09ZkfbXpVwXcYNOLvdvrv+OfVNs+E3Qy5cJJx4MdGyonN08frthSVLcA4Ao99Wyc0/t2HaJVo2YtvTX1DX21eoXadYiWJOXm5mjSuNd07/0PKCj4luIYKq41RbgEs02bNpc8v3r1xdcOnz59WqNHj1ZcXNwFH3ZLTT33wKrNZnM6fv79+fNpaWny8fFxud7X11fbtm279A38TYkpMHNzc/Xaa69p4cKFOnPmjKpUqSJfX19J5278xIkT8vDwUExMjBISEgq00BTXjlee6aw/0jI1bcHai7bx8HDX528+q6+/360XXvvAcfzLjb/qh8UvK65XWw2e5LrFibeXpzq3DNXKb3boVOqFC1AAJVPMI700c/pkbd74raPAXDj/HaWk/KEn+j9TzKMDitb06dNVuXJl3X///cU9FIcSU6VNnDhRn3zyiYYOHaqOHTu6VNAZGRn64osv9Prrr6t8+fJ68cUXi2mkKC61a1ZRn/si9NLYD3VTFV/H8fKeZVS2jIdq3uSv9Mxs1Q+prnq3VlP8uI+crt974IR2Jh9V07DgC/bfpdWd8vYqx8M9QClUrnx52Xz9lPZ/SUxGerrmzXpL93aPUWZmpjIzz/2lMSsrS/n50m9HDqtc+fLy969cnMNGKVOUT5FfKqG8lMOHD2vOnDmaOnWq0tPPPdyalZXl+M/MzExHYJeenu40E5yWliZJjvM2m01Hjx51+YzU1FRHG1MlpsD85JNPNHDgQN13330XPF+xYkV1795d7u7umjBhAgXmdahaFT95eLhrfHx3jY/v7nL+18QRmjL/K323bZ8kycPD9V8EZct4qIzHhZ9ti4luqPTMbC1du9XScQMoepmZmUpN+UN+lSpJktLT05SVlaX58+Zo/rw5Lu3v79xezVu21mvjJ1/toQKWOnTokHJzc/Xkk0+6nOvVq5fuvPNOjRs3TtK5tZjBwf8LWex2u8qWLasaNWpIOrfWcsOGDcrPz3cqppOTk3XbbbcVaFwlpsDMzMzUjTfeeNl2N954o+Nvori+bN97RA/EzXA5/sozneXjXV4vjlks+6Hf5Vn23DYk3TvcpZXf7HC0C7u9um67OUCzP3J9ivyGShXV+u7b9d/lm3U6+9LbGAEoPn/++afy8vLk7e3tdPztmdOVn5+vJs0iJUmVKvlr1LhJLtd/sOA9bfv5Jw1/9XXdUIAtkQCpZO6DWadOHb3zzjtOx3bs2KFRo0Zp+PDhCg0NVY0aNVSrVi0tW7ZMbdu2dbRLTExU06ZN5enpKUmKiorStGnTtGHDBjVr1kzSueJy+/bteuKJJwo0rhJTYIaFhenNN99UaGjoBReYSuemyd98802Fh4df5dGhJDiZkqnP1rimi7GPnPsVgr+eW7Vhh3r+o4ls3uW16tuduvEGm56KaaHTf+ZqyvyvXPro1r6Bypb10MJEpseB4rR44XylZ6Tr9xPHJUnrk9bo+PFjkqTuDz6i9PQ0PfZQN7W9p6NurnUuidm4Yb02rEtSk2aRat6ytSSpvJeXWrRyfWji6zWrteOXny94DricElhfymazqXHjxhc8d8cdd+iOO+6QJD377LN68cUXVbNmTTVu3FiJiYnaunWr3nvvPUf78PBwRUZGatCgQYqPj1e5cuU0YcIEhYSEqH379gUaV4kpMIcMGaJHH31ULVq0ULNmzRQcHOwoNDMyMmS32/XNN9/I29tbb7/9dvEOFiVe97gZGtCrjbp3uEvtmtVVTl6e1v+wVyOmLdXu/cdd2sdEN9Kxk2n6cuPOYhgtgPPef/dtHf3tf/vbrvlyldZ8uUqSdE90F1X08VGz5i303bcb9MVnn+rs2TMKrFFT/WMH6OGej8ndne2dgQvp3LmzTp8+rZkzZ2rGjBkKCgrSlClTXEK7iRMnatSoURo6dKjy8vIUGRmpwYMHF/jharf8/Px8K2/gSqSlpWnBggX6+uuvZbfbHYtPbTabgoODFRUVpZiYGJfH7AvDKzz2ivsAUDIdWjexuIcAoIhU9i6+bOzWl5YVWd+7X7+nyPouDiUmwZTOFZL9+vVTv379insoAAAAKKQSVWACAACUVCVxDWZJxWIVAAAAWIoEEwAAwEBJ3KaopCLBBAAAgKVIMAEAAAwQYJqjwAQAADDg7k6FaYopcgAAAFiKBBMAAMAAU+TmSDABAABgKRJMAAAAA2xTZI4EEwAAAJYiwQQAADBAgGmOBBMAAACWIsEEAAAwwBpMcxSYAAAABigwzTFFDgAAAEuRYAIAABggwDRHggkAAABLkWACAAAYYA2mORJMAAAAWIoEEwAAwAABpjkSTAAAAFiKBBMAAMAAazDNUWACAAAYoL40xxQ5AAAALEWCCQAAYIApcnMkmAAAALAUCSYAAIABAkxzJJgAAACwFAkmAACAAdZgmiPBBAAAgKVIMAEAAAwQYJqjwAQAADDAFLk5psgBAABgKRJMAAAAAwSY5kgwAQAAYCkSTAAAAAOswTRHggkAAABLkWACAAAYIMA0R4IJAAAAS5FgAgAAGGANpjkKTAAAAAMUmOaYIgcAAIClSDABAAAMEGCaI8EEAACApUgwAQAADLAG0xwJJgAAACxFggkAAGCAANMcCSYAAAAsRYIJAABggDWY5kgwAQAAYCkSTAAAAAMlMcBcu3atZs6cqT179igjI0MBAQFq27atYmNj5ePjI0lKSEjQxx9/7HLtzJkzFRUV5Xifk5OjCRMm6NNPP1VmZqbCw8M1ZMgQBQcHF3hcFJgAAAAG3EtghZmSkqL69eurZ8+e8vPz0+7duzV58mTt3r1bc+bMcbSrUaOGxo4d63Rt7dq1nd6PHDlSiYmJSkhIUEBAgN5880099thj+vzzzx3FqikKTAAAgFKqa9euTu8bN24sT09PDRkyRMeOHVNAQIAkqXz58goLC7toP0ePHtXixYv1yiuvqFu3bpKk0NBQtWrVSgsXLlTfvn0LNC7WYAIAABhwcyu6l5X8/PwkSbm5ucbXrFu3TmfPntU999zj1E9ERISSkpIKPAYKTAAAgFLuzJkz+vPPP/XLL79o6tSpat26tapXr+44v3//ft11112qV6+e7rvvPq1atcrpervdrsqVK8vX19fpeO3atWW32ws8HqbIAQAADBTlNkVt2rS55PnVq1df8nyrVq107NgxSVLz5s01btw4x7k6deooNDRUt9xyi9LT07VgwQI988wzeuONNxyJZVpa2gXXWdpsNqWmphb0digwAQAASrsZM2bo9OnT2rNnj6ZPn67+/ftr7ty58vDw0KOPPurUtnXr1oqJidGkSZOcpsStRIEJAABgwL0IHyK/XEJ5ObfffrskKTw8XKGhoeratatWrlx5wQLS3d1d7du31+uvv67s7GyVL19eNptNGRkZLm3T0tJcps1NsAYTAADgGhISEqKyZcvqwIEDxtcEBwfr999/d5kOt9vthdoHkwITAADAgJubW5G9rPTTTz8pNzfX6SGfvzp79qyWLVumW2+9VeXLl5ckRUZGyt3dXStWrHC0S01N1bp165w2YzfFFDkAAICBErjPumJjY1WvXj2FhISofPny2rlzp2bPnq2QkBC1bdtWhw8fVkJCgjp16qSbb75ZqampWrBggbZt26bJkyc7+rnxxhvVrVs3jRkzRu7u7goICNBbb70lHx8fxcTEFHhcFJgAAAClVP369ZWYmKgZM2YoPz9fgYGB6t69u/r06SNPT095e3urYsWKmj59uk6ePKmyZcuqXr16mjlzppo3b+7U1+DBg+Xt7a1x48YpMzNTDRo00Ny5cwv8Kz6S5Jafn59v1U2WJl7hscU9BABF5NC6icU9BABFpLJ38WVjnd/6rsj6XtqvUZH1XRxYgwkAAABLMUUOAABgoCi3KbrWkGACAADAUiSYAAAABorypyKvNSSYAAAAsBQJJgAAgAECTHMUmAAAAAbcqTCNMUUOAAAAS5FgAgAAGCDANEeCCQAAAEuRYAIAABhgmyJzJJgAAACwFAkmAACAAQJMcySYAAAAsBQJJgAAgAH2wTRHgQkAAGCA8tIcU+QAAACwFAkmAACAAbYpMkeCCQAAAEuRYAIAABhwJ8A0RoIJAAAAS5FgAgAAGGANpjkSTAAAAFiKBBMAAMAAAaY5CkwAAAADTJGbY4ocAAAAliLBBAAAMMA2ReZIMAEAAGAp4wRz4MCBBe7czc1Nr776aoGvAwAAKGlYg2nOuMDcuHGjy7Hs7GydOnVKkuTr6ytJSk1NlST5+/vLy8vLijECAACgFDEuML/88kun93v27NHjjz+ufv366dFHH5W/v78k6dSpU5o3b56WLFmiGTNmWDtaAACAYkJ+aa7QazD//e9/KyoqSnFxcY7iUjqXXMbFxal58+b697//bckgAQAAUHoUusD86aefVLdu3Yuer1Onjn766afCdg8AAFCiuLu5FdnrWlPoAtPX11dJSUkXPZ+UlCQfH5/Cdg8AAFCiuLkV3etaU+gC88EHH9SaNWv01FNP6ZtvvtGhQ4d06NAhrV+/Xv3791dSUpJiYmKsHCsAAABKgUJvtP70008rJydHs2fP1po1a5zOeXh46Mknn9TTTz99peMDAAAoEdimyNwV/ZLPgAED1KtXL23YsEGHDx+WJAUGBqpp06ZOD/4AAADg+nHFPxXp7++vTp06WTEWAACAEosA05xxgXnkyJFCfUC1atUKdR0AAABKJ+MCs3Xr1oVae7Bjx44CXwMAAFDSXIvbCRUV4wLz1VdfZXErAAAALsu4wLzvvvuKchwAAAAlGjmbuSt+yOe87OxsSVL58uWt6hIAAKDEYCbX3BUVmEeOHNHkyZO1du1a/fHHH5KkSpUqqUWLFoqNjVVgYKAlgwQAAEDpUegCc+/evXr44YeVnp6uZs2aqXbt2pIku92uTz75RF999ZXef/99BQcHWzZYK/3x3ZTiHgKAIlKpUWxxDwFAETm9pfj+/C70zx9ehwpdYI4bN07u7u76+OOPFRIS4nRu165deuyxxzRu3DhNnTr1igcJAACA0qPQxfh3332nnj17uhSXknTbbbfpkUce0aZNm65ocAAAACWFm5tbkb2uNYUuMPPy8i75QI+Xl5fy8vIK2z0AAABKqUIXmHXq1NEHH3yg9PR0l3MZGRlavHix6tate0WDAwAAKCnc3Yruda0p9BrMZ599Vn379lXHjh113333qVatWpKk5ORkffzxx0pJSdHQoUOtGicAAABKiUIXmE2bNtWMGTM0ZswYzZgxw+lcnTp19Prrr6tJkyZXPEAAAICS4FpMGovKFe2D2axZMy1ZskQnTpzQkSNHJEnVqlVTlSpVLBkcAABASXEtPoxTVApcYP72229yd3dXQECAJOnPP//U0qVLHed/+OEHSVJAQICio6MtGiYAAABKiwIVmL/++qvuvfdeDRo0SD169JAkZWVl6bXXXpObm5vy8/MdbT08PFS7du0LbmMEAABQ2pTEKfK1a9dq5syZ2rNnjzIyMhQQEKC2bdsqNjZWPj4+jnZffvmlJk6cqOTkZFWrVk1PPvmk7r//fqe+cnJyNGHCBH366afKzMxUeHi4hgwZUqgfzSnQU+SLFi1StWrV9PDDD7uce/3117V69WqtXr1aK1euVNWqVbVo0aICDwgAAABmUlJSVL9+fQ0fPlyzZ89W7969tWTJEj3//POONps3b1ZsbKzCwsI0c+ZMdezYUS+//LKWLVvm1NfIkSP1wQcfKC4uTpMnT1ZOTo4ee+yxC+4YdDkFSjA3btyodu3ayd3dtS6tXLmy02+Pd+7cWV9++WWBBwQAAFASlcQlmF27dnV637hxY3l6emrIkCE6duyYAgICNH36dNWvX18jRoyQJDVp0kQHDx7UpEmTdM8990iSjh49qsWLF+uVV15Rt27dJEmhoaFq1aqVFi5cqL59+xZoXAVKMA8fPuwSk5YpU0a33367vL29nY5Xr17d8eAPAAAArg4/Pz9JUm5urnJycrRx40ZHIXledHS09u7dq0OHDkmS1q1bp7Nnzzq18/PzU0REhJKSkgo8hgI/5PPXdZaS5OPjoyVLlri0+/uaTAAAgNLMvSRGmP/nzJkzysvL0549ezR16lS1bt1a1atX1549e5Sbm+sSENauXVuSZLfbVb16ddntdlWuXFm+vr4u7RYvXlzg8RSowAwICNDOnTuN2u7cudPxpDkAAAAurk2bNpc8v3r16kueb9WqlY4dOyZJat68ucaNGydJSk1NlSTZbDan9uffnz+flpbm9FDQX9udb1MQBZoij4iI0GeffaaTJ09est3Jkyf12WefKSIiosADAgAAKInci/B1pWbMmKGFCxdq5MiRstvt6t+/v86cOWNBz4VToATz8ccf18cff6zHHntMr776qkJDQ13a/Pzzzxo0aJDy8vLUu3dvywYKAABQnIpyhvxyCeXl3H777ZKk8PBwhYaGqmvXrlq5cqVuueUWSXJ5EjwtLU2SHFPiNptNGRkZLv2mpaW5TJubKFCBWb16dY0fP14vvPCCHnjgAdWsWVO33XabKlSooKysLO3atUsHDhxQ+fLlNXbsWNWoUaPAAwIAAEDhhYSEqGzZsjpw4IBat26tsmXLym63q3nz5o42drtdkhxrM4ODg/X7778rNTXVqaC02+1Fvw+mdG6O/9NPP1X37t11+vRprVy5Up988olWrlyprKwsdevWTUuWLLnsWgIAAIDSxN3NrcheVvrpp5+Um5ur6tWry9PTU40bN9by5cud2iQmJqp27dqqXr26JCkyMlLu7u5asWKFo01qaqrWrVunqKioAo+hUL9FXqNGDcdeShkZGcrMzJS3t7cqVqxYmO4AAABQCLGxsapXr55CQkJUvnx57dy5U7Nnz1ZISIjatm0rSXrqqafUq1cvDRs2TB07dtTGjRu1dOlSTZgwwdHPjTfeqG7dumnMmDGOnwR/66235OPjo5iYmAKPq1AF5l9VrFiRwhIAAFzzSuIuRfXr11diYqJmzJih/Px8BQYGqnv37urTp488PT0lSQ0bNtTkyZM1ceJELV68WNWqVdPIkSPVsWNHp74GDx4sb29vjRs3TpmZmWrQoIHmzp17wafLL8ct/zrdrDI7r7hHAKCoVGoUW9xDAFBETm+ZUmyfPXT57iLre0SHW4us7+JwxQkmAADA9cC9BCaYJZUVWy8BAAAADiSYAAAABkryT0WWNCSYAAAAsBQJJgAAgAECTHMUmAAAAAZ4yMccU+QAAACwFAkmAACAATcRYZoiwQQAAIClSDABAAAMsAbTHAkmAAAALEWCCQAAYIAE0xwJJgAAACxFggkAAGDAjZ3WjVFgAgAAGGCK3BxT5AAAALAUCSYAAIABZsjNkWACAADAUiSYAAAABtyJMI2RYAIAAMBSJJgAAAAGeIrcHAkmAAAALEWCCQAAYIAlmOYoMAEAAAy4iwrTFFPkAAAAsBQJJgAAgAGmyM2RYAIAAMBSJJgAAAAG2KbIHAkmAAAALEWCCQAAYICfijRHggkAAABLkWACAAAYIMA0R4EJAABggClyc0yRAwAAwFIkmAAAAAYIMM2RYAIAAMBSJJgAAAAGSOXM8V0BAADAUiSYAAAABtxYhGmMBBMAAACWIsEEAAAwQH5pjgITAADAAButm2OKHAAAAJYiwQQAADBAfmmOBBMAAACWIsEEAAAwwBJMcySYAAAAsBQJJgAAgAE2WjdHggkAAABLkWACAAAYIJUzR4EJAABggClycxTjAAAAsBQJJgAAgIGSmF9+8cUX+vTTT/XLL78oLS1NN998s3r27Kn777/fkbj27NlTmzZtcrk2MTFRtWvXdrxPT0/XqFGjtGrVKuXm5qp58+YaPHiwqlatWuBxUWACAACUUm+//bYCAwOVkJCgSpUq6ZtvvtGQIUN09OhRxcbGOto1aNBA8fHxTtdWr17d6f2AAQO0Z88eDRs2TOXKldPEiRPVt29fffjhhypTpmAlIwUmAACAgZK4BnP69Ony9/d3vG/atKlSUlI0d+5cPf3003J3P7ca0mazKSws7KL9bNmyRevWrdPs2bMVGRkpSQoKClJ0dLRWrFih6OjoAo2LNZgAAACl1F+Ly/Pq1KmjjIwMZWVlGfeTlJQkm82miIgIx7Hg4GDVqVNHSUlJBR4XBSYAAIAB9yJ8Wen7779XQECAKlas6Di2adMmhYWFKTQ0VD169NB3333ndI3dbldQUJBLShscHCy73V7gMTBFDgAAUMzatGlzyfOrV6826mfz5s1KTEx0Wm/ZqFEjde3aVbVq1dLx48c1e/Zs9e7dW++++67Cw8MlSWlpafLx8XHpz9fXV9u2bSvAnZxDgQkAAGCgJK7B/KujR48qLi5OjRs3Vq9evRzHn3vuOad2LVu2VOfOnTVt2jTNnDmzSMZCgQkAAGCgKMtL04TyYtLS0tS3b1/5+flp8uTJjod7LqRChQpq0aKFli9f7jhms9l09OhRl7apqany9fUt8HhYgwkAAFCKZWdnq1+/fkpPT9esWbMuONV9OcHBwUpOTlZ+fr7T8eTkZAUHBxe4PwpMAAAAA25uRfcqrLy8PA0YMEB2u12zZs1SQEDAZa/JysrSmjVrFBoa6jgWFRWl1NRUbdiwwXEsOTlZ27dvV1RUVIHHxRQ5AABAKTV8+HB99dVXSkhIUEZGhn788UfHubp162rr1q2aNWuW2rVrp8DAQB0/flxz587ViRMn9MYbbzjahoeHKzIyUoMGDVJ8fLzKlSunCRMmKCQkRO3bty/wuCgwAQAADLiXwB+LXL9+vSRp9OjRLudWr16tKlWqKDc3VxMmTFBKSoq8vLwUHh6u4cOHq379+k7tJ06cqFGjRmno0KHKy8tTZGSkBg8eXOBf8ZEkt/y/T7ZfJ7LzinsEAIpKpUaxl28EoFQ6vWVKsX32Zz8fK7K+u4Refmq7NCHBBAAAMFDCdykqUXjIBwAAAJYiwQQAADDgVgLXYJZUFJgAAAAGmCI3xxQ5AAAALEWCCQAAYKAkblNUUpFgAgAAwFIkmAAAAAZYg2mOBBMAAACWIsEEAAAwQIJpjgQTAAAAliLBBAAAMMBG6+ZIMAEAAGApEkwAAAAD7gSYxigwAQAADDBFbo4pcgAAAFiKBBMAAMAA2xSZI8EEAACApUgwAQAADLAG0xwJJgAAACxFggkAAGCAbYrMUWCiVMnKzNTbc2fr560/advPPystLVUjRo5S13vvc2r34Qf/1edLP1Vysl3paWmqUrWqGjZqrP5PP6PAwOoX7f+H7zerd69HJElr1m1QpUr+RXo/AC7uX306aHhsF/2y54gadn/VcdzNzU197o/QE90iVbtGFWWe/lM/7jyo0TOX6dufkp36qF2zil55urOahQWrks1bB4+e0qJlmzXxndU6nZ17tW8JuG5QYKJU+SPlD701fapuuqmabgsJ0ebvNl2w3c4d2xUYWF0tWrWWzWbT4UOH9NHiD/T12q/0348+UdWqAS7XnD17VqNfHSkvrwo6fTqrqG8FwCUEVvXTv/q0V0bWny7nRsX9U8/3bKP3l27SjP9+LT8fL/W5P0IrZg5Q697jtfmX/ZKk6gF++vrdl5SWcVpvLkrSqdQsNa4fpKFPdVZ4nZp6IG7G1b4tlHKswTRHgYlSpUqVqlq9Zp1uqFJFv2z7WQ8/2O2C7V4eOszlWOs2bfXQA/frs08+UZ++T7qcX/zBIh07+pvuu7+b5r/3jtVDB1AAo164V5u27pOHh7sq+3k7jnt4uKtvt+b6aOUP6jPkf/8//XDlFu38fLhiohs6CsyHOt2tSrYKatN7vHbYj0qS5ny0Xu7uburRpbH8fLyUkn766t4YSjW2KTLHQz4oVTw9PXVDlSqFurZaYKAkKT09zeVcakqKpk6aqKdjn5OPzXZFYwRwZSIa1Na9bcL00tgPXc6VLeOhCl6eOn4y3en4iVPpOnPmrE7/+b9pb1vF8pKk46ec2x79PVVnzpxVTu6ZIhg9AIkCE9e4lJQ/dPLkSf2y7WcNfXmgJKlxk6Yu7aZOfkOVb6iibg/EXO0hAvgLd3c3jY/vrrlLNuiXPUdczmf/matNW5PV4x9NFNOxoWrcWEn1bq2mmSN66I+0LM3+cL2jbdLm3ZKk6a88ovq3Bap6gJ+6tW+gvt2aa9qCNcrKzrlq94Vrg1sRvq41TJHjmtauVZRycs79IeLn56f4QYPVtFmEU5tdv+7U4g8Wacr0GfLw8CiOYQL4P327NVfNm/zVqf+Ui7bpPXie3h39uOa++pjjmP3gCbXuPV77Dp90HFv5zQ4Nm/qZ/vV4B3VpWd9xfPTMZRo+bWmRjB/AOaWuwPzjjz+0Z88eNWrUqLiHglJg6pszlZPzp+x77fp86ac6neW63uq1Uf9RRGSUmkVEFsMIAZzn7+utIU910uiZy/T7HxkXbZeR+ad22H/Tpq3J+mrTrwq4waYXe7fXf8c/qbZ9JuhkSqaj7f4jp7Tuhz1asvpHnUrN1D3N79C/+rTXsZNpenNR0tW4LVxD3FmEaazUFZibNm3SgAEDtGPHjuIeCkqBuxs3kSRFNm+hVq3b6P5/dlaFChX00CM9JEnLvkjUj1u26MNPPivOYQKQ9MoznfVHWqamLVh70TYeHu76/M1n9fX3u/XCax84jn+58Vf9sPhlxfVqq8GTPpEkde9wl6YOfkj1/zlCh4+nSJI++fInubu5a+TzXfXfZd/rVGrmhT4GwBViDSauGzVq1tTtdeoq8fP/FZMTxo5R+w4dVLZsWR0+fEiHDx9Setq5h4COHj2q48ePFddwgetK7ZpV1Oe+CE1bsFY3VfFVzZv8VfMmf5X3LKOyZTxU8yZ/VbJVUGSDW1Tv1mpauuZnp+v3HjihnclH1TQs2HHsyQea66dfDzqKy/M+X7tV3l7ldOftF98TF7gQ1mCaKzEJZpcuXYzaZWbyt00UXnZ2tnJz/rew/+jR35T4+VIlfu66Hium270KCbld//3ok6s5ROC6VK2Knzw83DU+vrvGx3d3Of9r4ghNmf+Vvtu2T5Lk4eH6R3LZMh4q4/G/3KSqv49S0lz3tC1b5txa67+2BWCtElNg2u123XLLLapbt+4l2x0+fFi//fbbVRoVSqO8vDxlZWbK5uvrdPznrVu1Z/cudezU2XFswqSpLtcv++JzLf8iUSNHvaaAgBuLfLwApO17j1xw4/NXnuksH+/yenHMYtkP/S7PsueKw+4d7tLKb/63VCrs9uq67eYAzf7of0+R795/XG2b3q5balbVngPHHccfuKehzpw5q227XZ9SBy7pWowai0iJKTBvvfVW3XzzzRo1atQl2y1fvlzffffdVRoVSqIF899TenqaThw/9wfG2jVf6dixc5soP/RIT+Xn56t9m5bq0LGjate+VV4VvLR71y59suQjVazooyf7P+3oq3Wbti79/7rz3B9akc2j+KlI4Co5mZKpz9ZsdTke+0grSXI6t2rDDvX8RxPZvMtr1bc7deMNNj0V00Kn/8zVlPlfOdpNeGeVOkTU1ao5A879kk9KpjpG1dM9kXdozkfr9duJ1KK/MVxT+CUfcyWmwKxfv76+/vpro7b5+flFPBqUZO+8PUdHjhx2vF+9aoVWr1ohSerU5R+qWqWq7ru/m77btFGrVixXdvafqlq1qjpGd1Lffk9d8rfIAZR83eNmaECvNure4S61a1ZXOXl5Wv/DXo2YtlS79/8vqVz/w161emy8Xu4frSe7N1dlP2/tO3xSQyd/qvHzVhXjHQDXPrf8ElKtHThwQLt371abNm0u2S47O1snT55U4P/9KkthZedd0eUASrBKjWKLewgAisjpLRffI7WobbIXXep9d7Dv5RuVIiUmwaxZs6Zq1qx52Xbly5e/4uISAAAARafEFJgAAAAlGSswzbFHAwAAACxFggkAAGCCCNMYCSYAAAAsRYIJAABggH0wzVFgAgAAGHCjvjTGFDkAAAAsRYIJAABggADTHAkmAAAALEWCCQAAYIII0xgJJgAAACxFggkAAGCAbYrMkWACAADAUiSYAAAABtgH0xwFJgAAgAHqS3NMkQMAAMBSFJgAAAAm3IrwVUhffPGFnnrqKUVFRSksLExdu3bV4sWLlZ+f79Tugw8+UIcOHRQaGqp//OMf+uqrr1z6Sk9P16BBg3T33XcrPDxczz33nI4fP16ocVFgAgAAlFJvv/22vLy8lJCQoOnTpysqKkpDhgzR1KlTHW0+//xzDRkyRB07dtTMmTMVFham2NhY/fjjj059DRgwQOvXr9ewYcM0duxYJScnq2/fvsrLyyvwuNzy/17iXieyC/5dASglKjWKLe4hACgip7dMKbbP3nowo8j6rl+jYqGuO3XqlPz9/Z2ODRkyRImJifruu+/k7u6uDh06qF69eho3bpyjTUxMjHx8fDRz5kxJ0pYtWxQTE6PZs2crMjJSkmS32xUdHa3x48crOjq6QOMiwQQAACil/l5cSlKdOnWUkZGhrKwsHTx4UPv27VPHjh2d2kRHR2vDhg3KycmRJCUlJclmsykiIsLRJjg4WHXq1FFSUlKBx0WBCQAAYMDNreheVvr+++8VEBCgihUrym63S5KCgoKc2tSuXVu5ubk6ePCgpHNpZVBQkNz+Npjg4GBHHwXBNkUAAADFrE2bNpc8v3r1aqN+Nm/erMTERMXHx0uSUlNTJUk2m82p3fn358+npaXJx8fHpT9fX19t27bN6LP/igITAADAQEnfB/Po0aOKi4tT48aN1atXr2IdCwUmAACAiSKsME0TyotJS0tT37595efnp8mTJ8vd/dwqSF9fX0nntiCqUqWKU/u/nrfZbDp69KhLv6mpqY42BcEaTAAAgFIsOztb/fr1U3p6umbNmuU01R0cHCxJLuso7Xa7ypYtqxo1ajjaJScnu+yfmZyc7OijICgwAQAADLgV4T+FlZeXpwEDBshut2vWrFkKCAhwOl+jRg3VqlVLy5YtczqemJiopk2bytPTU5IUFRWl1NRUbdiwwdEmOTlZ27dvV1RUVIHHxRQ5AABAKTV8+HB99dVXSkhIUEZGhtPm6XXr1pWnp6eeffZZvfjii6pZs6YaN26sxMREbd26Ve+9956jbXh4uCIjIzVo0CDFx8erXLlymjBhgkJCQtS+ffsCj4uN1gFcc9hoHbh2FedG69uPZBZZ33WreRfqutatW+vw4cMXPLd69WpVr15d0rmfipw5c6aOHDmioKAgvfDCC2rVqpVT+/T0dI0aNUorV65UXl6eIiMjNXjwYJdU1AQFJoBrDgUmcO2iwCwdmCIHAAAwUNK3KSpJeMgHAAAAliLBBAAAMEGEaYwCEwAAwMCVbCd0vWGKHAAAAJYiwQQAADDgRoBpjAQTAAAAliLBBAAAMECAaY4EEwAAAJYiwQQAADBBhGmMBBMAAACWIsEEAAAwwD6Y5igwAQAADLBNkTmmyAEAAGApEkwAAAADBJjmSDABAABgKRJMAAAAE0SYxkgwAQAAYCkSTAAAAANsU2SOBBMAAACWIsEEAAAwwD6Y5kgwAQAAYCkSTAAAAAMEmOYoMAEAAExQYRpjihwAAACWIsEEAAAwwDZF5kgwAQAAYCkSTAAAAANsU2SOBBMAAACWIsEEAAAwQIBpjgQTAAAAliLBBAAAMMAaTHMUmAAAAEaoME0xRQ4AAABLkWACAAAYYIrcHAkmAAAALEWCCQAAYIAA0xwJJgAAACxFggkAAGCANZjmSDABAABgKRJMAAAAA26swjRGgQkAAGCC+tIYU+QAAACwFAkmAACAAQJMcySYAAAAsBQJJgAAgAG2KTJHggkAAABLkWACAAAYYJsicySYAAAAsBQJJgAAgAkCTGMUmAAAAAaoL80xRQ4AAABLkWACAAAYKKnbFO3fv1+zZ8/WTz/9pN27dys4OFhLly51atOzZ09t2rTJ5drExETVrl3b8T49PV2jRo3SqlWrlJubq+bNm2vw4MGqWrVqgcZEgQkAAFCK7d69W2vXrtWdd96ps2fPKj8//4LtGjRooPj4eKdj1atXd3o/YMAA7dmzR8OGDVO5cuU0ceJE9e3bVx9++KHKlDEvGykwAQAADJTUbYpat26ttm3bSpISEhK0bdu2C7az2WwKCwu7aD9btmzRunXrNHv2bEVGRkqSgoKCFB0drRUrVig6Otp4TKzBBAAAKMXc3a0p55KSkmSz2RQREeE4FhwcrDp16igpKalgY7JkRAAAANc4N7eie10NmzZtUlhYmEJDQ9WjRw999913TuftdruCgoLk9rcBBQcHy263F+izmCIHAAAoZm3atLnk+dWrV19R/40aNVLXrl1Vq1YtHT9+XLNnz1bv3r317rvvKjw8XJKUlpYmHx8fl2t9fX0vOu1+MRSYAAAA17jnnnvO6X3Lli3VuXNnTZs2TTNnzrT88ygwAQAADBTlVPaVJpQFVaFCBbVo0ULLly93HLPZbDp69KhL29TUVPn6+haof9ZgAgAAQMHBwUpOTnbZ5ig5OVnBwcEF6osCEwAAwIBbEf5ztWVlZWnNmjUKDQ11HIuKilJqaqo2bNjgOJacnKzt27crKiqqQP0zRQ4AAFCKnT59WmvXrpUkHT58WBkZGVq2bJkk6e6775bdbtesWbPUrl07BQYG6vjx45o7d65OnDihN954w9FPeHi4IiMjNWjQIMXHx6tcuXKaMGGCQkJC1L59+wKNyS3/Ytu9X+Oy84p7BACKSqVGscU9BABF5PSWKcX22WnZZ4usb1v5wk8qHzp06KJPob/zzju68cYbNWLECP36669KSUmRl5eXwsPDFRsbq/r16zu1P/9TkStXrlReXp4iIyM1ePBgBQQEFGhMFJgArjkUmMC1iwKzdGCKHAAAwEDJ/KHIkunaKpcBAABQ7EgwAQAATBBhGqPABAAAMFAc2wmVVkyRAwAAwFIkmAAAAAaK8qcirzUkmAAAALAUCSYAAIABAkxzJJgAAACwFAkmAACACSJMYySYAAAAsBQJJgAAgAH2wTRHgQkAAGCAbYrMMUUOAAAAS7nl5+fnF/cgAAAAcO0gwQQAAIClKDABAABgKQpMAAAAWIoCEwAAAJaiwAQAAIClKDABAABgKQpMAAAAWIoCEwAAAJaiwAQAAIClKDABAABgKQpMAAAAWIoCEwAAAJaiwAQAAIClKDBxzdq7d6969+6tsLAwRUREaMyYMcrJySnuYQGwwP79+zV06FB17dpVdevWVefOnYt7SAD+okxxDwAoCqmpqXr00UdVq1YtTZ48WceOHdPo0aOVnZ2toUOHFvfwAFyh3bt3a+3atbrzzjt19uxZ5efnF/eQAPwFBSauSQsXLlRmZqamTJkiPz8/SdKZM2c0fPhw9evXTwEBAcU7QABXpHXr1mrbtq0kKSEhQdu2bSvmEQH4K6bIcU1KSkpS06ZNHcWlJHXs2FFnz57V+vXri29gACzh7s4fX0BJxv9DcU2y2+0KDg52Omaz2VSlShXZ7fZiGhUAANcHCkxck9LS0mSz2VyO+/r6KjU1tRhGBADA9YMCEwAAAJaiwMQ1yWazKT093eV4amqqfH19i2FEAABcPygwcU0KDg52WWuZnp6uEydOuKzNBAAA1qLAxDUpKipK33zzjdLS0hzHli1bJnd3d0VERBTjyAAAuPaxDyauSTExMXr33Xf1zDPPqF+/fjp27JjGjBmjmJgY9sAErgGnT5/W2rVrJUmHDx9WRkaGli1bJkm6++675e/vX5zDA657bvn8/AGuUXv37tW///1vbdmyRd7e3uratavi4uLk6elZ3EMDcIUOHTqkNm3aXPDcO++8o8aNG1/lEQH4KwpMAAAAWIo1mAAAALAUBSYAAAAsRYEJAAAAS1FgAgAAwFIUmAAAALAUBSYAAAAsRYEJAAAAS1FgAih1WrdurYSEBMf7jRs3KiQkRBs3brTsM0JCQjR58mTL+gOA6wkFJoAC++ijjxQSEuJ4hYaGqkOHDhoxYoR+//334h6esbVr11JEAkAR4LfIARTac889p+rVqysnJ0fff/+9FixYoLVr12rp0qXy8vK6auNo1KiRtm7dqrJlyxbourVr12r+/Pl69tlnXc5t3bpVHh4eVg0RAK4rFJgACi0qKkqhoaGSpO7du8vPz09z587V6tWr1blzZ5f2WVlZqlChguXjcHd3V7ly5Szt0+r+AOB6whQ5AMs0adJEknTo0CElJCQoPDxcBw4cUN++fRUeHq4XX3xRknT27Fm9/fbb6tSpk0JDQ9WsWTMNHTpUqampTv3l5+dr2rRpioqK0p133qmePXtq9+7dLp97sTWYP/30k/r27atGjRopLCxMXbp00bx58yRJCQkJmj9/viQ5Tfefd6E1mNu3b9cTTzyhBg0aKDw8XI8++qh+/PFHpzbnlw98//33GjVqlJo0aaKwsDA988wzOnXqVCG+VQAofUgwAVjmwIEDkiQ/Pz9JUl5envr06aO77rpL8fHxKl++vCRp6NCh+vjjj3XfffepZ8+eOnTokObPn6/t27drwYIFjqnuN954Q9OnT1eLFi3UokUL/fLLL3r88ceVm5t72bGsX79e/fr1U9WqVdWrVy/dcMMN2rt3r9asWaNHH31UDz74oI4fP67169drzJgxl+1v9+7deuSRR+Tt7a0nnnhCZcqU0aJFi9SzZ0+99957uvPOO53ajxw5UjabTbGxsTp8+LDmzZunESNGaOLEiQX4RgGgdKLABFBoGRkZOnXqlHJycvTDDz9o6tSpKl++vFq1aqUff/xROTk5uueee/T//t//c1yzefNmffDBBxo7dqy6dOniON64cWM98cQTWrZsmbp06aJTp05p1qxZatmypd588025ublJkiZMmKA333zzkuM6c+aMhg4dqqpVq2rJkiWy2WyOc/n5+ZKk8PBw1apVS+vXr1fXrl0ve68TJ05Ubm6uFixYoBo1akiS/vnPf+qee+7R66+/rvfee8+pvZ+fn+bMmeMY99mzZ/Xuu+8qPT1dPj4+l/08ACjNmCIHUGiPPfaYmjZtqhYtWiguLk7e3t6aMmWKAgICHG0eeughp2uWLVsmHx8fRURE6NSpU47XHXfcoQoVKjimub/55hvl5uaqR48ejiJNkh599NHLjmv79u06dOiQevXq5VRcSnLqy9SZM2e0fv16tW3b1lFcSlLVqlXVuXNnff/998rIyHC65oEHHnD6rIYNG+rMmTM6fPhwgT8fAEobEkwAhTZ06FAFBQXJw8NDN9xwg4KCguTu/r+/t5YpU0Y33nij0zX79+9Xenq6mjZtesE+T548KUk6cuSIJKlWrVpO5/39/eXr63vJcR08eFCSdNtttxXofi7m1KlTOn36tIKCglzO1a5dW2fPntVvv/2mW2+91XG8WrVqTu3OF7ppaWmWjAkASjIKTACFVr9+fcdT5Bfi6enpVHBK56aKK1eurLFjx17wGn9/f0vHWFz+ft/nnZ+iB4BrGQUmgKuqZs2a2rBhgxo0aOB46OdCzieA+/btc5qWPnXqlMvT5n93vv2uXbvUrFmzi7YznS739/eXl5eXkpOTXc7Z7Xa5u7vrpptuMuoLAK4HrMEEcFV17NhRZ86c0bRp01zO5eXlOaaQmzVrprJly+q9995zSv3ObzN0KXfccYeqV6+ud955x2VK+q99nd8M/nLT1h4eHoqIiNDq1at16NAhx/Hff/9dS5cu1V133aWKFStedlwAcL0gwQRwVd1999168MEH9dZbb2nHjh2KiIhQ2bJltW/fPi1btkwvv/yy7rnnHvn7++vxxx/XW2+9pX79+qlFixbavn27kpKSVKlSpUt+hru7u4YNG6annnpK//znP3XfffepSpUqstvt2rNnj2bPni3pXCEqndtSKDIyUh4eHurUqdMF+xwwYIC++eYbPfzww3r44Yfl4eGhRYsWKScnRy+99JK1XxIAlHIUmACuuhEjRqhevXpauHChJkyYIA8PDwUGBuof//iHGjRo4Gg3YMAAeXp6auHChdq4caPq16+vOXPmqF+/fpf9jObNm2vevHmaOnWq5syZo/z8fNWoUUMPPPCAo0379u3Vs2dPff755/r000+Vn59/0QLz1ltv1fz58zVu3Di99dZbys/PV/369fX666+77IEJANc7t3xWnAMAAMBCrMEEAACApSgwAQAAYCkKTAAAAFiKAhMAAACWosAEAACApSgwAQAAYCkKTAAAAFiKAhMAAACWosAEAACApSgwAQAAYCkKTAAAAFiKAhMAAACWosAEAACApf4/xu6DAMGVHEEAAAAASUVORK5CYII=\n"
+          },
+          "metadata": {}
+        }
+      ],
+      "source": [
+        "print('------Test set 1 (Tweets):------')\n",
+        "evaluate(test_dataloader_tweets)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 34,
+      "metadata": {
+        "id": "vS9ybeVFPspM",
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 781
+        },
+        "outputId": "314449e0-487d-44f9-d9c8-6498e9f2fbbb"
+      },
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "------Test set 2 (News):------\n",
+            "Accuracy: [386/500] 0.7720\n",
+            "Classification Report:\n",
+            "               precision    recall  f1-score   support\n",
+            "\n",
+            "           0     0.7556    0.9498    0.8417       319\n",
+            "           1     0.8384    0.4586    0.5929       181\n",
+            "\n",
+            "    accuracy                         0.7720       500\n",
+            "   macro avg     0.7970    0.7042    0.7173       500\n",
+            "weighted avg     0.7856    0.7720    0.7516       500\n",
+            "\n"
+          ]
+        },
+        {
+          "output_type": "display_data",
+          "data": {
+            "text/plain": [
+              "<Figure size 800x600 with 2 Axes>"
+            ],
+            "image/png": "iVBORw0KGgoAAAANSUhEUgAAApgAAAIsCAYAAABWatmqAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjguMCwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy81sbWrAAAACXBIWXMAAA9hAAAPYQGoP6dpAABHJUlEQVR4nO3deZzO9f7/8ecMZgazGcbI2GaUQYYZYTBjLGNpBmlRqSwt/LRQdOrMcORInRSKLGWXIpwUhQmRJUuklIQsMxhkZxZLs/7+cFzfrsbynvG5zOJxP7frduv6fN6f9/W+rpN69Xy/P++PU05OTo4AAAAAizgX9AAAAABQvFBgAgAAwFIUmAAAALAUBSYAAAAsRYEJAAAAS1FgAgAAwFIUmAAAALAUBSYAAAAsRYEJAAAAS1FgArhpBw4c0NNPP6177rlHQUFBWrlypaX9Hz58WEFBQfriiy8s7bco69Gjh3r06FHQwwCAq6LABIqJQ4cOaejQoYqKilJwcLAaNmyobt26adasWbp06ZJDPzsuLk579uzRwIEDNXLkSNWrV8+hn3crxcXFKSgoSA0bNrzq73jgwAEFBQUpKChI06dPz3P/x48f1/jx47Vr1y4rhgsAhULJgh4AgJu3Zs0avfTSS3JxcVGXLl1Uq1YtZWRk6Mcff9SoUaO0b98+vfHGGw757EuXLmnbtm169tln1b17d4d8hr+/v7Zv366SJQvmH1klS5bUpUuX9O233yomJsbu3OLFi+Xq6qo///wzX32fOHFCEyZMkL+/v+rUqWN8XX6KWQC4VSgwgSIuKSlJAwcOVOXKlTVr1ixVrFjRdu6JJ57QwYMHtWbNGod9/pkzZyRJnp6eDvsMJycnubq6Oqz/G3FxcVHDhg21dOnSXAXmkiVL1KpVKy1fvvyWjOXixYsqXbq0XFxcbsnnAUB+MEUOFHHTpk3ThQsX9J///MeuuLyievXq6tWrl+19ZmamJk6cqLZt26pevXpq06aN3nvvPaWnp9td16ZNG/Xt21dbt25V165dFRwcrKioKC1atMjWZvz48WrdurUkaeTIkQoKClKbNm0kXZ5avvLXfzV+/HgFBQXZHduwYYMee+wxNWrUSKGhoerQoYPee+892/lrrcHctGmTHn/8cYWEhKhRo0Z67rnntH///qt+3sGDBxUXF6dGjRrpnnvu0aBBg3Tx4sXr/bR2OnXqpHXr1iklJcV2bPv27Tpw4IA6deqUq/25c+f0zjvvqHPnzgoNDVXDhg3Vu3dv7d6929Zm8+bN6tq1qyRp0KBBtqn2K9+zR48e6tSpk3bs2KEnnnhCDRo0sP0uf1+DGRsbq+Dg4Fzf/5lnnlHjxo11/Phx4+8KADeLAhMo4lavXq2qVauqYcOGRu2HDBmicePGqW7duho0aJAaN26syZMna+DAgbnaHjx4UC+99JLCw8MVFxcnLy8vxcXFae/evZKkdu3aadCgQZIuF2AjR47U4MGD8zT+vXv3qm/fvkpPT9eLL76o2NhYtWnTRj/99NN1r9u4caN69+6t06dPq1+/fnryySe1bds2PfbYYzp8+HCu9gMGDND58+f18ssvKzo6Wl988YUmTJhgPM527drJyclJK1assB1bsmSJAgMDVbdu3Vztk5KStHLlSrVq1UpxcXF65plntGfPHnXv3t1W7NWsWVMvvviiJOnRRx/VyJEjNXLkSDVu3NjWz7lz59SnTx/VqVNHgwcPVlhY2FXH969//Us+Pj6KjY1VVlaWJGnevHlav369hgwZIj8/P+PvCgA3iylyoAhLS0vT8ePHFRUVZdR+9+7dWrhwoR5++GG9+eabki5Po/v4+GjGjBn6/vvv1bRpU1v7xMREzZkzR40aNZIkRUdHq2XLlvriiy8UGxur2rVry93dXSNGjFDdunXVpUuXPH+HDRs2KCMjQ1OnTpWPj4/xdSNHjpSXl5fmz58vb29vSVLbtm31wAMPaPz48XrnnXfs2tepU0dvvfWW7f25c+e0YMECvfrqq0af5+7urlatWmnJkiXq2rWrsrOzFR8fr27dul21fVBQkJYvXy5n5//77/guXbooOjpaCxYs0AsvvKAKFSooMjJS48aNU0hIyFV/v5MnT+r111+/5udc4enpqf/85z965plnNGXKFHXq1EnvvPOO2rZtm6//XwDgZpBgAkVYWlqaJKls2bJG7deuXStJeuqpp+yOP/3003bnr7jzzjttxaUk+fj4KCAgQElJSfke899dWbu5atUqZWdnG11z4sQJ7dq1Sw888ICtuJSk2rVrq3nz5rm+h6RcBVqjRo107tw5229oonPnztqyZYtOnjyp77//XidPnlTnzp2v2tbFxcVWXGZlZens2bMqU6aMAgICtHPnTuPPdHFx0YMPPmjUNiIiQo8++qgmTpyo/v37y9XVVcOHDzf+LACwCgUmUIS5u7tLks6fP2/U/siRI3J2dla1atXsjvv6+srT01NHjhyxO37HHXfk6sPLy0vJycn5HHFuMTExatiwoYYMGaLmzZtr4MCBio+Pv26xefToUUlSQEBArnM1a9bU2bNndeHCBbvjlStXtnt/pbDNy3dp2bKlypYtq/j4eC1evFjBwcGqXr36VdtmZ2fro48+Uvv27RUcHKymTZuqWbNm+v3335Wammr8mX5+fnm6oSc2Nlbe3t7atWuXhgwZovLlyxtfCwBWYYocKMLc3d1VsWJF25pIU05OTkbtSpQokZ9hXfczrqwPvMLNzU1z5szR5s2btWbNGn333XeKj4/X/PnzNWPGjJsaw1/9dar6r3Jycoz7cHFxUbt27bRo0SIlJSWpX79+12w7adIkvf/++3rooYf00ksvycvLS87Oznrrrbfy9Jlubm7GbSVp165dOn36tCRpz549eboWAKxCggkUca1bt9ahQ4e0bdu2G7b19/dXdna2Dh48aHf81KlTSklJkb+/v2Xj8vT0tLvj+oor6eNfOTs7q1mzZho0aJDi4+M1cOBAff/999q8efNV+76SRiYmJuY6l5CQoHLlyqlMmTI3+Q2urnPnztq5c6fOnz+vjh07XrPd8uXLFRYWprfeeksdO3ZURESEmjdvnus3MS32TVy4cEGDBg3SnXfeqUcffVTTpk3T9u3bLesfAExRYAJFXO/evVWmTBkNGTJEp06dynX+0KFDmjVrlqTLU7ySbO+vmDlzpt15K1SrVk2pqal22/KcOHFC33zzjV27c+fO5br2yobjf9866YqKFSuqTp06WrRokV3BtmfPHm3YsMHS7/F3YWFheumll/Taa6/J19f3mu1KlCiRK6n8+uuvc20XVLp0aUm6ajGeV6NHj9Yff/yht99+W3FxcfL391dcXNw1f0cAcBSmyIEirlq1aho9erQGDhyomJgY25N80tPTtW3bNi1btsx2k0jt2rX1wAMPaP78+UpJSVHjxo3166+/auHChWrbtq3dHeQ3KyYmRqNHj1a/fv3Uo0cPXbp0SXPnzlVAQIB+++03W7uJEydq69atatmypfz9/XX69Gl9+umnqlSpku65555r9v/Pf/5Tffr00aOPPqquXbvq0qVLmj17tjw8PK47dX2znJ2d9fzzz9+wXatWrTRx4kQNGjRIoaGh2rNnjxYvXqyqVavatatWrZo8PT01b948lS1bVmXKlFH9+vVztbuRTZs26dNPP1W/fv109913S5JGjBihHj16aOzYsfrnP/+Zp/4A4GZQYALFQFRUlL766itNnz5dq1at0ty5c+Xi4qKgoCDFxcXpkUcesbV98803VaVKFS1cuFArV65UhQoV1LdvX8uLsnLlymnChAl6++23NWrUKFWpUkUvv/yyDh48aFdgtmnTRkeOHNHnn3+us2fPqly5cmrSpIn69+8vDw+Pa/bfvHlzTZs2TePGjdO4ceNUsmRJNW7cWK+++mqeizNHePbZZ3Xx4kUtXrxY8fHxqlu3riZPnqx3333Xrl2pUqX09ttv67333tOwYcOUmZmpESNG5Ok7pKWl6V//+pfq1q2rZ5991na8UaNG6tmzp2bOnKn27dsrJCTEqq8HANfllJOX1eYAAADADbAGEwAAAJaiwAQAAIClKDABAABgKQpMAAAAWIoCEwAAAJaiwAQAAIClKDABAACKqLVr16p79+5q2rSp6tWrp6ioKI0YMUKpqal27b799lvdd999Cg4OVocOHfT555/n6is9PV3vvPOOwsPDFRISoqeeekoJCQn5Gtdtuw9m6VDHPekDQME6+8OEgh4CAAdxK8BHxDiydri4LX//3Pryyy/1+++/q0GDBvL29tbevXs1fvx43X333ZoxY4YkaevWrerZs6e6du2qmJgYff/995o0aZLGjh2re++919bX0KFDFR8fr7i4OPn5+WnSpElKSkrS0qVLr/vgi6vhST4AAABFVJcuXezeh4WFycXFRa+99pqOHz8uPz8/ffjhh6pfv76GDx8uSWratKmSkpI0btw4W4F57NgxLViwQP/+97/VtWtXSVJwcLBat26tefPmqU+fPnkaF1PkAAAAJpycHfeykLe3tyQpIyND6enp2rx5s11SKUkxMTHav3+/Dh8+LElav369srOz7dp5e3srPDxc69aty/MYKDABAACKuKysLP3555/67bffNHHiRLVp00ZVqlTRoUOHlJGRocDAQLv2NWvWlCTbGsuEhASVL19eXl5eudrlZx0mU+QAAAAmnJwc1nVUVNR1z69ateq651u3bq3jx49Lklq0aKF3331XkpScnCxJ8vT0tGt/5f2V8ykpKVddZ+np6WlrkxcUmAAAAEXclClTdPHiRe3bt08ffvihnn32Wc2cObPAxkOBCQAAYMLitZJ/daOE8kZq164tSQoNDVVwcLC6dOmib775Rnfeeack5dq2KCUlRZJsU+Kenp5KS0vL1W9KSkquaXMTrMEEAAAw4eTkuJeFgoKCVKpUKR06dEjVqlVTqVKlcq2jvPL+ytrMwMBAnTp1Ktd0eEJCQq71myYoMAEAAIqRX375RRkZGapSpYpcXFwUFham5cuX27WJj49XzZo1VaVKFUlSRESEnJ2dtWLFClub5ORkrV+/XpGRkXkeA1PkAAAAJhw4RZ5f/fr1U7169RQUFCQ3Nzft3r1b06dPV1BQkNq2bStJeu6559SzZ08NGzZM0dHR2rx5s5YsWaIxY8bY+qlUqZK6du2qkSNHytnZWX5+fpo8ebI8PDzUrVu3PI+LAhMAAKCIql+/vuLj4zVlyhTl5OTI399fDz/8sJ555hm5uLhIkho1aqTx48dr7NixWrBggSpXrqw333xT0dHRdn0NGTJEZcuW1bvvvqvz58+rYcOGmjlzZp6f4iPxqEgAxRCPigSKrwJ9VGTYqw7r++LmUQ7ruyAUvqwXAAAARRpT5AAAACYK4RrMwopfCgAAAJYiwQQAADDhwEdFFjcUmAAAACaYIjfGLwUAAABLkWACAACYYIrcGAkmAAAALEWCCQAAYII1mMb4pQAAAGApEkwAAAATrME0RoIJAAAAS5FgAgAAmGANpjF+KQAAAFiKBBMAAMAECaYxCkwAAAATztzkY4pSHAAAAJYiwQQAADDBFLkxfikAAABYigQTAADABButGyPBBAAAgKVIMAEAAEywBtMYvxQAAAAsRYIJAABggjWYxigwAQAATDBFboxfCgAAAJYiwQQAADDBFLkxEkwAAABYigQTAADABGswjfFLAQAAwFIkmAAAACZYg2mMBBMAAACWIsEEAAAwwRpMYxSYAAAAJpgiN0YpDgAAAEuRYAIAAJhgitwYvxQAAAAsRYIJAABgggTTGL8UAAAALEWCCQAAYIK7yI2RYAIAAMBSJJgAAAAmWINpjAITAADABFPkxijFAQAAYCkSTAAAABNMkRvjlwIAAIClSDABAABMsAbTGAkmAAAALEWCCQAAYMCJBNMYCSYAAAAsRYIJAABggATTHAUmAACACepLY0yRAwAAwFIkmAAAAAaYIjdHggkAAABLkWACAAAYIME0R4IJAAAAS5FgAgAAGCDBNEeCCQAAAEuRYAIAABggwTRHgQkAAGCC+tIYU+QAAACwFAkmAACAAabIzZFgAgAAwFIkmAAAAAZIMM2RYAIAAMBSJJgAAAAGSDDNkWACAADAUiSYAAAABgpjgvn111/rq6++0m+//aaUlBRVr15dPXr00EMPPWQbb48ePbRly5Zc18bHx6tmzZq296mpqRoxYoRWrlypjIwMtWjRQkOGDFHFihXzPC4KTAAAABOFr77URx99JH9/f8XFxalcuXLauHGjXnvtNR07dkz9+vWztWvYsKFiY2Ptrq1SpYrd+wEDBmjfvn0aNmyYXF1dNXbsWPXp00eff/65SpbMW8lIgQkAAFBEffjhh/Lx8bG9b9asmc6dO6eZM2fq+eefl7Pz5dWQnp6eCgkJuWY/27Zt0/r16zV9+nRFRERIkgICAhQTE6MVK1YoJiYmT+NiDSYAAIABJycnh73y66/F5RV16tRRWlqaLly4YNzPunXr5OnpqfDwcNuxwMBA1alTR+vWrcvzuCgwAQAAipEff/xRfn5+cnd3tx3bsmWLQkJCFBwcrO7du+uHH36wuyYhIUEBAQG5it3AwEAlJCTkeQxMkQMAABhw5E0+UVFR1z2/atUqo362bt2q+Ph4u/WWjRs3VpcuXVSjRg2dOHFC06dP11NPPaVPPvlEoaGhkqSUlBR5eHjk6s/Ly0s7duzIwze5jAITAACgGDh27JgGDhyosLAw9ezZ03b8xRdftGvXqlUrderUSR988IGmTp3qkLFQYAIAABhwZIJpmlBeS0pKivr06SNvb2+NHz/ednPP1ZQpU0YtW7bU8uXLbcc8PT117NixXG2Tk5Pl5eWV5/GwBhMAAKAIu3Tpkvr27avU1FRNmzbtqlPdNxIYGKjExETl5OTYHU9MTFRgYGCe+6PABAAAMOHkwFc+ZWZmasCAAUpISNC0adPk5+d3w2suXLigNWvWKDg42HYsMjJSycnJ2rRpk+1YYmKidu7cqcjIyDyPiylyAAAAA4XxST6vv/66Vq9erbi4OKWlpennn3+2natbt662b9+uadOmqV27dvL399eJEyc0c+ZMnTx5Uu+//76tbWhoqCIiIjR48GDFxsbK1dVVY8aMUVBQkNq3b5/ncVFgAgAAFFEbNmyQJL399tu5zq1atUq+vr7KyMjQmDFjdO7cOZUuXVqhoaF6/fXXVb9+fbv2Y8eO1YgRIzR06FBlZmYqIiJCQ4YMyfNTfCTJKefvk+23idKh/W7cCECRdPaHCQU9BAAO4laA0VilPgsc1vexqV0d1ndBYA0mAAAALMUUOQAAgIHCuAazsCLBBAAAgKVIMAEAAAyQYJojwQQAAIClSDABAABMEGAaI8EEAACApUgwAQAADLAG0xwFJgAAgAEKTHNMkQMAAMBSJJgAAAAGSDDNkWACAADAUiSYAAAAJggwjZFgAgAAwFIkmAAAAAZYg2mOAhNFRp3AShrybIxC61STX3lPXbiUrt2JxzRm1krFr9th1zYowE8j//GQmofWVHpGppZ995ti3/tCp86m2drc4eul/7zURffcXV13+HopKztb+w6e0KT/fqc5izff6q8H4CounD+vj2ZO16/bf9GOX39VSkqyhr85Ql0eeDBX2+zsbC347zwt+O98HTiQKDe30qoVFKRXYwcrqHbtAhg9cPuiwESRUa2yj9zLuGn24s3642Syyri56P62Ifr8/Wf1whtzNeOLDZIk/4re+mb6AKWkXtK/J3ylsqVdNaBnlO6+q7JadB+ljMwsSVJ577Ly9yunhSt/VtKxMypVsoTaNK2tacN7qFb1ivr3hMUF+XUBSDp77qwmfzhRd9xRWbWCgrT1hy3XbPvvIYMVv3SxOt3XRd0e766LFy9o965dOnPm9C0cMYozEkxzTjk5OTkFPYiCUDq0X0EPARZwdnbSxk9j5eZSUiEPvilJGjvoEfXo3FQhD76hpGNnJUmtw4IUP6m/XSF6LQvG9lXLxrXk1+IVZWffln88iryzP0wo6CHAIunp6UpJTlYFX1/9tuNXPf5o16smmMuXxeuf/xio996foKi27QpotLgV3AowGqvx0hKH9X3g/U4O67sgcJMPirTs7BwdPnZWXh5lbMfujwrR19/tsBWXkrR68+/ac+C4HmofesM+D/1xRmXcSsmlFAE/UNBcXFxUwdf3hu0+mfWR6gXXV1TbdsrOztaFCxduwegAXAsFJoqcMm4uKu9dVgFVKqj/E63VIbyu1mz5XZJU2ddLfuU99dPOQ7mu27rjoBoEVc113M21lMp7l1W1O3z0ROcw9bivqTZvT9SlPzMc/l0A3Ly0tDTt+HW77q4XrHFj31N42D1q1jhUMR2itHxZfEEPD8WIk5OTw17FDRENipy3//Gg+nSNkCRlZWXry29/1sC3/ytJquTrJUn641RyruuOnUpWee+ycilVUukZmbbj/R5vpTde7GJ7/+3m3er779mO/AoALJSUdEg5OTla/vVSlShRUgP/8arc3T00Z/bHin3lZbmXdVd4i8iCHiZwWyl0BebJkye1YcMGJSQk6Ny5c5Ikb29vBQYGKjw8XL4GUyUo3ibMWa2FK7fpDl8vPdSuoUo4O9ums0u7lpIkpadn5rru0v+OlXYtZVdg/nfZVv2485B8y7krukU9VSzvITdXl1vwTQBY4eL/psPPnTunT+b+V/XrN5AktWrdRjEdojRl8ocUmLBG8QsaHabQFJgZGRl65513NG/ePGVlZcnX11deXpfTqOTkZJ08eVIlSpRQt27dFBcXp5IlC83QcYvtOXBcew4clyR9umSLFn/wgj5/v69a9Biti/+b1nZxyf33h9v/jl3829T3oT/O6tAfl9dr/nfZj5ow5DHFT+qn+g+8wTQ5UAS4urpKkvyrVLEVl5JUpmxZRbZqraWLFyszM5N/bwC3UKH50zZ27Fh9+eWXGjp0qKKjo+Xh4WF3Pi0tTV9//bVGjRolNzc3vfLKKwU0UhQ2C1f+rImvPaa7qlfUsZOXp8bvqOCVq12lCl46fe68XXp59f626ZmHwhXR8E6t3LTLIWMGYB3fihUlSeXLV8h1zsenvDIzM3Tx4sVc/14B8qo4rpV0lEJzk8+XX36pQYMG6ZFHHrnqPwTc3d318MMPKzY2VosWLbr1A0ShdWVa3Mu9tI6eTNaJM6lqWLdarnaN6lXX9t8P37g/tyv9uVk7UAAOUbGinypU8NWJ48dznTt58oRcXV1VtmzZAhgZcPsqNAXm+fPnValSpRu2q1Spks6fP38LRoTCxrece65jJUs66/FOTXThYrp2JfwhSVq06mdFt6inKn7etnatmtRSrRp++mLlNtuxClfpT5J63d9c2dnZ2rY7ydovAMBhOtwbrWPH/tCmjf+3z+3Zs2e05ttVahLWVM7OheZfdyjCuIvcXKGZIg8JCdGkSZMUHBx8zWmMtLQ0TZo0SaGhN97LEMXPhCGPyaOsm9b/tE9HT56TX3lPdYturNqBlRT77hc6fzFdkjRq+nI92DZUy6a8pIlz16hsGVcN7BmlX/cc0cdffm/rL/aZDmoWEqgVG3cq6Y+z8vEqo/ujQtSoXg19MHeNEpJOFdRXBfAXc+fMVmpqik6eOCFJWrtmtY4fPyZJeuyJHvLw8NAzffpqxfKv9Y8B/dWj11Nyd/fQZ/+dq8zMTPV/6eWCHD6KkWJYBzpMoXmST0JCgnr16qXz58+refPmCgwMtBWaaWlpSkhI0MaNG1W2bFl99NFHCgwMvKnP40k+Rc/DHe5Rr/ub6e47K6u8V1mlXrikbbuS9OG8tVq69le7tnUCK+mdfzyk5qGBSs/I0rLvdijuvYU6cSbV1qZNWG09/1hLhdapqgrl3HXpzwzt2HtUMxdu1GyeRV6k8SSf4iW6XRsdPXrkqufiV6ySv38VSdLhpCS9O/odbfl+kzIzM1W/QYheGvgP1QuufyuHCwcryCf53PnK1w7re9/oaIf1XRAKTYEpSSkpKZo7d66+++47JSQkKCUlRZLk6empwMBARUZGqlu3bvL09Lzpz6LABIovCkyg+CrIAvOuV5c5rO+9o+51WN8FodBMkUuXC8m+ffuqb9++BT0UAAAA5FOhKjABAAAKK9ZgmuO2OgAAAFiKBBMAAMBAcdxOyFFIMAEAAGApEkwAAAADBJjmKDABAAAMODtTYZpiihwAAACWIsEEAAAwwBS5ORJMAAAAWIoEEwAAwADbFJkjwQQAAIClSDABAAAMEGCaI8EEAACApUgwAQAADLAG0xwFJgAAgAEKTHNMkQMAAMBSJJgAAAAGCDDNkWACAADAUiSYAAAABliDaY4EEwAAAJYiwQQAADBAgGmOBBMAAACWIsEEAAAwwBpMcxSYAAAABqgvzTFFDgAAAEuRYAIAABhgitwcCSYAAAAsRYIJAABggADTHAkmAAAALEWCCQAAYIA1mOZIMAEAAGApEkwAAAADBJjmKDABAAAMMEVujilyAAAAWIoEEwAAwAABpjkSTAAAAFiKBBMAAMAAazDNkWACAAAUUV9//bWee+45RUZGKiQkRF26dNGCBQuUk5Nj1+6zzz5Thw4dFBwcrPvuu0+rV6/O1VdqaqoGDx6sJk2aKDQ0VC+++KJOnDiRr3FRYAIAABhwcnLcK78++ugjlS5dWnFxcfrwww8VGRmp1157TRMnTrS1Wbp0qV577TVFR0dr6tSpCgkJUb9+/fTzzz/b9TVgwABt2LBBw4YN0+jRo5WYmKg+ffooMzMzz+NiihwAAKCI+vDDD+Xj42N736xZM507d04zZ87U888/L2dnZ40bN04dO3bUgAEDJElNmzbVnj17NHHiRE2dOlWStG3bNq1fv17Tp09XRESEJCkgIEAxMTFasWKFYmJi8jQuEkwAAAADTk5ODnvl11+Lyyvq1KmjtLQ0XbhwQUlJSTpw4ICio6Pt2sTExGjTpk1KT0+XJK1bt06enp4KDw+3tQkMDFSdOnW0bt26PI+LAhMAAMBAYSwwr+bHH3+Un5+f3N3dlZCQIOlyGvlXNWvWVEZGhpKSkiRJCQkJCggIyDWWwMBAWx95wRQ5AABAAYuKirru+VWrVhn1s3XrVsXHxys2NlaSlJycLEny9PS0a3fl/ZXzKSkp8vDwyNWfl5eXduzYYfTZf0WBCQAAYKCw71J07NgxDRw4UGFhYerZs2eBjoUCEwAAoICZJpTXkpKSoj59+sjb21vjx4+Xs/PlVZBeXl6SLm9B5Ovra9f+r+c9PT117NixXP0mJyfb2uQFazABAAAMFNY1mJcuXVLfvn2VmpqqadOm2U11BwYGSlKudZQJCQkqVaqUqlatamuXmJiYa//MxMREWx95QYEJAABQRGVmZmrAgAFKSEjQtGnT5OfnZ3e+atWqqlGjhpYtW2Z3PD4+Xs2aNZOLi4skKTIyUsnJydq0aZOtTWJionbu3KnIyMg8j4spcgAAAAOFcQ3m66+/rtWrVysuLk5paWl2m6fXrVtXLi4u6t+/v1555RVVq1ZNYWFhio+P1/bt2zV79mxb29DQUEVERGjw4MGKjY2Vq6urxowZo6CgILVv3z7P43LK+XsWepsoHdqvoIcAwEHO/jChoIcAwEHcCjAaa/3+Rof1vfql5vm6rk2bNjpy5MhVz61atUpVqlSRdPlRkVOnTtXRo0cVEBCgl19+Wa1bt7Zrn5qaqhEjRuibb75RZmamIiIiNGTIkFypqAkKTADFDgUmUHwVZIHZZtymGzfKp29fbOawvgsCazABAABgKdZgAgAAGCiMazALKwpMAAAAA85UmMaYIgcAAIClSDABAAAMEGCaI8EEAACApUgwAQAADNzsIx1vJySYAAAAsBQJJgAAgAFnAkxjJJgAAACwFAkmAACAAdZgmqPABAAAMEB9aY4pcgAAAFiKBBMAAMCAk4gwTZFgAgAAwFIkmAAAAAbYpsgcCSYAAAAsRYIJAABggG2KzJFgAgAAwFIkmAAAAAYIMM1RYAIAABhwpsI0xhQ5AAAALEWCCQAAYIAA0xwJJgAAACxFggkAAGCAbYrMkWACAADAUiSYAAAABggwzZFgAgAAwFIkmAAAAAbYB9McBSYAAIAByktzTJEDAADAUiSYAAAABtimyBwJJgAAACxFggkAAGDAmQDTGAkmAAAALEWCCQAAYIA1mOZIMAEAAGApEkwAAAADBJjmKDABAAAMMEVujilyAAAAWIoEEwAAwADbFJkjwQQAAICljBPMQYMG5blzJycnvfXWW3m+DgAAoLBhDaY54wJz8+bNuY5dunRJZ86ckSR5eXlJkpKTkyVJPj4+Kl26tBVjBAAAQBFiXGB+++23du/37dunp59+Wn379lWvXr3k4+MjSTpz5oxmzZqlRYsWacqUKdaOFgAAoICQX5rL9xrMN954Q5GRkRo4cKCtuJQuJ5cDBw5UixYt9MYbb1gySAAAABQd+S4wf/nlF9WtW/ea5+vUqaNffvklv90DAAAUKs5OTg57FTf5LjC9vLy0bt26a55ft26dPDw88ts9AABAoeLk5LhXcZPvAvPRRx/VmjVr9Nxzz2njxo06fPiwDh8+rA0bNujZZ5/VunXr1K1bNyvHCgAAgCIg3xutP//880pPT9f06dO1Zs0au3MlSpTQ//t//0/PP//8zY4PAACgUGCbInM39SSfAQMGqGfPntq0aZOOHDkiSfL391ezZs3sbvwBAADA7eOmHxXp4+Ojjh07WjEWAACAQosA05xxgXn06NF8fUDlypXzdR0AAACKJuMCs02bNvlae7Br1648XwMAAFDYFMfthBzFuMB86623WNwKAACAGzIuMB988EFHjgMAAKBQI2czd9M3+Vxx6dIlSZKbm5tVXQIAABQazOSau6kC8+jRoxo/frzWrl2rs2fPSpLKlSunli1bql+/fvL397dkkAAAACg68l1g7t+/X48//rhSU1PVvHlz1axZU5KUkJCgL7/8UqtXr9ann36qwMBAywZrpa8+HVbQQwDgIL8eSi7oIQBwkMaBXgX22fl+/OFtKN8F5rvvvitnZ2ctXLhQQUFBduf27NmjJ598Uu+++64mTpx404MEAABA0ZHvYvyHH35Qjx49chWXklSrVi098cQT2rJly00NDgAAoLBwcnJy2Ku4yXeBmZmZed0bekqXLq3MzMz8dg8AAIAiKt8FZp06dfTZZ58pNTU117m0tDQtWLBAdevWvanBAQAAFBbOTo57FTf5XoPZv39/9enTR9HR0XrwwQdVo0YNSVJiYqIWLlyoc+fOaejQoVaNEwAAAEVEvgvMZs2aacqUKRo5cqSmTJlid65OnToaNWqUmjZtetMDBAAAKAyKY9LoKDe1D2bz5s21aNEinTx5UkePHpUkVa5cWb6+vpYMDgAAoLAojjfjOEqeC8w//vhDzs7O8vPzkyT9+eefWrJkie38Tz/9JEny8/NTTEyMRcMEAABAUZGnAvP333/XAw88oMGDB6t79+6SpAsXLuidd96Rk5OTcnJybG1LlCihmjVrXnUbIwAAgKKGKXJzeSow58+fr8qVK+vxxx/PdW7UqFEKDQ2VJGVnZ6tnz56aP38+N/oAAAA40MGDBzV9+nT98ssv2rt3rwIDA+1mlyWpR48eV92fPD4+3vY0RklKTU3ViBEjtHLlSmVkZKhFixYaMmSIKlasmKcx5anA3Lx5s9q1aydn59y7G5UvX97u2eOdOnXSt99+m6fBAAAAFFaFdQnm3r17tXbtWjVo0EDZ2dl2M8p/1bBhQ8XGxtodq1Klit37AQMGaN++fRo2bJhcXV01duxY9enTR59//rlKljQvG/NUYB45ciTXs8VLliyp2rVrq2zZsrkGfOXGHwAAADhGmzZt1LZtW0lSXFycduzYcdV2np6eCgkJuWY/27Zt0/r16zV9+nRFRERIkgICAhQTE6MVK1bk6d6aPN/k8/eq2MPDQ4sWLcrV7u9rMgEAAIoy50IaYV5tZjk/1q1bJ09PT4WHh9uOBQYGqk6dOlq3bl2eCsw8jcjPz0+7d+82art7927bneYAAAAoWFu2bFFISIiCg4PVvXt3/fDDD3bnExISFBAQkGs7psDAQCUkJOTps/KUYIaHh2vx4sV64YUXVL58+Wu2O336tBYvXqzOnTvnaTAAAACFlTU54dVFRUVd9/yqVatuqv/GjRurS5cuqlGjhk6cOKHp06frqaee0ieffGK7STslJUUeHh65rvXy8rrmtPu15Om3evrpp5WZmaknn3xSv/7661Xb/Prrr3ryySeVmZmpp556Kk+DAQAAKKycnBz3crQXX3xRXbt2VaNGjRQTE6NPPvlEFStW1AcffOCQz8tTglmlShW99957evnll/XII4+oWrVqqlWrlsqUKaMLFy5oz549OnTokNzc3DR69GhVrVrVIYMGAAAoTm42ocyrMmXKqGXLllq+fLntmKenp44dO5arbXJysry8vPLUf55v8mndurW++uorTZ06VWvWrNE333xjO+fr66uuXbuqd+/eql69el67BgAAKLQK600+VgkMDNSmTZuUk5Njtw4zMTFRtWrVylNf+XoWedWqVTV8+HBJUlpams6fP6+yZcvK3d09P90BAADgFrpw4YLWrFmj4OBg27HIyEh98MEH2rRpk5o3by7pcnG5c+dO9e7dO0/956vA/Ct3d3cKSwAAUOwV1gDz4sWLWrt2raTLe5anpaVp2bJlkqQmTZooISFB06ZNU7t27eTv768TJ05o5syZOnnypN5//31bP6GhoYqIiNDgwYMVGxsrV1dXjRkzRkFBQWrfvn2exuSUc5tuVvnNrlMFPQQADuLtWqqghwDAQRoH5m0toJWGLt/rsL6Hd7gr39cePnz4mnehf/zxx6pUqZKGDx+u33//XefOnVPp0qUVGhqqfv36qX79+nbtrzwq8ptvvlFmZqYiIiI0ZMiQPG89SYEJoNihwASKr4IsMIetcFyBOax9/gvMwsiRWzoBAADgNnTTazABAABuB8X9LnIrkWACAADAUiSYAAAABggwzVFgAgAAGHCmwDTGFDkAAAAsRYIJAABgwElEmKZIMAEAAGApEkwAAAADrME0R4IJAAAAS5FgAgAAGCDBNEeCCQAAAEuRYAIAABhwYqd1YxSYAAAABpgiN8cUOQAAACxFggkAAGCAGXJzJJgAAACwFAkmAACAAWciTGMkmAAAALAUCSYAAIAB7iI3R4IJAAAAS5FgAgAAGGAJpjkKTAAAAAPOosI0xRQ5AAAALEWCCQAAYIApcnMkmAAAALAUCSYAAIABtikyR4IJAAAAS5FgAgAAGOBRkeZIMAEAAGApEkwAAAADBJjmKDABAAAMMEVujilyAAAAWIoEEwAAwAABpjkSTAAAAFiKBBMAAMAAqZw5fisAAABYigQTAADAgBOLMI2RYAIAAMBSJJgAAAAGyC/NUWACAAAYYKN1c0yRAwAAwFIkmAAAAAbIL82RYAIAAMBSJJgAAAAGWIJpjgQTAAAAliLBBAAAMMBG6+ZIMAEAAGApEkwAAAADpHLmKDABAAAMMEVujmIcAAAAliLBBAAAMEB+aY4EEwAAAJYiwQQAADDAGkxzJJgAAACwFAkmAACAAVI5c/xWAAAAsBQJJgAAgAHWYJqjwAQAADBAeWmOKXIAAABYigQTAADAADPk5kgwAQAAYCkSTAAAAAPOrMI0RoIJAAAAS5FgAgAAGGANpjkSTAAAAFiKBBMAAMCAE2swjZFgAgAAGHByctzrZhw8eFBDhw5Vly5dVLduXXXq1Omq7T777DN16NBBwcHBuu+++7R69epcbVJTUzV48GA1adJEoaGhevHFF3XixIk8j4kCEwAAoAjbu3ev1q5dq+rVq6tmzZpXbbN06VK99tprio6O1tSpUxUSEqJ+/frp559/tms3YMAAbdiwQcOGDdPo0aOVmJioPn36KDMzM09jYoocAADAQGHdpqhNmzZq27atJCkuLk47duzI1WbcuHHq2LGjBgwYIElq2rSp9uzZo4kTJ2rq1KmSpG3btmn9+vWaPn26IiIiJEkBAQGKiYnRihUrFBMTYzwmEkwAAIAizNn5+uVcUlKSDhw4oOjoaLvjMTEx2rRpk9LT0yVJ69atk6enp8LDw21tAgMDVadOHa1bty5vY8pTawAAgNtUYV2DeSMJCQmSLqeRf1WzZk1lZGQoKSnJ1i4gIEBOfxtQYGCgrQ9TTJEDAAAUsKioqOueX7VqVb77Tk5OliR5enraHb/y/sr5lJQUeXh45Lrey8vrqtPu10OBCQAAYICN1s1RYAIAABSwm0kob8TLy0vS5S2IfH19bcdTUlLsznt6eurYsWO5rk9OTra1McUaTAAAAANODvyfIwUGBkpSrnWUCQkJKlWqlKpWrWprl5iYqJycHLt2iYmJtj5MUWACAAAUY1WrVlWNGjW0bNkyu+Px8fFq1qyZXFxcJEmRkZFKTk7Wpk2bbG0SExO1c+dORUZG5ukzmSIHAAAw4FxI12BevHhRa9eulSQdOXJEaWlptmKySZMm8vHxUf/+/fXKK6+oWrVqCgsLU3x8vLZv367Zs2fb+gkNDVVERIQGDx6s2NhYubq6asyYMQoKClL79u3zNCannL/noLeJb3adKughAHAQb9dSBT0EAA7SODBvawGt9O3u0w7ru03t8vm+9vDhw9e8C/3jjz9WWFiYpMuPipw6daqOHj2qgIAAvfzyy2rdurVd+9TUVI0YMULffPONMjMzFRERoSFDhsjPzy9PY6LABFDsUGACxRcFZtHAFDkAAIABtikyx00+AAAAsBQJJgAAgAFHbydUnJBgAgAAwFIkmAAAAAYK6zZFhREFJoq8Q/t2a/GcKUrc/atycnIUEFRP9/d6XlUCa9m1y87O1oYVX2r9skU6eeyIXF3dVLVmkO595EkF1g4uoNEDuJ5jRw5pwceT9ftvv+h8WrLK+1ZS81YdFPNQd7m6uUmSvpw3Uz99/51O/HFYly5ekI+vn0Iah6tLt6fk6V2ugL8BcHtimyIUaUn7f9d7g56VdwU/RbTvopycbH339UKdT0vRq6Omys+/uq3tFzPG69uv5qlxyw6qWbeBLp5P04bli3Tm1HG9PGKSatSqW4DfBFZim6Li4fTJ4xr0/OMqU8ZdbTo+KHd3T+3d/au++2aJGjaN1Mv/Hi1Jev/NWHl4eatylRpyK1NGRw8d0Opli+Tp7aP/TJwtN7fSBfxNYKWC3Kbouz1nHdZ3i1rF6z+GSDBRpC35dKpKubjqH29Plrvn5X/oNG7ZQcOf76avPpmsPnFvSZKysjL13bKFCm3eWr0GDrVdHxreWsP6Pqyt61ZQYAKFzPpV8bqQlqqho6eoSvWakqQ2MQ8oJztb61fF63xqisp6eOqlIe/kuvbOOsEa9584bfv+OzVrlbcnkADXwjZF5rjJB0Xa/p2/KKh+Y1txKUlePhV0Z71Q/bZ1o/68eEGSlJWZpYz0P+Xxt+kyD69ycnJ2VikX11s6bgA3dvHCeUmSl7f9BtTePhXk5OysEqWunVT7+t0hSbpwPtVxAwRwTRSYKNIyMzJUytUl13EXFzdlZmbo6KGEy+9dXVWjVl19/+3X+mHtcp05eUxHDuzT7HH/UZmyHgpvf9+tHjqAG6hT/x5J0tSxb+rg/j06ffK4vl/7jVYt/Vwd7nvEbuo7JydHqcnndO7MKe3esU0fT3pXzs4lbH0AVnBy4Ku4YYocRVpF/2o68Ptvys7KknOJEpIuF50H9v4mSTp3+qStba+B/9aMUUM1a8xw27EKfpX18tsfqkIl/1s7cAA31KBRM3Xt2Vdfzf9IP32/zna8S7en9HCv5+zaJp89rX5PxNje+1SoqOdjh6ty1Rq3argA/qLIFZhnz57Vvn371Lhx44IeCgqBFtEPaP6k0ZozYYTaPviEcrJztOyzj5Ry9vLzYjPS021tXUuX0R3VAhRQ+24F1W+klLNntOKLTzRlxCANfOsDuXt6F9C3AHAtFfwqK6heqJqEt5G7p5d+3rJeX83/SF7lyqv9fY/Y2rl7eCnurQnKSP9TB/bv0dYNq/XnxYsFOHIUR84swjRW5ArMLVu2aMCAAdq1a1dBDwWFQIt7H9DZUye0atGn2rz6a0lStTtrq+0DT2j5Z7Pk+r8ptKysTI0f+pLuqheqR/7fy7brgxo00n9e7K6VCz/V/b2eL5DvAODqNq1ZoRnj3tKoqQtU3tdPktQ4vLWyc3I0f8YENWvVXh7/+w/DkqVKqV5oE0lSaFgL3R3SWMP/0Vue3uUUGtaioL4CcNtiDSaKvPu699WIjxZr4FsfaNDYj/XP0dOVk50tSaroX1WStO+3X/THoQQFN4mwu7Zi5aqqVKWGEnb/esvHDeD6Vi5doOo1g2zF5RUNw1rozz8v6eD+Pde8tlbd+vL2qaANq5c7epi4jbAG01yhSTA7d+5s1O78+fMOHgmKojLunqpZt4Ht/e/bt8q7fEXbPpip585Ikq3w/KuszExlZ2XemoECMJZ89ozKunvmOp71vz+vWVlZ170+Iz1dF8+nOWRsAK6v0BSYCQkJuvPOO1W37vX3Ijxy5Ij++OOPWzQqFEU/rl+pg3t36YEn+8nZ+XJIX7Hy5STzx+9Wqm7Dpra2Sft/1/Gjh7iLHCiE7vCvpl9/2qw/Dh/UHVX+76EJm9askJOzs6oF3KlLly7KSU62p/pcsWX9tzqflqKAu+rc6mGjOCuOUaODFJoC86677lL16tU1YsSI67Zbvny5fvjhh1s0KhR2+377WV/Pn6naIU1U1sNTB/b8pu9Xxatuw6Zq1flhW7tqd9ZW7QaNtXn117p08bxqhzRRytnTWrt0gUq5uKp150eu8ykACkLHrt31y9ZNeuPVvmrX+eHLN/lsXq9ftm5Uq3u7qFx5Xx3cv0cjBr+gppHtVLlKdTk5Oyth7y5t/PZr+frdoQ73P1rQXwPFiBMVprFCU2DWr19f3333nVHb2/TplrgKr/9tuLxq0ae6dPGCyvvdoU5P9FGb+7qpRAn7v73/3+B3tGrRp/px/Urt/GmzSpYspZp1G6jT473tHikJoHCoHdxQ/35vmr6YPVUrlyxQWmqyfP0q6+Fez6nTwz0kXd6OqHF4G+38Zau+W7lUWZmZquBXSe06P6wu3Z623QQE4NYqNM8iP3TokPbu3auoqKjrtrt06ZJOnz4tf/+b27eQZ5EDxRfPIgeKr4J8FvmWhGSH9d2kAL+XIxSaBLNatWqqVq3aDdu5ubnddHEJAAAAxyk0BSYAAEBhxgpMc+yDCQAAAEuRYAIAAJggwjRGggkAAABLkWACAAAYYB9McxSYAAAABpyoL40xRQ4AAABLkWACAAAYIMA0R4IJAAAAS5FgAgAAmCDCNEaCCQAAAEuRYAIAABhgmyJzJJgAAACwFAkmAACAAfbBNEeBCQAAYID60hxT5AAAALAUCSYAAIAJIkxjJJgAAACwFAkmAACAAbYpMkeCCQAAAEuRYAIAABhgmyJzJJgAAACwFAkmAACAAQJMcxSYAAAAJqgwjTFFDgAAAEuRYAIAABhgmyJzJJgAAACwFAkmAACAAbYpMkeCCQAAAEuRYAIAABggwDRHggkAAABLkWACAACYIMI0RoEJAABggG2KzDFFDgAAAEuRYAIAABhgmyJzJJgAAACwFAkmAACAAQJMcySYAAAAsBQJJgAAgAkiTGMkmAAAALAUCSYAAIAB9sE0R4EJAABggG2KzDFFDgAAAEuRYAIAABggwDRHggkAAABLkWACAACYIMI0RoIJAAAAS5FgAgAAGGCbInMkmAAAAEXUF198oaCgoFyv0aNH27X77LPP1KFDBwUHB+u+++7T6tWrHTouEkwAAAADhXkfzGnTpsnDw8P23s/Pz/bXS5cu1WuvvaZnn31WTZs2VXx8vPr166c5c+YoJCTEIeOhwAQAACji7r77bvn4+Fz13Lhx49SxY0cNGDBAktS0aVPt2bNHEydO1NSpUx0yHqbIAQAADDg58OUoSUlJOnDggKKjo+2Ox8TEaNOmTUpPT3fI51JgAgAAmCjEFWanTp1Up04dRUVFafLkycrKypIkJSQkSJICAgLs2tesWVMZGRlKSkq6+Q+/CqbIAQAAClhUVNR1z69ateqqx319fdW/f381aNBATk5O+vbbbzV27FgdP35cQ4cOVXJysiTJ09PT7ror76+ctxoFJgAAgIHCuE1RixYt1KJFC9v7iIgIubq6atasWXr22WcLbFwUmAAAAAXsWgllfkRHR2vGjBnatWuXvLy8JEmpqany9fW1tUlJSZEk23mrsQYTAADAgJOT416OEhgYKOn/1mJekZCQoFKlSqlq1aoO+VwKTAAAgGIkPj5eJUqUUN26dVW1alXVqFFDy5Yty9WmWbNmcnFxccgYmCIHAAAwUPhWYErPPPOMwsLCFBQUJOnyVPt///tf9ezZ0zYl3r9/f73yyiuqVq2awsLCFB8fr+3bt2v27NkOGxcFJgAAQBEVEBCgzz//XMeOHVN2drZq1KihwYMHq0ePHrY2nTp10sWLFzV16lRNmTJFAQEBmjBhgkJDQx02LqecnJwch/VeiH2z61RBDwGAg3i7liroIQBwkMaBjrkpxcThs386rO8q5Vwd1ndBIMEEAAAwUhgnyQsnbvIBAACApUgwAQAADDhyO6HihgQTAAAAliLBBAAAMECAaY4EEwAAAJYiwQQAADDAGkxzJJgAAACwFAkmAACAASdWYRqjwAQAADBBfWmMKXIAAABYigQTAADAAAGmORJMAAAAWIoEEwAAwADbFJkjwQQAAIClSDABAAAMsE2RORJMAAAAWIoEEwAAwAQBpjEKTAAAAAPUl+aYIgcAAIClSDABAAAMsE2RORJMAAAAWIoEEwAAwADbFJkjwQQAAIClSDABAAAMsAbTHAkmAAAALEWBCQAAAEsxRQ4AAGCAKXJzJJgAAACwFAkmAACAAbYpMkeCCQAAAEuRYAIAABhgDaY5EkwAAABYigQTAADAAAGmORJMAAAAWIoEEwAAwAQRpjEKTAAAAANsU2SOKXIAAABYigQTAADAANsUmSPBBAAAgKVIMAEAAAwQYJojwQQAAIClSDABAABMEGEaI8EEAACApUgwAQAADLAPpjkKTAAAAANsU2SOKXIAAABYyiknJyenoAcBAACA4oMEEwAAAJaiwAQAAIClKDABAABgKQpMAAAAWIoCEwAAAJaiwAQAAIClKDABAABgKQpMAAAAWIoCEwAAAJaiwAQAAIClKDABAABgKQpMAAAAWIoCEwAAAJaiwESxtX//fj311FMKCQlReHi4Ro4cqfT09IIeFgALHDx4UEOHDlWXLl1Ut25dderUqaCHBOAvShb0AABHSE5OVq9evVSjRg2NHz9ex48f19tvv61Lly5p6NChBT08ADdp7969Wrt2rRo0aKDs7Gzl5OQU9JAA/AUFJoqlefPm6fz585owYYK8vb0lSVlZWXr99dfVt29f+fn5FewAAdyUNm3aqG3btpKkuLg47dixo4BHBOCvmCJHsbRu3To1a9bMVlxKUnR0tLKzs7Vhw4aCGxgASzg7868voDDjTyiKpYSEBAUGBtod8/T0lK+vrxISEgpoVAAA3B4oMFEspaSkyNPTM9dxLy8vJScnF8CIAAC4fVBgAgAAwFIUmCiWPD09lZqamut4cnKyvLy8CmBEAADcPigwUSwFBgbmWmuZmpqqkydP5lqbCQAArEWBiWIpMjJSGzduVEpKiu3YsmXL5OzsrPDw8AIcGQAAxR/7YKJY6tatmz755BO98MIL6tu3r44fP66RI0eqW7du7IEJFAMXL17U2rVrJUlHjhxRWlqali1bJklq0qSJfHx8CnJ4wG3PKYfHH6CY2r9/v9544w1t27ZNZcuWVZcuXTRw4EC5uLgU9NAA3KTDhw8rKirqquc+/vhjhYWF3eIRAfgrCkwAAABYijWYAAAAsBQFJgAAACxFgQkAAABLUWACAADAUhSYAAAAsBQFJgAAACxFgQkAAABLUWACKHLatGmjuLg42/vNmzcrKChImzdvtuwzgoKCNH78eMv6A4DbCQUmgDz74osvFBQUZHsFBwerQ4cOGj58uE6dOlXQwzO2du1aikgAcACeRQ4g31588UVVqVJF6enp+vHHHzV37lytXbtWS5YsUenSpW/ZOBo3bqzt27erVKlSebpu7dq1mjNnjvr375/r3Pbt21WiRAmrhggAtxUKTAD5FhkZqeDgYEnSww8/LG9vb82cOVOrVq1Sp06dcrW/cOGCypQpY/k4nJ2d5erqammfVvcHALcTpsgBWKZp06aSpMOHDysuLk6hoaE6dOiQ+vTpo9DQUL3yyiuSpOzsbH300Ufq2LGjgoOD1bx5cw0dOlTJycl2/eXk5OiDDz5QZGSkGjRooB49emjv3r25PvdaazB/+eUX9enTR40bN1ZISIg6d+6sWbNmSZLi4uI0Z84cSbKb7r/iamswd+7cqd69e6thw4YKDQ1Vr1699PPPP9u1ubJ84Mcff9SIESPUtGlThYSE6IUXXtCZM2fy8asCQNFDggnAMocOHZIkeXt7S5IyMzP1zDPP6J577lFsbKzc3NwkSUOHDtXChQv14IMPqkePHjp8+LDmzJmjnTt3au7cubap7vfff18ffvihWrZsqZYtW+q3337T008/rYyMjBuOZcOGDerbt68qVqyonj17qkKFCtq/f7/WrFmjXr166dFHH9WJEye0YcMGjRw58ob97d27V0888YTKli2r3r17q2TJkpo/f7569Oih2bNnq0GDBnbt33zzTXl6eqpfv346cuSIZs2apeHDh2vs2LF5+EUBoGiiwASQb2lpaTpz5ozS09P1008/aeLEiXJzc1Pr1q31888/Kz09Xffee6/+8Y9/2K7ZunWrPvvsM40ePVqdO3e2HQ8LC1Pv3r21bNkyde7cWWfOnNG0adPUqlUrTZo0SU5OTpKkMWPGaNKkSdcdV1ZWloYOHaqKFStq0aJF8vT0tJ3LycmRJIWGhqpGjRrasGGDunTpcsPvOnbsWGVkZGju3LmqWrWqJOn+++/Xvffeq1GjRmn27Nl27b29vTVjxgzbuLOzs/XJJ58oNTVVHh4eN/w8ACjKmCIHkG9PPvmkmjVrppYtW2rgwIEqW7asJkyYID8/P1ubxx57zO6aZcuWycPDQ+Hh4Tpz5oztdffdd6tMmTK2ae6NGzcqIyND3bt3txVpktSrV68bjmvnzp06fPiwevbsaVdcSrLry1RWVpY2bNigtm3b2opLSapYsaI6deqkH3/8UWlpaXbXPPLII3af1ahRI2VlZenIkSN5/nwAKGpIMAHk29ChQxUQEKASJUqoQoUKCggIkLPz//13a8mSJVWpUiW7aw4ePKjU1FQ1a9bsqn2ePn1aknT06FFJUo0aNezO+/j4yMvL67rjSkpKkiTVqlUrT9/nWs6cOaOLFy8qICAg17maNWsqOztbf/zxh+666y7b8cqVK9u1u1LopqSkWDImACjMKDAB5Fv9+vVtd5FfjYuLi13BKV2eKi5fvrxGjx591Wt8fHwsHWNB+fv3vuLKFD0AFGcUmABuqWrVqmnTpk1q2LCh7aafq7mSAB44cMBuWvrMmTO57jb/uyvt9+zZo+bNm1+znel0uY+Pj0qXLq3ExMRc5xISEuTs7Kw77rjDqC8AuB2wBhPALRUdHa2srCx98MEHuc5lZmbappCbN2+uUqVKafbs2Xap35Vthq7n7rvvVpUqVfTxxx/nmpL+a19XNoO/0bR1iRIlFB4erlWrVunw4cO246dOndKSJUt0zz33yN3d/YbjAoDbBQkmgFuqSZMmevTRRzV58mTt2rVL4eHhKlWqlA4cOKBly5bpX//6l+699175+Pjo6aef1uTJk9W3b1+1bNlSO3fu1Lp161SuXLnrfoazs7OGDRum5557Tvfff78efPBB+fr6KiEhQfv27dP06dMlXS5EpctbCkVERKhEiRLq2LHjVfscMGCANm7cqMcff1yPP/64SpQoofnz5ys9PV2vvvqqtT8SABRxFJgAbrnhw4erXr16mjdvnsaMGaMSJUrI399f9913nxo2bGhrN2DAALm4uGjevHnavHmz6tevrxkzZqhv3743/IwWLVpo1qxZmjhxombMmKGcnBxVrVpVjzzyiK1N+/bt1aNHDy1dulRfffWVcnJyrllg3nXXXZozZ47effddTZ48WTk5Oapfv75GjRqVaw9MALjdOeWw4hwAAAAWYg0mAAAALEWBCQAAAEtRYAIAAMBSFJgAAACwFAUmAAAALEWBCQAAAEtRYAIAAMBSFJgAAACwFAUmAAAALEWBCQAAAEtRYAIAAMBSFJgAAACwFAUmAAAALPX/AeHImITn1m18AAAAAElFTkSuQmCC\n"
+          },
+          "metadata": {}
+        }
+      ],
+      "source": [
+        "print('------Test set 2 (News):------')\n",
+        "evaluate(test_dataloader_news)"
+      ]
+    }
+  ],
+  "metadata": {
+    "accelerator": "GPU",
+    "colab": {
+      "provenance": [],
+      "gpuType": "T4"
+    },
+    "kernelspec": {
+      "display_name": "Python 3",
+      "name": "python3"
+    },
+    "language_info": {
+      "name": "python"
+    },
+    "widgets": {
+      "application/vnd.jupyter.widget-state+json": {
+        "28bdd31f56c147928235762b80391c6f": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_name": "HBoxModel",
+          "model_module_version": "1.5.0",
+          "state": {
+            "_dom_classes": [],
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "HBoxModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/controls",
+            "_view_module_version": "1.5.0",
+            "_view_name": "HBoxView",
+            "box_style": "",
+            "children": [
+              "IPY_MODEL_b629edd4da2f44ff981e52704bb80b06",
+              "IPY_MODEL_3b8fbd932edc4a96b64f3f003fd1125c",
+              "IPY_MODEL_3c812cdc92d14961a60e0c5306991643"
+            ],
+            "layout": "IPY_MODEL_4bddcf4e5a7846db974357270fb0f8a5"
+          }
+        },
+        "b629edd4da2f44ff981e52704bb80b06": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_name": "HTMLModel",
+          "model_module_version": "1.5.0",
+          "state": {
+            "_dom_classes": [],
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "HTMLModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/controls",
+            "_view_module_version": "1.5.0",
+            "_view_name": "HTMLView",
+            "description": "",
+            "description_tooltip": null,
+            "layout": "IPY_MODEL_67991eabd9d2439ebe56c41ed0026db3",
+            "placeholder": "​",
+            "style": "IPY_MODEL_b8f91bb1736c4621adefe6912dcac88f",
+            "value": "vocab.txt: 100%"
+          }
+        },
+        "3b8fbd932edc4a96b64f3f003fd1125c": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_name": "FloatProgressModel",
+          "model_module_version": "1.5.0",
+          "state": {
+            "_dom_classes": [],
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "FloatProgressModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/controls",
+            "_view_module_version": "1.5.0",
+            "_view_name": "ProgressView",
+            "bar_style": "success",
+            "description": "",
+            "description_tooltip": null,
+            "layout": "IPY_MODEL_7f5b469bd3eb42e79d268dff00874214",
+            "max": 1108715,
+            "min": 0,
+            "orientation": "horizontal",
+            "style": "IPY_MODEL_ec21c6a06c5942e98137c5d05b14f67b",
+            "value": 1108715
+          }
+        },
+        "3c812cdc92d14961a60e0c5306991643": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_name": "HTMLModel",
+          "model_module_version": "1.5.0",
+          "state": {
+            "_dom_classes": [],
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "HTMLModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/controls",
+            "_view_module_version": "1.5.0",
+            "_view_name": "HTMLView",
+            "description": "",
+            "description_tooltip": null,
+            "layout": "IPY_MODEL_cbb4c015d35243179bd6b8db4b3db78c",
+            "placeholder": "​",
+            "style": "IPY_MODEL_47808be39e0641f3a301984e95c4a53b",
+            "value": " 1.11M/1.11M [00:00&lt;00:00, 9.21MB/s]"
+          }
+        },
+        "4bddcf4e5a7846db974357270fb0f8a5": {
+          "model_module": "@jupyter-widgets/base",
+          "model_name": "LayoutModel",
+          "model_module_version": "1.2.0",
+          "state": {
+            "_model_module": "@jupyter-widgets/base",
+            "_model_module_version": "1.2.0",
+            "_model_name": "LayoutModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "LayoutView",
+            "align_content": null,
+            "align_items": null,
+            "align_self": null,
+            "border": null,
+            "bottom": null,
+            "display": null,
+            "flex": null,
+            "flex_flow": null,
+            "grid_area": null,
+            "grid_auto_columns": null,
+            "grid_auto_flow": null,
+            "grid_auto_rows": null,
+            "grid_column": null,
+            "grid_gap": null,
+            "grid_row": null,
+            "grid_template_areas": null,
+            "grid_template_columns": null,
+            "grid_template_rows": null,
+            "height": null,
+            "justify_content": null,
+            "justify_items": null,
+            "left": null,
+            "margin": null,
+            "max_height": null,
+            "max_width": null,
+            "min_height": null,
+            "min_width": null,
+            "object_fit": null,
+            "object_position": null,
+            "order": null,
+            "overflow": null,
+            "overflow_x": null,
+            "overflow_y": null,
+            "padding": null,
+            "right": null,
+            "top": null,
+            "visibility": null,
+            "width": null
+          }
+        },
+        "67991eabd9d2439ebe56c41ed0026db3": {
+          "model_module": "@jupyter-widgets/base",
+          "model_name": "LayoutModel",
+          "model_module_version": "1.2.0",
+          "state": {
+            "_model_module": "@jupyter-widgets/base",
+            "_model_module_version": "1.2.0",
+            "_model_name": "LayoutModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "LayoutView",
+            "align_content": null,
+            "align_items": null,
+            "align_self": null,
+            "border": null,
+            "bottom": null,
+            "display": null,
+            "flex": null,
+            "flex_flow": null,
+            "grid_area": null,
+            "grid_auto_columns": null,
+            "grid_auto_flow": null,
+            "grid_auto_rows": null,
+            "grid_column": null,
+            "grid_gap": null,
+            "grid_row": null,
+            "grid_template_areas": null,
+            "grid_template_columns": null,
+            "grid_template_rows": null,
+            "height": null,
+            "justify_content": null,
+            "justify_items": null,
+            "left": null,
+            "margin": null,
+            "max_height": null,
+            "max_width": null,
+            "min_height": null,
+            "min_width": null,
+            "object_fit": null,
+            "object_position": null,
+            "order": null,
+            "overflow": null,
+            "overflow_x": null,
+            "overflow_y": null,
+            "padding": null,
+            "right": null,
+            "top": null,
+            "visibility": null,
+            "width": null
+          }
+        },
+        "b8f91bb1736c4621adefe6912dcac88f": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_name": "DescriptionStyleModel",
+          "model_module_version": "1.5.0",
+          "state": {
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "DescriptionStyleModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "StyleView",
+            "description_width": ""
+          }
+        },
+        "7f5b469bd3eb42e79d268dff00874214": {
+          "model_module": "@jupyter-widgets/base",
+          "model_name": "LayoutModel",
+          "model_module_version": "1.2.0",
+          "state": {
+            "_model_module": "@jupyter-widgets/base",
+            "_model_module_version": "1.2.0",
+            "_model_name": "LayoutModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "LayoutView",
+            "align_content": null,
+            "align_items": null,
+            "align_self": null,
+            "border": null,
+            "bottom": null,
+            "display": null,
+            "flex": null,
+            "flex_flow": null,
+            "grid_area": null,
+            "grid_auto_columns": null,
+            "grid_auto_flow": null,
+            "grid_auto_rows": null,
+            "grid_column": null,
+            "grid_gap": null,
+            "grid_row": null,
+            "grid_template_areas": null,
+            "grid_template_columns": null,
+            "grid_template_rows": null,
+            "height": null,
+            "justify_content": null,
+            "justify_items": null,
+            "left": null,
+            "margin": null,
+            "max_height": null,
+            "max_width": null,
+            "min_height": null,
+            "min_width": null,
+            "object_fit": null,
+            "object_position": null,
+            "order": null,
+            "overflow": null,
+            "overflow_x": null,
+            "overflow_y": null,
+            "padding": null,
+            "right": null,
+            "top": null,
+            "visibility": null,
+            "width": null
+          }
+        },
+        "ec21c6a06c5942e98137c5d05b14f67b": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_name": "ProgressStyleModel",
+          "model_module_version": "1.5.0",
+          "state": {
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "ProgressStyleModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "StyleView",
+            "bar_color": null,
+            "description_width": ""
+          }
+        },
+        "cbb4c015d35243179bd6b8db4b3db78c": {
+          "model_module": "@jupyter-widgets/base",
+          "model_name": "LayoutModel",
+          "model_module_version": "1.2.0",
+          "state": {
+            "_model_module": "@jupyter-widgets/base",
+            "_model_module_version": "1.2.0",
+            "_model_name": "LayoutModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "LayoutView",
+            "align_content": null,
+            "align_items": null,
+            "align_self": null,
+            "border": null,
+            "bottom": null,
+            "display": null,
+            "flex": null,
+            "flex_flow": null,
+            "grid_area": null,
+            "grid_auto_columns": null,
+            "grid_auto_flow": null,
+            "grid_auto_rows": null,
+            "grid_column": null,
+            "grid_gap": null,
+            "grid_row": null,
+            "grid_template_areas": null,
+            "grid_template_columns": null,
+            "grid_template_rows": null,
+            "height": null,
+            "justify_content": null,
+            "justify_items": null,
+            "left": null,
+            "margin": null,
+            "max_height": null,
+            "max_width": null,
+            "min_height": null,
+            "min_width": null,
+            "object_fit": null,
+            "object_position": null,
+            "order": null,
+            "overflow": null,
+            "overflow_x": null,
+            "overflow_y": null,
+            "padding": null,
+            "right": null,
+            "top": null,
+            "visibility": null,
+            "width": null
+          }
+        },
+        "47808be39e0641f3a301984e95c4a53b": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_name": "DescriptionStyleModel",
+          "model_module_version": "1.5.0",
+          "state": {
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "DescriptionStyleModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "StyleView",
+            "description_width": ""
+          }
+        },
+        "1542cfad9dc048f887fd958994b392aa": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_name": "HBoxModel",
+          "model_module_version": "1.5.0",
+          "state": {
+            "_dom_classes": [],
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "HBoxModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/controls",
+            "_view_module_version": "1.5.0",
+            "_view_name": "HBoxView",
+            "box_style": "",
+            "children": [
+              "IPY_MODEL_e837339546a842b6a0ce9b6fd63f7e3d",
+              "IPY_MODEL_f50a75d806f44d7f9a950de500482512",
+              "IPY_MODEL_f2ee89268723449e8e92f6f202a968ec"
+            ],
+            "layout": "IPY_MODEL_38035e10b23d4d9585f15b6fe2eaa468"
+          }
+        },
+        "e837339546a842b6a0ce9b6fd63f7e3d": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_name": "HTMLModel",
+          "model_module_version": "1.5.0",
+          "state": {
+            "_dom_classes": [],
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "HTMLModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/controls",
+            "_view_module_version": "1.5.0",
+            "_view_name": "HTMLView",
+            "description": "",
+            "description_tooltip": null,
+            "layout": "IPY_MODEL_f179284b1da54b4e9a8d08fca88daee0",
+            "placeholder": "​",
+            "style": "IPY_MODEL_c4d3214d601b4f1ea8191e68bbc634d9",
+            "value": "config.json: 100%"
+          }
+        },
+        "f50a75d806f44d7f9a950de500482512": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_name": "FloatProgressModel",
+          "model_module_version": "1.5.0",
+          "state": {
+            "_dom_classes": [],
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "FloatProgressModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/controls",
+            "_view_module_version": "1.5.0",
+            "_view_name": "ProgressView",
+            "bar_style": "success",
+            "description": "",
+            "description_tooltip": null,
+            "layout": "IPY_MODEL_998686baebd9472583634c26fe597867",
+            "max": 625,
+            "min": 0,
+            "orientation": "horizontal",
+            "style": "IPY_MODEL_e968f0ca73c14b73be9b2a4f075d5224",
+            "value": 625
+          }
+        },
+        "f2ee89268723449e8e92f6f202a968ec": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_name": "HTMLModel",
+          "model_module_version": "1.5.0",
+          "state": {
+            "_dom_classes": [],
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "HTMLModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/controls",
+            "_view_module_version": "1.5.0",
+            "_view_name": "HTMLView",
+            "description": "",
+            "description_tooltip": null,
+            "layout": "IPY_MODEL_f8eeeccfd660405b9ffa0b5b15ce6ba7",
+            "placeholder": "​",
+            "style": "IPY_MODEL_d98c125fb41349f6921294034af5e751",
+            "value": " 625/625 [00:00&lt;00:00, 10.5kB/s]"
+          }
+        },
+        "38035e10b23d4d9585f15b6fe2eaa468": {
+          "model_module": "@jupyter-widgets/base",
+          "model_name": "LayoutModel",
+          "model_module_version": "1.2.0",
+          "state": {
+            "_model_module": "@jupyter-widgets/base",
+            "_model_module_version": "1.2.0",
+            "_model_name": "LayoutModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "LayoutView",
+            "align_content": null,
+            "align_items": null,
+            "align_self": null,
+            "border": null,
+            "bottom": null,
+            "display": null,
+            "flex": null,
+            "flex_flow": null,
+            "grid_area": null,
+            "grid_auto_columns": null,
+            "grid_auto_flow": null,
+            "grid_auto_rows": null,
+            "grid_column": null,
+            "grid_gap": null,
+            "grid_row": null,
+            "grid_template_areas": null,
+            "grid_template_columns": null,
+            "grid_template_rows": null,
+            "height": null,
+            "justify_content": null,
+            "justify_items": null,
+            "left": null,
+            "margin": null,
+            "max_height": null,
+            "max_width": null,
+            "min_height": null,
+            "min_width": null,
+            "object_fit": null,
+            "object_position": null,
+            "order": null,
+            "overflow": null,
+            "overflow_x": null,
+            "overflow_y": null,
+            "padding": null,
+            "right": null,
+            "top": null,
+            "visibility": null,
+            "width": null
+          }
+        },
+        "f179284b1da54b4e9a8d08fca88daee0": {
+          "model_module": "@jupyter-widgets/base",
+          "model_name": "LayoutModel",
+          "model_module_version": "1.2.0",
+          "state": {
+            "_model_module": "@jupyter-widgets/base",
+            "_model_module_version": "1.2.0",
+            "_model_name": "LayoutModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "LayoutView",
+            "align_content": null,
+            "align_items": null,
+            "align_self": null,
+            "border": null,
+            "bottom": null,
+            "display": null,
+            "flex": null,
+            "flex_flow": null,
+            "grid_area": null,
+            "grid_auto_columns": null,
+            "grid_auto_flow": null,
+            "grid_auto_rows": null,
+            "grid_column": null,
+            "grid_gap": null,
+            "grid_row": null,
+            "grid_template_areas": null,
+            "grid_template_columns": null,
+            "grid_template_rows": null,
+            "height": null,
+            "justify_content": null,
+            "justify_items": null,
+            "left": null,
+            "margin": null,
+            "max_height": null,
+            "max_width": null,
+            "min_height": null,
+            "min_width": null,
+            "object_fit": null,
+            "object_position": null,
+            "order": null,
+            "overflow": null,
+            "overflow_x": null,
+            "overflow_y": null,
+            "padding": null,
+            "right": null,
+            "top": null,
+            "visibility": null,
+            "width": null
+          }
+        },
+        "c4d3214d601b4f1ea8191e68bbc634d9": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_name": "DescriptionStyleModel",
+          "model_module_version": "1.5.0",
+          "state": {
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "DescriptionStyleModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "StyleView",
+            "description_width": ""
+          }
+        },
+        "998686baebd9472583634c26fe597867": {
+          "model_module": "@jupyter-widgets/base",
+          "model_name": "LayoutModel",
+          "model_module_version": "1.2.0",
+          "state": {
+            "_model_module": "@jupyter-widgets/base",
+            "_model_module_version": "1.2.0",
+            "_model_name": "LayoutModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "LayoutView",
+            "align_content": null,
+            "align_items": null,
+            "align_self": null,
+            "border": null,
+            "bottom": null,
+            "display": null,
+            "flex": null,
+            "flex_flow": null,
+            "grid_area": null,
+            "grid_auto_columns": null,
+            "grid_auto_flow": null,
+            "grid_auto_rows": null,
+            "grid_column": null,
+            "grid_gap": null,
+            "grid_row": null,
+            "grid_template_areas": null,
+            "grid_template_columns": null,
+            "grid_template_rows": null,
+            "height": null,
+            "justify_content": null,
+            "justify_items": null,
+            "left": null,
+            "margin": null,
+            "max_height": null,
+            "max_width": null,
+            "min_height": null,
+            "min_width": null,
+            "object_fit": null,
+            "object_position": null,
+            "order": null,
+            "overflow": null,
+            "overflow_x": null,
+            "overflow_y": null,
+            "padding": null,
+            "right": null,
+            "top": null,
+            "visibility": null,
+            "width": null
+          }
+        },
+        "e968f0ca73c14b73be9b2a4f075d5224": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_name": "ProgressStyleModel",
+          "model_module_version": "1.5.0",
+          "state": {
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "ProgressStyleModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "StyleView",
+            "bar_color": null,
+            "description_width": ""
+          }
+        },
+        "f8eeeccfd660405b9ffa0b5b15ce6ba7": {
+          "model_module": "@jupyter-widgets/base",
+          "model_name": "LayoutModel",
+          "model_module_version": "1.2.0",
+          "state": {
+            "_model_module": "@jupyter-widgets/base",
+            "_model_module_version": "1.2.0",
+            "_model_name": "LayoutModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "LayoutView",
+            "align_content": null,
+            "align_items": null,
+            "align_self": null,
+            "border": null,
+            "bottom": null,
+            "display": null,
+            "flex": null,
+            "flex_flow": null,
+            "grid_area": null,
+            "grid_auto_columns": null,
+            "grid_auto_flow": null,
+            "grid_auto_rows": null,
+            "grid_column": null,
+            "grid_gap": null,
+            "grid_row": null,
+            "grid_template_areas": null,
+            "grid_template_columns": null,
+            "grid_template_rows": null,
+            "height": null,
+            "justify_content": null,
+            "justify_items": null,
+            "left": null,
+            "margin": null,
+            "max_height": null,
+            "max_width": null,
+            "min_height": null,
+            "min_width": null,
+            "object_fit": null,
+            "object_position": null,
+            "order": null,
+            "overflow": null,
+            "overflow_x": null,
+            "overflow_y": null,
+            "padding": null,
+            "right": null,
+            "top": null,
+            "visibility": null,
+            "width": null
+          }
+        },
+        "d98c125fb41349f6921294034af5e751": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_name": "DescriptionStyleModel",
+          "model_module_version": "1.5.0",
+          "state": {
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "DescriptionStyleModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "StyleView",
+            "description_width": ""
+          }
+        },
+        "a67e1b4bf617448f9db20fd46dc56f46": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_name": "HBoxModel",
+          "model_module_version": "1.5.0",
+          "state": {
+            "_dom_classes": [],
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "HBoxModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/controls",
+            "_view_module_version": "1.5.0",
+            "_view_name": "HBoxView",
+            "box_style": "",
+            "children": [
+              "IPY_MODEL_11d1b591773d4b829d98d9d780c25161",
+              "IPY_MODEL_53bfe85b38c848b0b3ea02abed50f33d",
+              "IPY_MODEL_db5c52b41b0e4242bca881dc14b642a3"
+            ],
+            "layout": "IPY_MODEL_cd751523a0ae4a46892f13602c5b5916"
+          }
+        },
+        "11d1b591773d4b829d98d9d780c25161": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_name": "HTMLModel",
+          "model_module_version": "1.5.0",
+          "state": {
+            "_dom_classes": [],
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "HTMLModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/controls",
+            "_view_module_version": "1.5.0",
+            "_view_name": "HTMLView",
+            "description": "",
+            "description_tooltip": null,
+            "layout": "IPY_MODEL_344289826beb4c56aa3f612891a82135",
+            "placeholder": "​",
+            "style": "IPY_MODEL_a444a7b7eff94a94a24f6ada365bf6c5",
+            "value": "pytorch_model.bin: 100%"
+          }
+        },
+        "53bfe85b38c848b0b3ea02abed50f33d": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_name": "FloatProgressModel",
+          "model_module_version": "1.5.0",
+          "state": {
+            "_dom_classes": [],
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "FloatProgressModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/controls",
+            "_view_module_version": "1.5.0",
+            "_view_name": "ProgressView",
+            "bar_style": "success",
+            "description": "",
+            "description_tooltip": null,
+            "layout": "IPY_MODEL_c95a34b695814dc29bc440ec6c45d658",
+            "max": 740314266,
+            "min": 0,
+            "orientation": "horizontal",
+            "style": "IPY_MODEL_f7c8b37f6a3545ad8fff6b634a6f8406",
+            "value": 740314266
+          }
+        },
+        "db5c52b41b0e4242bca881dc14b642a3": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_name": "HTMLModel",
+          "model_module_version": "1.5.0",
+          "state": {
+            "_dom_classes": [],
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "HTMLModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/controls",
+            "_view_module_version": "1.5.0",
+            "_view_name": "HTMLView",
+            "description": "",
+            "description_tooltip": null,
+            "layout": "IPY_MODEL_05954e578fac410891c0ed47b466a136",
+            "placeholder": "​",
+            "style": "IPY_MODEL_7b7007bb5269451da6a576835b8b6953",
+            "value": " 740M/740M [00:06&lt;00:00, 81.5MB/s]"
+          }
+        },
+        "cd751523a0ae4a46892f13602c5b5916": {
+          "model_module": "@jupyter-widgets/base",
+          "model_name": "LayoutModel",
+          "model_module_version": "1.2.0",
+          "state": {
+            "_model_module": "@jupyter-widgets/base",
+            "_model_module_version": "1.2.0",
+            "_model_name": "LayoutModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "LayoutView",
+            "align_content": null,
+            "align_items": null,
+            "align_self": null,
+            "border": null,
+            "bottom": null,
+            "display": null,
+            "flex": null,
+            "flex_flow": null,
+            "grid_area": null,
+            "grid_auto_columns": null,
+            "grid_auto_flow": null,
+            "grid_auto_rows": null,
+            "grid_column": null,
+            "grid_gap": null,
+            "grid_row": null,
+            "grid_template_areas": null,
+            "grid_template_columns": null,
+            "grid_template_rows": null,
+            "height": null,
+            "justify_content": null,
+            "justify_items": null,
+            "left": null,
+            "margin": null,
+            "max_height": null,
+            "max_width": null,
+            "min_height": null,
+            "min_width": null,
+            "object_fit": null,
+            "object_position": null,
+            "order": null,
+            "overflow": null,
+            "overflow_x": null,
+            "overflow_y": null,
+            "padding": null,
+            "right": null,
+            "top": null,
+            "visibility": null,
+            "width": null
+          }
+        },
+        "344289826beb4c56aa3f612891a82135": {
+          "model_module": "@jupyter-widgets/base",
+          "model_name": "LayoutModel",
+          "model_module_version": "1.2.0",
+          "state": {
+            "_model_module": "@jupyter-widgets/base",
+            "_model_module_version": "1.2.0",
+            "_model_name": "LayoutModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "LayoutView",
+            "align_content": null,
+            "align_items": null,
+            "align_self": null,
+            "border": null,
+            "bottom": null,
+            "display": null,
+            "flex": null,
+            "flex_flow": null,
+            "grid_area": null,
+            "grid_auto_columns": null,
+            "grid_auto_flow": null,
+            "grid_auto_rows": null,
+            "grid_column": null,
+            "grid_gap": null,
+            "grid_row": null,
+            "grid_template_areas": null,
+            "grid_template_columns": null,
+            "grid_template_rows": null,
+            "height": null,
+            "justify_content": null,
+            "justify_items": null,
+            "left": null,
+            "margin": null,
+            "max_height": null,
+            "max_width": null,
+            "min_height": null,
+            "min_width": null,
+            "object_fit": null,
+            "object_position": null,
+            "order": null,
+            "overflow": null,
+            "overflow_x": null,
+            "overflow_y": null,
+            "padding": null,
+            "right": null,
+            "top": null,
+            "visibility": null,
+            "width": null
+          }
+        },
+        "a444a7b7eff94a94a24f6ada365bf6c5": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_name": "DescriptionStyleModel",
+          "model_module_version": "1.5.0",
+          "state": {
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "DescriptionStyleModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "StyleView",
+            "description_width": ""
+          }
+        },
+        "c95a34b695814dc29bc440ec6c45d658": {
+          "model_module": "@jupyter-widgets/base",
+          "model_name": "LayoutModel",
+          "model_module_version": "1.2.0",
+          "state": {
+            "_model_module": "@jupyter-widgets/base",
+            "_model_module_version": "1.2.0",
+            "_model_name": "LayoutModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "LayoutView",
+            "align_content": null,
+            "align_items": null,
+            "align_self": null,
+            "border": null,
+            "bottom": null,
+            "display": null,
+            "flex": null,
+            "flex_flow": null,
+            "grid_area": null,
+            "grid_auto_columns": null,
+            "grid_auto_flow": null,
+            "grid_auto_rows": null,
+            "grid_column": null,
+            "grid_gap": null,
+            "grid_row": null,
+            "grid_template_areas": null,
+            "grid_template_columns": null,
+            "grid_template_rows": null,
+            "height": null,
+            "justify_content": null,
+            "justify_items": null,
+            "left": null,
+            "margin": null,
+            "max_height": null,
+            "max_width": null,
+            "min_height": null,
+            "min_width": null,
+            "object_fit": null,
+            "object_position": null,
+            "order": null,
+            "overflow": null,
+            "overflow_x": null,
+            "overflow_y": null,
+            "padding": null,
+            "right": null,
+            "top": null,
+            "visibility": null,
+            "width": null
+          }
+        },
+        "f7c8b37f6a3545ad8fff6b634a6f8406": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_name": "ProgressStyleModel",
+          "model_module_version": "1.5.0",
+          "state": {
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "ProgressStyleModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "StyleView",
+            "bar_color": null,
+            "description_width": ""
+          }
+        },
+        "05954e578fac410891c0ed47b466a136": {
+          "model_module": "@jupyter-widgets/base",
+          "model_name": "LayoutModel",
+          "model_module_version": "1.2.0",
+          "state": {
+            "_model_module": "@jupyter-widgets/base",
+            "_model_module_version": "1.2.0",
+            "_model_name": "LayoutModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "LayoutView",
+            "align_content": null,
+            "align_items": null,
+            "align_self": null,
+            "border": null,
+            "bottom": null,
+            "display": null,
+            "flex": null,
+            "flex_flow": null,
+            "grid_area": null,
+            "grid_auto_columns": null,
+            "grid_auto_flow": null,
+            "grid_auto_rows": null,
+            "grid_column": null,
+            "grid_gap": null,
+            "grid_row": null,
+            "grid_template_areas": null,
+            "grid_template_columns": null,
+            "grid_template_rows": null,
+            "height": null,
+            "justify_content": null,
+            "justify_items": null,
+            "left": null,
+            "margin": null,
+            "max_height": null,
+            "max_width": null,
+            "min_height": null,
+            "min_width": null,
+            "object_fit": null,
+            "object_position": null,
+            "order": null,
+            "overflow": null,
+            "overflow_x": null,
+            "overflow_y": null,
+            "padding": null,
+            "right": null,
+            "top": null,
+            "visibility": null,
+            "width": null
+          }
+        },
+        "7b7007bb5269451da6a576835b8b6953": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_name": "DescriptionStyleModel",
+          "model_module_version": "1.5.0",
+          "state": {
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "DescriptionStyleModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "StyleView",
+            "description_width": ""
+          }
+        }
+      }
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 0
+}

--- a/src/BERTBaseItalian_finetune_binary.ipynb
+++ b/src/BERTBaseItalian_finetune_binary.ipynb
@@ -1,0 +1,3042 @@
+{
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "c4HnTWtmSBD2"
+      },
+      "source": [
+        "# 1st model: [dbmdz/bert-base-italian-cased](https://huggingface.co/dbmdz/bert-base-italian-cased)\n",
+        "\n",
+        "In this script, we'll use a pre-trained BERT\n",
+        "(https://arxiv.org/abs/1810.04805) model for text classification\n",
+        "using PyTorch and PyTorch-Transformers\n",
+        "(https://github.com/huggingface/pytorch-transformers). This script\n",
+        "is based on \"Predicting Movie Review Sentiment with BERT on TF Hub\"\n",
+        "(https://github.com/google-research/bert/blob/master/predicting_movie_reviews_with_bert_on_tf_hub.ipynb)\n",
+        "by Google and \"BERT Fine-Tuning Tutorial with PyTorch\"\n",
+        "(https://mccormickml.com/2019/07/22/BERT-fine-tuning/) by Chris\n",
+        "McCormick.\n",
+        "\n",
+        "**Note that using a GPU with this script is highly recommended.**\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 1,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "BX_5tmtfSZFx",
+        "outputId": "05350ec4-5057-4dad-9258-65defaaaa283"
+      },
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "Requirement already satisfied: transformers in /usr/local/lib/python3.10/dist-packages (4.47.1)\n",
+            "Requirement already satisfied: filelock in /usr/local/lib/python3.10/dist-packages (from transformers) (3.16.1)\n",
+            "Requirement already satisfied: huggingface-hub<1.0,>=0.24.0 in /usr/local/lib/python3.10/dist-packages (from transformers) (0.27.0)\n",
+            "Requirement already satisfied: numpy>=1.17 in /usr/local/lib/python3.10/dist-packages (from transformers) (1.26.4)\n",
+            "Requirement already satisfied: packaging>=20.0 in /usr/local/lib/python3.10/dist-packages (from transformers) (24.2)\n",
+            "Requirement already satisfied: pyyaml>=5.1 in /usr/local/lib/python3.10/dist-packages (from transformers) (6.0.2)\n",
+            "Requirement already satisfied: regex!=2019.12.17 in /usr/local/lib/python3.10/dist-packages (from transformers) (2024.11.6)\n",
+            "Requirement already satisfied: requests in /usr/local/lib/python3.10/dist-packages (from transformers) (2.32.3)\n",
+            "Requirement already satisfied: tokenizers<0.22,>=0.21 in /usr/local/lib/python3.10/dist-packages (from transformers) (0.21.0)\n",
+            "Requirement already satisfied: safetensors>=0.4.1 in /usr/local/lib/python3.10/dist-packages (from transformers) (0.4.5)\n",
+            "Requirement already satisfied: tqdm>=4.27 in /usr/local/lib/python3.10/dist-packages (from transformers) (4.67.1)\n",
+            "Requirement already satisfied: fsspec>=2023.5.0 in /usr/local/lib/python3.10/dist-packages (from huggingface-hub<1.0,>=0.24.0->transformers) (2024.10.0)\n",
+            "Requirement already satisfied: typing-extensions>=3.7.4.3 in /usr/local/lib/python3.10/dist-packages (from huggingface-hub<1.0,>=0.24.0->transformers) (4.12.2)\n",
+            "Requirement already satisfied: charset-normalizer<4,>=2 in /usr/local/lib/python3.10/dist-packages (from requests->transformers) (3.4.0)\n",
+            "Requirement already satisfied: idna<4,>=2.5 in /usr/local/lib/python3.10/dist-packages (from requests->transformers) (3.10)\n",
+            "Requirement already satisfied: urllib3<3,>=1.21.1 in /usr/local/lib/python3.10/dist-packages (from requests->transformers) (2.2.3)\n",
+            "Requirement already satisfied: certifi>=2017.4.17 in /usr/local/lib/python3.10/dist-packages (from requests->transformers) (2024.12.14)\n",
+            "Requirement already satisfied: torch in /usr/local/lib/python3.10/dist-packages (2.5.1+cu121)\n",
+            "Requirement already satisfied: torchvision in /usr/local/lib/python3.10/dist-packages (0.20.1+cu121)\n",
+            "Requirement already satisfied: filelock in /usr/local/lib/python3.10/dist-packages (from torch) (3.16.1)\n",
+            "Requirement already satisfied: typing-extensions>=4.8.0 in /usr/local/lib/python3.10/dist-packages (from torch) (4.12.2)\n",
+            "Requirement already satisfied: networkx in /usr/local/lib/python3.10/dist-packages (from torch) (3.4.2)\n",
+            "Requirement already satisfied: jinja2 in /usr/local/lib/python3.10/dist-packages (from torch) (3.1.4)\n",
+            "Requirement already satisfied: fsspec in /usr/local/lib/python3.10/dist-packages (from torch) (2024.10.0)\n",
+            "Requirement already satisfied: sympy==1.13.1 in /usr/local/lib/python3.10/dist-packages (from torch) (1.13.1)\n",
+            "Requirement already satisfied: mpmath<1.4,>=1.1.0 in /usr/local/lib/python3.10/dist-packages (from sympy==1.13.1->torch) (1.3.0)\n",
+            "Requirement already satisfied: numpy in /usr/local/lib/python3.10/dist-packages (from torchvision) (1.26.4)\n",
+            "Requirement already satisfied: pillow!=8.3.*,>=5.3.0 in /usr/local/lib/python3.10/dist-packages (from torchvision) (11.0.0)\n",
+            "Requirement already satisfied: MarkupSafe>=2.0 in /usr/local/lib/python3.10/dist-packages (from jinja2->torch) (3.0.2)\n",
+            "Collecting datasets\n",
+            "  Downloading datasets-3.2.0-py3-none-any.whl.metadata (20 kB)\n",
+            "Requirement already satisfied: filelock in /usr/local/lib/python3.10/dist-packages (from datasets) (3.16.1)\n",
+            "Requirement already satisfied: numpy>=1.17 in /usr/local/lib/python3.10/dist-packages (from datasets) (1.26.4)\n",
+            "Requirement already satisfied: pyarrow>=15.0.0 in /usr/local/lib/python3.10/dist-packages (from datasets) (17.0.0)\n",
+            "Collecting dill<0.3.9,>=0.3.0 (from datasets)\n",
+            "  Downloading dill-0.3.8-py3-none-any.whl.metadata (10 kB)\n",
+            "Requirement already satisfied: pandas in /usr/local/lib/python3.10/dist-packages (from datasets) (2.2.2)\n",
+            "Requirement already satisfied: requests>=2.32.2 in /usr/local/lib/python3.10/dist-packages (from datasets) (2.32.3)\n",
+            "Requirement already satisfied: tqdm>=4.66.3 in /usr/local/lib/python3.10/dist-packages (from datasets) (4.67.1)\n",
+            "Collecting xxhash (from datasets)\n",
+            "  Downloading xxhash-3.5.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl.metadata (12 kB)\n",
+            "Collecting multiprocess<0.70.17 (from datasets)\n",
+            "  Downloading multiprocess-0.70.16-py310-none-any.whl.metadata (7.2 kB)\n",
+            "Collecting fsspec<=2024.9.0,>=2023.1.0 (from fsspec[http]<=2024.9.0,>=2023.1.0->datasets)\n",
+            "  Downloading fsspec-2024.9.0-py3-none-any.whl.metadata (11 kB)\n",
+            "Requirement already satisfied: aiohttp in /usr/local/lib/python3.10/dist-packages (from datasets) (3.11.10)\n",
+            "Requirement already satisfied: huggingface-hub>=0.23.0 in /usr/local/lib/python3.10/dist-packages (from datasets) (0.27.0)\n",
+            "Requirement already satisfied: packaging in /usr/local/lib/python3.10/dist-packages (from datasets) (24.2)\n",
+            "Requirement already satisfied: pyyaml>=5.1 in /usr/local/lib/python3.10/dist-packages (from datasets) (6.0.2)\n",
+            "Requirement already satisfied: aiohappyeyeballs>=2.3.0 in /usr/local/lib/python3.10/dist-packages (from aiohttp->datasets) (2.4.4)\n",
+            "Requirement already satisfied: aiosignal>=1.1.2 in /usr/local/lib/python3.10/dist-packages (from aiohttp->datasets) (1.3.2)\n",
+            "Requirement already satisfied: async-timeout<6.0,>=4.0 in /usr/local/lib/python3.10/dist-packages (from aiohttp->datasets) (4.0.3)\n",
+            "Requirement already satisfied: attrs>=17.3.0 in /usr/local/lib/python3.10/dist-packages (from aiohttp->datasets) (24.3.0)\n",
+            "Requirement already satisfied: frozenlist>=1.1.1 in /usr/local/lib/python3.10/dist-packages (from aiohttp->datasets) (1.5.0)\n",
+            "Requirement already satisfied: multidict<7.0,>=4.5 in /usr/local/lib/python3.10/dist-packages (from aiohttp->datasets) (6.1.0)\n",
+            "Requirement already satisfied: propcache>=0.2.0 in /usr/local/lib/python3.10/dist-packages (from aiohttp->datasets) (0.2.1)\n",
+            "Requirement already satisfied: yarl<2.0,>=1.17.0 in /usr/local/lib/python3.10/dist-packages (from aiohttp->datasets) (1.18.3)\n",
+            "Requirement already satisfied: typing-extensions>=3.7.4.3 in /usr/local/lib/python3.10/dist-packages (from huggingface-hub>=0.23.0->datasets) (4.12.2)\n",
+            "Requirement already satisfied: charset-normalizer<4,>=2 in /usr/local/lib/python3.10/dist-packages (from requests>=2.32.2->datasets) (3.4.0)\n",
+            "Requirement already satisfied: idna<4,>=2.5 in /usr/local/lib/python3.10/dist-packages (from requests>=2.32.2->datasets) (3.10)\n",
+            "Requirement already satisfied: urllib3<3,>=1.21.1 in /usr/local/lib/python3.10/dist-packages (from requests>=2.32.2->datasets) (2.2.3)\n",
+            "Requirement already satisfied: certifi>=2017.4.17 in /usr/local/lib/python3.10/dist-packages (from requests>=2.32.2->datasets) (2024.12.14)\n",
+            "Requirement already satisfied: python-dateutil>=2.8.2 in /usr/local/lib/python3.10/dist-packages (from pandas->datasets) (2.8.2)\n",
+            "Requirement already satisfied: pytz>=2020.1 in /usr/local/lib/python3.10/dist-packages (from pandas->datasets) (2024.2)\n",
+            "Requirement already satisfied: tzdata>=2022.7 in /usr/local/lib/python3.10/dist-packages (from pandas->datasets) (2024.2)\n",
+            "Requirement already satisfied: six>=1.5 in /usr/local/lib/python3.10/dist-packages (from python-dateutil>=2.8.2->pandas->datasets) (1.17.0)\n",
+            "Downloading datasets-3.2.0-py3-none-any.whl (480 kB)\n",
+            "\u001b[2K   \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m480.6/480.6 kB\u001b[0m \u001b[31m13.0 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+            "\u001b[?25hDownloading dill-0.3.8-py3-none-any.whl (116 kB)\n",
+            "\u001b[2K   \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m116.3/116.3 kB\u001b[0m \u001b[31m12.2 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+            "\u001b[?25hDownloading fsspec-2024.9.0-py3-none-any.whl (179 kB)\n",
+            "\u001b[2K   \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m179.3/179.3 kB\u001b[0m \u001b[31m15.3 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+            "\u001b[?25hDownloading multiprocess-0.70.16-py310-none-any.whl (134 kB)\n",
+            "\u001b[2K   \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m134.8/134.8 kB\u001b[0m \u001b[31m11.1 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+            "\u001b[?25hDownloading xxhash-3.5.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (194 kB)\n",
+            "\u001b[2K   \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m194.1/194.1 kB\u001b[0m \u001b[31m10.4 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+            "\u001b[?25hInstalling collected packages: xxhash, fsspec, dill, multiprocess, datasets\n",
+            "  Attempting uninstall: fsspec\n",
+            "    Found existing installation: fsspec 2024.10.0\n",
+            "    Uninstalling fsspec-2024.10.0:\n",
+            "      Successfully uninstalled fsspec-2024.10.0\n",
+            "\u001b[31mERROR: pip's dependency resolver does not currently take into account all the packages that are installed. This behaviour is the source of the following dependency conflicts.\n",
+            "gcsfs 2024.10.0 requires fsspec==2024.10.0, but you have fsspec 2024.9.0 which is incompatible.\u001b[0m\u001b[31m\n",
+            "\u001b[0mSuccessfully installed datasets-3.2.0 dill-0.3.8 fsspec-2024.9.0 multiprocess-0.70.16 xxhash-3.5.0\n"
+          ]
+        }
+      ],
+      "source": [
+        "!pip3 install transformers\n",
+        "!pip3 install torch torchvision\n",
+        "!pip install datasets"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 2,
+      "metadata": {
+        "id": "rLa0OltsR369"
+      },
+      "outputs": [],
+      "source": [
+        "from pathlib import Path\n",
+        "\n",
+        "import torch\n",
+        "from torch.utils.data import (TensorDataset, DataLoader,\n",
+        "                              RandomSampler, SequentialSampler)\n",
+        "\n",
+        "from transformers import BertTokenizer, BertConfig\n",
+        "from transformers import BertForSequenceClassification\n",
+        "\n",
+        "from transformers import AdamW, get_linear_schedule_with_warmup\n",
+        "\n",
+        "from distutils.version import LooseVersion as LV\n",
+        "\n",
+        "from sklearn.model_selection import train_test_split\n",
+        "from sklearn.metrics import precision_score, recall_score, f1_score, classification_report, confusion_matrix\n",
+        "\n",
+        "import io\n",
+        "import os\n",
+        "import pandas as pd\n",
+        "import numpy as np\n",
+        "\n",
+        "import matplotlib\n",
+        "matplotlib.use('Agg')\n",
+        "import matplotlib.pyplot as plt\n",
+        "import seaborn as sns\n",
+        "sns.set()"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 3,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "Sr_7M6TySQCC",
+        "outputId": "c8c7ef55-f505-4057-c8db-883d44177bed"
+      },
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "Using PyTorch version: 2.5.1+cu121 Device: cuda [Tesla T4]\n"
+          ]
+        },
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": [
+            "<ipython-input-3-d1a1187c676c>:10: DeprecationWarning: distutils Version classes are deprecated. Use packaging.version instead.\n",
+            "  assert(LV(torch.__version__) >= LV(\"1.0.0\"))\n"
+          ]
+        }
+      ],
+      "source": [
+        "if torch.cuda.is_available():\n",
+        "    device = torch.device('cuda')\n",
+        "    devicename = '['+torch.cuda.get_device_name(0)+']'\n",
+        "else:\n",
+        "    device = torch.device('cpu')\n",
+        "    devicename = \"\"\n",
+        "\n",
+        "print('Using PyTorch version:', torch.__version__,\n",
+        "      'Device:', device, devicename)\n",
+        "assert(LV(torch.__version__) >= LV(\"1.0.0\"))"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "b1J4daS74g5D"
+      },
+      "source": [
+        "# Loading the dataset\n",
+        "N.B. If you rerun this code on Colab, remember to comment the `!git clone` command, or to delete runtime before rerunning."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "try:\n",
+        "    from google.colab import drive\n",
+        "    #drive.mount('/content/drive')\n",
+        "    COLAB = True\n",
+        "    !git clone https://github.com/g-fabiani4-unipi/txa_project.git\n",
+        "    %cd txa_project\n",
+        "except:\n",
+        "    COLAB = False"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "12-BEjZHu_Jm",
+        "outputId": "e4ea50e3-eafd-4ca4-ce24-0f4a11a740fb"
+      },
+      "execution_count": 4,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "Cloning into 'txa_project'...\n",
+            "remote: Enumerating objects: 505, done.\u001b[K\n",
+            "remote: Counting objects: 100% (130/130), done.\u001b[K\n",
+            "remote: Compressing objects: 100% (110/110), done.\u001b[K\n",
+            "remote: Total 505 (delta 46), reused 55 (delta 20), pack-reused 375 (from 1)\u001b[K\n",
+            "Receiving objects: 100% (505/505), 163.19 MiB | 11.79 MiB/s, done.\n",
+            "Resolving deltas: 100% (257/257), done.\n",
+            "Updating files: 100% (63/63), done.\n",
+            "/content/txa_project\n"
+          ]
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "#N.B. We have two test sets\n",
+        "\n",
+        "data_dir = Path(\"./data\")\n",
+        "\n",
+        "training_set_dir = \"haspeede2_dev\"\n",
+        "training_file = \"haspeede2_dev_taskAB.tsv\"\n",
+        "\n",
+        "test_set_dir = \"haspeede2_reference\"\n",
+        "test_file_tweets = \"haspeede2_reference_taskAB-tweets.tsv\"\n",
+        "test_file_news = \"haspeede2_reference_taskAB-news.tsv\"\n",
+        "\n",
+        "train_path = data_dir / training_set_dir / training_file\n",
+        "test_path_tweets = data_dir / test_set_dir / test_file_tweets\n",
+        "test_path_news = data_dir / test_set_dir / test_file_news"
+      ],
+      "metadata": {
+        "id": "Vq8X0qPZQuhB"
+      },
+      "execution_count": 5,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "def load_tsv_file(file_path):\n",
+        "    \"\"\"\n",
+        "    Loads a .tvs file w/ or w/out an header in a pandas dataframe w/ columns\n",
+        "    'id', 'text' and 'hs' ('stereotype' is ignored).\n",
+        "    \"\"\"\n",
+        "    try:\n",
+        "\n",
+        "        df = pd.read_csv(file_path, sep='\\\\t', header=None, engine='python') #engine='python' → else tweets w/ id 8094 and 9261 are not loaded\n",
+        "        # Check for header → train file\n",
+        "        if df.iloc[0, 0] == 'id': #df.iloc[row, col]\n",
+        "            df = df.iloc[1:]  # If header → skip first line\n",
+        "\n",
+        "        df.columns = ['id', 'text', 'hs', 'stereotype'] #rename col\n",
+        "        df = df[['id', 'text', 'hs']] #select the cols of intereste\n",
+        "\n",
+        "        #Convert number to int\n",
+        "        df['id'] = df['id'].astype(int)\n",
+        "        df['hs'] = df['hs'].astype(int)\n",
+        "\n",
+        "        return df\n",
+        "    except Exception as e:\n",
+        "        raise ValueError(f\"Errore durante la lettura del file: {e}\")"
+      ],
+      "metadata": {
+        "id": "j2QbiYPFWHHj"
+      },
+      "execution_count": 6,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "#Dataframes w/ the datasets\n",
+        "df_train = load_tsv_file(train_path)\n",
+        "df_test_tweets = load_tsv_file(test_path_tweets)\n",
+        "df_test_news = load_tsv_file(test_path_news)"
+      ],
+      "metadata": {
+        "id": "7EeW_XGjSDXx"
+      },
+      "execution_count": 7,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "def list_x_y(df):\n",
+        "  \"\"\"\n",
+        "  For a df (dataset), create for each record (tweet) a list contaning the text (x) and a list contaning its label (y),\n",
+        "  so that their indexes correspond.\n",
+        "  \"\"\"\n",
+        "  x = list()\n",
+        "  y = list()\n",
+        "  for index, row in df.iterrows():\n",
+        "      x.append(row['text'])\n",
+        "      y.append(row['hs'])\n",
+        "  return x, y\n",
+        "\n",
+        "x_train, y_train = list_x_y(df_train)\n",
+        "x_test_tweets, y_test_tweets = list_x_y(df_test_tweets)\n",
+        "x_test_news, y_test_news = list_x_y(df_test_news)"
+      ],
+      "metadata": {
+        "id": "JoFsXoIKCcLR"
+      },
+      "execution_count": 8,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "len(x_train),len(y_train),  len(x_test_tweets),len(y_test_tweets),  len(x_test_news),len(y_test_news)\n"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "WgmWswkeg3MF",
+        "outputId": "4674fc21-1109-4dc6-e07d-74f29120ecca"
+      },
+      "execution_count": 9,
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "(6839, 6839, 1263, 1263, 500, 500)"
+            ]
+          },
+          "metadata": {},
+          "execution_count": 9
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 10,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "62X87ZY84g5Z",
+        "outputId": "33dd06df-0be4-4ad2-8c9a-81f7b3af850f"
+      },
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "({0, 1}, {0, 1}, {0, 1})"
+            ]
+          },
+          "metadata": {},
+          "execution_count": 10
+        }
+      ],
+      "source": [
+        "set(y_train), set(y_test_tweets), set(y_test_news)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 11,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "r42x4ICg4g5e",
+        "outputId": "8b31c946-945d-4726-f5b7-c81d85ae4e8b"
+      },
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "È terrorismo anche questo, per mettere in uno stato di soggezione le persone e renderle innocue, mentre qualcuno... URL \n",
+            "0\n"
+          ]
+        }
+      ],
+      "source": [
+        "sample_idx = 0\n",
+        "print(x_train[sample_idx])\n",
+        "print(y_train[sample_idx])"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "#y_train[sample_idx]"
+      ],
+      "metadata": {
+        "id": "3lTQi8a9IXnL"
+      },
+      "execution_count": 12,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "4O3HWztTUmaE"
+      },
+      "source": [
+        "# Preparation of the text for BERT.\n",
+        "\n",
+        "The tokenizer is already fit on the same dataset on which BERT has been pretrained and it is included in the BERT model.\n",
+        "To be properly handled by BERT we need to add the `[CLS]` token at the beginning of each tweet."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 13,
+      "metadata": {
+        "id": "K46G-KVgUhNQ"
+      },
+      "outputs": [],
+      "source": [
+        "sentences_train = [\"[CLS] \" + s for s in x_train]\n",
+        "sentences_test_tweets = [\"[CLS] \" + s for s in x_test_tweets]\n",
+        "sentences_test_news = [\"[CLS] \" + s for s in x_test_news]\n",
+        "\n",
+        "labels_train = y_train\n",
+        "labels_test_tweets = y_test_tweets\n",
+        "labels_test_news = y_test_news"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "sentences_train[0]"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 36
+        },
+        "id": "1a0IDScSSeNL",
+        "outputId": "0281e2c6-2840-42b0-b486-0277dbc61e66"
+      },
+      "execution_count": 14,
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "'[CLS] È terrorismo anche questo, per mettere in uno stato di soggezione le persone e renderle innocue, mentre qualcuno... URL '"
+            ],
+            "application/vnd.google.colaboratory.intrinsic+json": {
+              "type": "string"
+            }
+          },
+          "metadata": {},
+          "execution_count": 14
+        }
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "1bcbtpRjhbCN"
+      },
+      "source": [
+        "Next we use the BERT tokenizer to convert the sentences into tokens that match the data BERT was trained on."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 15,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 411,
+          "referenced_widgets": [
+            "5764a78b7242483fab28116500345003",
+            "c13f371182494d5ca7f940ac92ca14fe",
+            "a344d30bb9ae42eca1e5af923ee2bff2",
+            "10fb94afa63649aa9bbcb057775f9b5b",
+            "ae5acaca56584953a7d3ef1cbfe779c4",
+            "1e153593a4f549f99dcdb6d35ebabd5e",
+            "4218d75eac164226933371e51607580d",
+            "f3ed6977f76347bd8eda7a844ddea5a8",
+            "8f29f53629044124bd82c4343448f239",
+            "77da3aed82c84d48b6c53f69461b6e7d",
+            "1e2cd445d6c04845b480ec744953d0e3",
+            "0ddc49566bbd4f9fa7a6b107b8e9c529",
+            "7d70ddf69a2247a095f057f480b9ec4f",
+            "4b95509bb3a647619e7b9322cd611998",
+            "ef0211e7837e4f9898f3021d03b70980",
+            "d12728f0487c4cca948e22affd369fa6",
+            "6ebfd5780446489e9515c0ee8c19fa96",
+            "7b395281b4a340bfb535e779123d4f0a",
+            "1792006a7f204f08800ecfd00347fca7",
+            "1e246c312fb94a409104fe49193dbb3d",
+            "4a15e7cace0c4f269654c43f0b560c8e",
+            "e1b2481b7a9848188d15177e774f536c",
+            "5b9bc639210f44798081a477505adad1",
+            "dd42d1ad6883442db6ea2b7d64cf066e",
+            "87c875520b144e649a854a31e911dd93",
+            "c39ea49c0a5943bca9f44d9dd26a7bff",
+            "130526a132634d06b5e93729481ee639",
+            "bc98480a55db4099a54f981d21d168c4",
+            "557e1bfcdb144468a1d3f0500e564b40",
+            "0c8c7aba4cf94821900f633721105840",
+            "628ed27a64c046e0a38ad2da58bf8088",
+            "a4ebb362a8d6459d800684c6d1aa0ca6",
+            "e69e2a4898b34b2680006fd6e2418190"
+          ]
+        },
+        "id": "KpKdIgJvSD-b",
+        "outputId": "5eb695d8-b0ec-4dee-aa72-62c8b31ba161"
+      },
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": [
+            "/usr/local/lib/python3.10/dist-packages/huggingface_hub/utils/_auth.py:94: UserWarning: \n",
+            "The secret `HF_TOKEN` does not exist in your Colab secrets.\n",
+            "To authenticate with the Hugging Face Hub, create a token in your settings tab (https://huggingface.co/settings/tokens), set it as secret in your Google Colab and restart your session.\n",
+            "You will be able to reuse this secret in all of your notebooks.\n",
+            "Please note that authentication is recommended but still optional to access public models or datasets.\n",
+            "  warnings.warn(\n"
+          ]
+        },
+        {
+          "output_type": "display_data",
+          "data": {
+            "text/plain": [
+              "tokenizer_config.json:   0%|          | 0.00/59.0 [00:00<?, ?B/s]"
+            ],
+            "application/vnd.jupyter.widget-view+json": {
+              "version_major": 2,
+              "version_minor": 0,
+              "model_id": "5764a78b7242483fab28116500345003"
+            }
+          },
+          "metadata": {}
+        },
+        {
+          "output_type": "display_data",
+          "data": {
+            "text/plain": [
+              "vocab.txt:   0%|          | 0.00/235k [00:00<?, ?B/s]"
+            ],
+            "application/vnd.jupyter.widget-view+json": {
+              "version_major": 2,
+              "version_minor": 0,
+              "model_id": "0ddc49566bbd4f9fa7a6b107b8e9c529"
+            }
+          },
+          "metadata": {}
+        },
+        {
+          "output_type": "display_data",
+          "data": {
+            "text/plain": [
+              "config.json:   0%|          | 0.00/433 [00:00<?, ?B/s]"
+            ],
+            "application/vnd.jupyter.widget-view+json": {
+              "version_major": 2,
+              "version_minor": 0,
+              "model_id": "5b9bc639210f44798081a477505adad1"
+            }
+          },
+          "metadata": {}
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "BertTokenizer(name_or_path='dbmdz/bert-base-italian-cased', vocab_size=31102, model_max_length=512, is_fast=False, padding_side='right', truncation_side='right', special_tokens={'unk_token': '[UNK]', 'sep_token': '[SEP]', 'pad_token': '[PAD]', 'cls_token': '[CLS]', 'mask_token': '[MASK]'}, clean_up_tokenization_spaces=True, added_tokens_decoder={\n",
+              "\t0: AddedToken(\"[PAD]\", rstrip=False, lstrip=False, single_word=False, normalized=False, special=True),\n",
+              "\t101: AddedToken(\"[UNK]\", rstrip=False, lstrip=False, single_word=False, normalized=False, special=True),\n",
+              "\t102: AddedToken(\"[CLS]\", rstrip=False, lstrip=False, single_word=False, normalized=False, special=True),\n",
+              "\t103: AddedToken(\"[SEP]\", rstrip=False, lstrip=False, single_word=False, normalized=False, special=True),\n",
+              "\t104: AddedToken(\"[MASK]\", rstrip=False, lstrip=False, single_word=False, normalized=False, special=True),\n",
+              "}\n",
+              ")"
+            ]
+          },
+          "metadata": {},
+          "execution_count": 15
+        }
+      ],
+      "source": [
+        "BERTMODEL = \"dbmdz/bert-base-italian-cased\" #m-polignano-uniba/bert_uncased_L-12_H-768_A-12_italian_alb3rt0\n",
+        "tokenizer = BertTokenizer.from_pretrained(BERTMODEL)\n",
+        "tokenizer"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 16,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "mXuRy_9Pg3sJ",
+        "outputId": "c4f59230-9b81-413d-ccd1-ad6b9e1042bc"
+      },
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": [
+            "100%|██████████| 6839/6839 [00:10<00:00, 654.78it/s] \n",
+            "100%|██████████| 1263/1263 [00:00<00:00, 1602.34it/s]\n",
+            "100%|██████████| 500/500 [00:00<00:00, 3403.37it/s]\n"
+          ]
+        }
+      ],
+      "source": [
+        "from tqdm import tqdm #library that displays progress bars\n",
+        "\n",
+        "tokenized_train = [tokenizer.tokenize(s) for s in tqdm(sentences_train)]\n",
+        "tokenized_test_tweets  = [tokenizer.tokenize(s) for s in tqdm(sentences_test_tweets)]\n",
+        "tokenized_test_news  = [tokenizer.tokenize(s) for s in tqdm(sentences_test_news)]"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "sentences_train[0]"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 36
+        },
+        "id": "Tqs-1u-HiRGE",
+        "outputId": "5d274245-9724-4fe5-f8fb-b7f24378e181"
+      },
+      "execution_count": 17,
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "'[CLS] È terrorismo anche questo, per mettere in uno stato di soggezione le persone e renderle innocue, mentre qualcuno... URL '"
+            ],
+            "application/vnd.google.colaboratory.intrinsic+json": {
+              "type": "string"
+            }
+          },
+          "metadata": {},
+          "execution_count": 17
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 18,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "JswOYlyGhfu3",
+        "outputId": "cd8aea43-f1b6-488f-a1fa-b9720686693a"
+      },
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "The full tokenized first training sentence:\n",
+            "['[CLS]', 'È', 'terrorismo', 'anche', 'questo', ',', 'per', 'mettere', 'in', 'uno', 'stato', 'di', 'sogg', '##ez', '##ione', 'le', 'persone', 'e', 'rende', '##rle', 'inno', '##cue', ',', 'mentre', 'qualcuno', '.', '.', '.', 'UR', '##L']\n"
+          ]
+        }
+      ],
+      "source": [
+        "print (\"The full tokenized first training sentence:\")\n",
+        "print (tokenized_train[0])"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "M1bclIl2hoEG"
+      },
+      "source": [
+        "BERT has several embeddings that pass through many levels...\n",
+        "\n",
+        "...but this is not a variable encoding! **BERT exploits fixed-length encoding**\n",
+        "\n",
+        "Thus, we set the maximum sequence lengths for our training and test sentences as `MAX_LEN_TRAIN` and `MAX_LEN_TEST`. The maximum length supported by the used BERT model is 512.\n",
+        "\n",
+        "The token `[SEP]` (separation token) is another special token required by BERT at the end of the sentence, e.g., useful in Q/A."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 19,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "OAtcXAOzhvMD",
+        "outputId": "100b45c6-3f94-4ebb-9430-bd744f8bae4a"
+      },
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "The truncated tokenized first training sentence:\n",
+            "['[CLS]', 'È', 'terrorismo', 'anche', 'questo', ',', 'per', 'mettere', 'in', 'uno', 'stato', 'di', 'sogg', '##ez', '##ione', 'le', 'persone', 'e', 'rende', '##rle', 'inno', '##cue', ',', 'mentre', 'qualcuno', '.', '.', '.', 'UR', '##L', 'SEP']\n"
+          ]
+        }
+      ],
+      "source": [
+        "MAX_LEN_TRAIN, MAX_LEN_TEST = 128, 512\n",
+        "\n",
+        "tokenized_train = [t[:(MAX_LEN_TRAIN-1)]+['SEP'] for t in tokenized_train]\n",
+        "tokenized_test_tweets  = [t[:(MAX_LEN_TEST-1)]+['SEP'] for t in tokenized_test_tweets]\n",
+        "tokenized_test_news  = [t[:(MAX_LEN_TEST-1)]+['SEP'] for t in tokenized_test_news]\n",
+        "\n",
+        "print (\"The truncated tokenized first training sentence:\")\n",
+        "print (tokenized_train[0])"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "xDBDbn4Ch7sP"
+      },
+      "source": [
+        "Next we use the BERT tokenizer to convert each token into an integer index in the BERT vocabulary *= Which is the proper embedding to get?*\n",
+        "\n",
+        "We also pad any shorter sequences to `MAX_LEN_TRAIN` or `MAX_LEN_TEST` indices with trailing zeros.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 20,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "BrcrPP8eh_ef",
+        "outputId": "0eca8c19-aaf7-407f-ad60-893e1732cc37"
+      },
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "The indices of the first training sentence:\n",
+            "[  102   696 11601   409   395  1307   156  3234   139   610   482   120\n",
+            " 10590 30394   256   199  1022   126  4101  6546  6870 11356  1307  1105\n",
+            "  1776   697   697   697 17943 30909   101     0     0     0     0     0\n",
+            "     0     0     0     0     0     0     0     0     0     0     0     0\n",
+            "     0     0     0     0     0     0     0     0     0     0     0     0\n",
+            "     0     0     0     0     0     0     0     0     0     0     0     0\n",
+            "     0     0     0     0     0     0     0     0     0     0     0     0\n",
+            "     0     0     0     0     0     0     0     0     0     0     0     0\n",
+            "     0     0     0     0     0     0     0     0     0     0     0     0\n",
+            "     0     0     0     0     0     0     0     0     0     0     0     0\n",
+            "     0     0     0     0     0     0     0     0]\n"
+          ]
+        }
+      ],
+      "source": [
+        "ids_train = [tokenizer.convert_tokens_to_ids(t) for t in tokenized_train]\n",
+        "ids_train = np.array([np.pad(i, (0, MAX_LEN_TRAIN-len(i)),\n",
+        "                             mode='constant') for i in ids_train])\n",
+        "\n",
+        "ids_test_tweets = [tokenizer.convert_tokens_to_ids(t) for t in tokenized_test_tweets]\n",
+        "ids_test_tweets = np.array([np.pad(i, (0, MAX_LEN_TEST-len(i)),\n",
+        "                            mode='constant') for i in ids_test_tweets])\n",
+        "\n",
+        "ids_test_news = [tokenizer.convert_tokens_to_ids(t) for t in tokenized_test_news]\n",
+        "ids_test_news = np.array([np.pad(i, (0, MAX_LEN_TEST-len(i)),\n",
+        "                            mode='constant') for i in ids_test_news])\n",
+        "\n",
+        "print (\"The indices of the first training sentence:\")\n",
+        "print (ids_train[0])"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "OiKEIwpIiOeF"
+      },
+      "source": [
+        "BERT also requires *attention masks*, with 1 for each real token in the sequences and 0 for the padding.\n",
+        "\n",
+        "The attention mask tells which positions you have tokens in and which are just empty and do not have tokens."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 21,
+      "metadata": {
+        "id": "SrJ1QioFiQOr"
+      },
+      "outputs": [],
+      "source": [
+        "amasks_train, amasks_test_tweets, amasks_test_news = [], [], []\n",
+        "\n",
+        "for seq in ids_train:\n",
+        "  seq_mask = [float(i>0) for i in seq]\n",
+        "  amasks_train.append(seq_mask)\n",
+        "\n",
+        "for seq in ids_test_tweets:\n",
+        "  seq_mask = [float(i>0) for i in seq]\n",
+        "  amasks_test_tweets.append(seq_mask)\n",
+        "\n",
+        "for seq in ids_test_news:\n",
+        "  seq_mask = [float(i>0) for i in seq]\n",
+        "  amasks_test_news.append(seq_mask)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "PaaKi8FwiU0_"
+      },
+      "source": [
+        "We use scikit-learn's train_test_split() to use 10% of our training data as a validation set.\n",
+        "\n",
+        "So far, we are working with Python lists, i.e., lists of integers. In order for these lists to be correctly handled by BERT, we must convert our lists into other dedicated structures, i.e., using `torch.tensors` into tensor data structures."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 22,
+      "metadata": {
+        "id": "8MFbb7zNPspK"
+      },
+      "outputs": [],
+      "source": [
+        "from sklearn.model_selection import train_test_split"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 23,
+      "metadata": {
+        "id": "S6BDKPqtiSbL"
+      },
+      "outputs": [],
+      "source": [
+        "(train_inputs, validation_inputs,\n",
+        " train_labels, validation_labels) = train_test_split(ids_train, labels_train,\n",
+        "                                                     random_state=42,\n",
+        "                                                     test_size=0.1)\n",
+        "(train_masks, validation_masks,\n",
+        " _, _) = train_test_split(amasks_train, ids_train,\n",
+        "                          random_state=42, test_size=0.1)\n",
+        "\n",
+        "#From lists of int into tensor data structures\n",
+        "train_inputs = torch.tensor(train_inputs)\n",
+        "train_labels = torch.tensor(train_labels)\n",
+        "train_masks  = torch.tensor(train_masks)\n",
+        "validation_inputs = torch.tensor(validation_inputs)\n",
+        "validation_labels = torch.tensor(validation_labels)\n",
+        "validation_masks  = torch.tensor(validation_masks)\n",
+        "\n",
+        "test_inputs_tweets = torch.tensor(ids_test_tweets)\n",
+        "test_labels_tweets = torch.tensor(labels_test_tweets)\n",
+        "test_masks_tweets  = torch.tensor(amasks_test_tweets)\n",
+        "\n",
+        "test_inputs_news = torch.tensor(ids_test_news)\n",
+        "test_labels_news = torch.tensor(labels_test_news)\n",
+        "test_masks_news = torch.tensor(amasks_test_news)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "FwJkAHmbicwU"
+      },
+      "source": [
+        "Now we are almost ready to use our data into a fitting process.\n",
+        "\n",
+        "Next we create PyTorch *DataLoader*s for all data sets.\n",
+        "\n",
+        "For fine-tuning BERT on a specific task, the authors recommend a batch size of 16 or 32."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 24,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "H5wj7YLOiZfZ",
+        "outputId": "8ee10a0b-dbb3-478e-9d5b-d77ea633c427"
+      },
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "Datasets:\n",
+            "Train: 6155 documents\n",
+            "Validation: 684 documents\n",
+            "Test 1 (Tweets): 1263 documents\n",
+            "Test 2 (News): 500 documents\n"
+          ]
+        }
+      ],
+      "source": [
+        "BATCH_SIZE = 32 # How many training examples in one shot are processed in parallel\n",
+        "\n",
+        "print('Datasets:')\n",
+        "print('Train: ', end=\"\")\n",
+        "train_data = TensorDataset(train_inputs, train_masks,\n",
+        "                           train_labels) # The tensor defines the training documents, the training labels, and labels\n",
+        "train_sampler = RandomSampler(train_data) # Random sampling to avoid creating patterns that are not there, and helps in generalizing\n",
+        "train_dataloader = DataLoader(train_data, sampler=train_sampler,\n",
+        "                              batch_size=BATCH_SIZE) # We wrap data into a Data Loader that will take care of moving objs from the GPU to the CPU\n",
+        "print(len(train_data), 'documents')\n",
+        "\n",
+        "# We do the same for Validation and for the two Test datasets\n",
+        "\n",
+        "print('Validation: ', end=\"\")\n",
+        "validation_data = TensorDataset(validation_inputs, validation_masks,\n",
+        "                                validation_labels)\n",
+        "validation_sampler = SequentialSampler(validation_data)\n",
+        "validation_dataloader = DataLoader(validation_data,\n",
+        "                                   sampler=validation_sampler,\n",
+        "                                   batch_size=BATCH_SIZE)\n",
+        "print(len(validation_data), 'documents')\n",
+        "\n",
+        "print('Test 1 (Tweets): ', end=\"\")\n",
+        "test_data_tweets = TensorDataset(test_inputs_tweets, test_masks_tweets, test_labels_tweets)\n",
+        "test_sampler_tweets = SequentialSampler(test_data_tweets)\n",
+        "test_dataloader_tweets = DataLoader(test_data_tweets, sampler=test_sampler_tweets,\n",
+        "                             batch_size=BATCH_SIZE)\n",
+        "print(len(test_data_tweets), 'documents')\n",
+        "\n",
+        "print('Test 2 (News): ', end=\"\")\n",
+        "test_data_news = TensorDataset(test_inputs_news, test_masks_news, test_labels_news)\n",
+        "test_sampler_news = SequentialSampler(test_data_news)\n",
+        "test_dataloader_news = DataLoader(test_data_news, sampler=test_sampler_news,\n",
+        "                             batch_size=BATCH_SIZE)\n",
+        "print(len(test_data_news), 'documents')"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "nEgt4NkqirRi"
+      },
+      "source": [
+        "# BERT Model Inizialization\n",
+        "\n",
+        "We now load a pretrained BERT model (using `BertForSequenceClassification` class) with a single linear classification layer added on top. We pass the\n",
+        "\n",
+        "We pass as input the same model that we passed to the tokenizer → stored in the `BERTMODEL` variable.\n",
+        "\n",
+        "We also have to pass the labels. In our case we have a binary classification, therefore `num_labels=2`.\n",
+        "\n",
+        "\n",
+        "`.cuda()` comes from NVIDIA, but there is also a more open resource, that is *opencl*.\n",
+        "\n",
+        "\n",
+        "`740M/740M` is the size of the zipped BERT model.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 25,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 121,
+          "referenced_widgets": [
+            "9ac9cdeb7b914268b903be1671cd08af",
+            "84a0117cb0b542c48ce69aa9d70e4fff",
+            "55ca22a2ce42460aa61182edeada6661",
+            "7e6fa7f2f34a4da499bb264b18ba05a2",
+            "c8820fd13dd6454cb22bee7ada5142a1",
+            "8e0634b7de8a44d6b58b885e8e1fd528",
+            "ba3c2b0e6cf44e5391c5110039e6ba6b",
+            "4bfb4cec9af34046beee263e12ce9750",
+            "07021d0b3a8041dbae9e91004498b6b1",
+            "0a73ae8491e748629fb0d2450538656a",
+            "fd56c87f4afb44ae886eefed08bb4a69"
+          ]
+        },
+        "id": "sOG0wOuaiiVr",
+        "outputId": "b06696ee-68f5-40d4-c3a9-39fb09906ddd"
+      },
+      "outputs": [
+        {
+          "output_type": "display_data",
+          "data": {
+            "text/plain": [
+              "model.safetensors:   0%|          | 0.00/442M [00:00<?, ?B/s]"
+            ],
+            "application/vnd.jupyter.widget-view+json": {
+              "version_major": 2,
+              "version_minor": 0,
+              "model_id": "9ac9cdeb7b914268b903be1671cd08af"
+            }
+          },
+          "metadata": {}
+        },
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": [
+            "Some weights of BertForSequenceClassification were not initialized from the model checkpoint at dbmdz/bert-base-italian-cased and are newly initialized: ['classifier.bias', 'classifier.weight']\n",
+            "You should probably TRAIN this model on a down-stream task to be able to use it for predictions and inference.\n"
+          ]
+        },
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "Pretrained BERT model \"dbmdz/bert-base-italian-cased\" loaded\n"
+          ]
+        }
+      ],
+      "source": [
+        "model = BertForSequenceClassification.from_pretrained(BERTMODEL,\n",
+        "                                                      num_labels=2)\n",
+        "model.cuda() # Move to the cuda computing\n",
+        "print('Pretrained BERT model \"{}\" loaded'.format(BERTMODEL))"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "You can go into detail about the model and if you want you can intervene by customizing it, e.g., adding or moving layers."
+      ],
+      "metadata": {
+        "id": "y9-9od7dvdNg"
+      }
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 26,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "LElGRFEMUCZS",
+        "outputId": "df533f87-6e51-44fb-e6d8-1ee018bac9aa"
+      },
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "BertForSequenceClassification(\n",
+            "  (bert): BertModel(\n",
+            "    (embeddings): BertEmbeddings(\n",
+            "      (word_embeddings): Embedding(31102, 768, padding_idx=0)\n",
+            "      (position_embeddings): Embedding(512, 768)\n",
+            "      (token_type_embeddings): Embedding(2, 768)\n",
+            "      (LayerNorm): LayerNorm((768,), eps=1e-12, elementwise_affine=True)\n",
+            "      (dropout): Dropout(p=0.1, inplace=False)\n",
+            "    )\n",
+            "    (encoder): BertEncoder(\n",
+            "      (layer): ModuleList(\n",
+            "        (0-11): 12 x BertLayer(\n",
+            "          (attention): BertAttention(\n",
+            "            (self): BertSdpaSelfAttention(\n",
+            "              (query): Linear(in_features=768, out_features=768, bias=True)\n",
+            "              (key): Linear(in_features=768, out_features=768, bias=True)\n",
+            "              (value): Linear(in_features=768, out_features=768, bias=True)\n",
+            "              (dropout): Dropout(p=0.1, inplace=False)\n",
+            "            )\n",
+            "            (output): BertSelfOutput(\n",
+            "              (dense): Linear(in_features=768, out_features=768, bias=True)\n",
+            "              (LayerNorm): LayerNorm((768,), eps=1e-12, elementwise_affine=True)\n",
+            "              (dropout): Dropout(p=0.1, inplace=False)\n",
+            "            )\n",
+            "          )\n",
+            "          (intermediate): BertIntermediate(\n",
+            "            (dense): Linear(in_features=768, out_features=3072, bias=True)\n",
+            "            (intermediate_act_fn): GELUActivation()\n",
+            "          )\n",
+            "          (output): BertOutput(\n",
+            "            (dense): Linear(in_features=3072, out_features=768, bias=True)\n",
+            "            (LayerNorm): LayerNorm((768,), eps=1e-12, elementwise_affine=True)\n",
+            "            (dropout): Dropout(p=0.1, inplace=False)\n",
+            "          )\n",
+            "        )\n",
+            "      )\n",
+            "    )\n",
+            "    (pooler): BertPooler(\n",
+            "      (dense): Linear(in_features=768, out_features=768, bias=True)\n",
+            "      (activation): Tanh()\n",
+            "    )\n",
+            "  )\n",
+            "  (dropout): Dropout(p=0.1, inplace=False)\n",
+            "  (classifier): Linear(in_features=768, out_features=2, bias=True)\n",
+            ")\n"
+          ]
+        }
+      ],
+      "source": [
+        "print(model)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "The first layer of the network is an embedding layer,\n",
+        "```\n",
+        "(embeddings): BertEmbeddings(\n",
+        "      (word_embeddings): Embedding(30522, 768, padding_idx=0)\n",
+        "      (position_embeddings) : Embedding(512, 768)\n",
+        "      ...\n",
+        "```\n",
+        "So, the number you have assigned to a feature is converted to a vector of 768 and has more than 30,000 different embeddings.\n",
+        "Then there is the position embedding...\n",
+        "\n",
+        "Note we are using a\n",
+        "```\n",
+        "(encoder): BertEncoder(\n",
+        "      ...)\n",
+        "```\n",
+        "so, you can see the Q, K, V decomposition\n",
+        "```\n",
+        "(query): Linear(in_features=768, out_features=768, bias=True)\n",
+        "(key): Linear(in_features=768, out_features=768, bias=True)\n",
+        "(value): Linear(in_features=768, out_features=768, bias=True)\n",
+        "\n",
+        "```"
+      ],
+      "metadata": {
+        "id": "EGjweYmewVoy"
+      }
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "JjtNQUINizE2"
+      },
+      "source": [
+        "We set the remaining hyperparameters needed for fine-tuning the pretrained model:\n",
+        " * EPOCHS: the number of training epochs in fine-tuning\n",
+        "   (recommended values between 2 and 4)\n",
+        " * WEIGHT_DECAY: weight decay for the Adam optimizer\n",
+        " * LR: learning rate for the Adam optimizer (2e-5 to 5e-5 recommended)\n",
+        " * WARMUP_STEPS: number of warmup steps to (linearly) reach the set learning rate\n",
+        "\n",
+        "We also need to grab the training parameters from the pretrained model."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 27,
+      "metadata": {
+        "id": "naOcRV62iwAR",
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "outputId": "8a4bca74-b03f-4fa3-e012-9aecf99b38c7"
+      },
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": [
+            "/usr/local/lib/python3.10/dist-packages/transformers/optimization.py:591: FutureWarning: This implementation of AdamW is deprecated and will be removed in a future version. Use the PyTorch implementation torch.optim.AdamW instead, or set `no_deprecation_warning=True` to disable this warning\n",
+            "  warnings.warn(\n"
+          ]
+        }
+      ],
+      "source": [
+        "EPOCHS = 4\n",
+        "WEIGHT_DECAY = 0.01\n",
+        "LR = 2e-5\n",
+        "WARMUP_STEPS =int(0.2*len(train_dataloader))\n",
+        "\n",
+        "no_decay = ['bias', 'LayerNorm.weight']\n",
+        "optimizer_grouped_parameters = [\n",
+        "    {'params': [p for n, p in model.named_parameters()\n",
+        "                if not any(nd in n for nd in no_decay)],\n",
+        "     'weight_decay': WEIGHT_DECAY},\n",
+        "    {'params': [p for n, p in model.named_parameters()\n",
+        "                if any(nd in n for nd in no_decay)],\n",
+        "     'weight_decay': 0.0}\n",
+        "]\n",
+        "optimizer = AdamW(optimizer_grouped_parameters, lr=LR, eps=1e-8)\n",
+        "scheduler = get_linear_schedule_with_warmup(optimizer, num_warmup_steps=WARMUP_STEPS,\n",
+        "                                 num_training_steps =len(train_dataloader)*EPOCHS)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "dk4A50LtjIQS"
+      },
+      "source": [
+        "## Training\n",
+        "\n",
+        "Let's now define functions to train() and evaluate() the model. Since we are working with pythorch and not with keras we have to set up the forward pass, steps..."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 28,
+      "metadata": {
+        "id": "Y617BgqjjAJG"
+      },
+      "outputs": [],
+      "source": [
+        "def train(epoch, loss_vector=None, log_interval=200): #loss_vector = train_lossv\n",
+        "  # Set model to training mode\n",
+        "  model.train()\n",
+        "\n",
+        "  # Loop over each batch from the training set\n",
+        "  for step, batch in enumerate(train_dataloader):\n",
+        "\n",
+        "    # Copy data to GPU if needed\n",
+        "    batch = tuple(t.to(device) for t in batch)\n",
+        "\n",
+        "    # Unpack the inputs from our dataloader\n",
+        "    b_input_ids, b_input_mask, b_labels = batch\n",
+        "\n",
+        "    # Zero gradient buffers\n",
+        "    optimizer.zero_grad()\n",
+        "\n",
+        "    # Forward pass\n",
+        "    outputs = model(b_input_ids, token_type_ids=None,\n",
+        "                    attention_mask=b_input_mask, labels=b_labels)\n",
+        "\n",
+        "    loss = outputs[0]\n",
+        "    if loss_vector is not None:\n",
+        "        loss_vector.append(loss.item())\n",
+        "\n",
+        "    # Backward pass\n",
+        "    loss.backward()\n",
+        "\n",
+        "    # Update weights\n",
+        "    optimizer.step()\n",
+        "    scheduler.step()\n",
+        "\n",
+        "    if step % log_interval == 0:\n",
+        "        print('Train Epoch: {} [{}/{} ({:.0f}%)]\\tLoss: {:.6f}'.format(\n",
+        "                epoch, step * len(b_input_ids),\n",
+        "                len(train_dataloader.dataset),\n",
+        "                100. * step / len(train_dataloader), loss))\n",
+        "\n",
+        "\n",
+        "def evaluate(loader, loss_vector=None):\n",
+        "    # Set model to evaluation mode\n",
+        "    model.eval()\n",
+        "\n",
+        "    all_predictions = []\n",
+        "    all_labels = []\n",
+        "\n",
+        "    for batch in loader:\n",
+        "        batch = tuple(t.to(device) for t in batch)\n",
+        "        b_input_ids, b_input_mask, b_labels = batch\n",
+        "\n",
+        "        with torch.no_grad():\n",
+        "            outputs = model(b_input_ids, token_type_ids=None,\n",
+        "                            attention_mask=b_input_mask, labels=b_labels) #we provide the labels to get the loss\n",
+        "            loss = outputs[0]  # Compute validation loss\n",
+        "            if loss_vector is not None:\n",
+        "                loss_vector.append(loss.item())  # Append loss to loss vector\n",
+        "\n",
+        "            logits = outputs[1]  # Get logits\n",
+        "            logits = logits.detach().cpu().numpy()\n",
+        "            predictions = np.argmax(logits, axis=1)\n",
+        "\n",
+        "            labels = b_labels.to('cpu').numpy()\n",
+        "            all_predictions.extend(predictions)\n",
+        "            all_labels.extend(labels)\n",
+        "\n",
+        "    # Calculate metrics\n",
+        "    accuracy = np.mean(np.array(all_predictions) == np.array(all_labels))\n",
+        "    precision = precision_score(all_labels, all_predictions, average='macro')\n",
+        "    recall = recall_score(all_labels, all_predictions, average='macro')\n",
+        "    f1 = f1_score(all_labels, all_predictions, average='macro')\n",
+        "\n",
+        "    print('Accuracy: {:.4f}'.format(accuracy))\n",
+        "    print('Precision: {:.4f}'.format(precision))\n",
+        "    print('Recall: {:.4f}'.format(recall))\n",
+        "    print('F1 Score: {:.4f}'.format(f1))"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "o0x87vj4jLG8"
+      },
+      "source": [
+        "Now we are ready to train our model using the train() function. After each epoch, we evaluate the model using the validation set and evaluate()."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 29,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "CtNwgXKDjJQ3",
+        "outputId": "52c1208b-4985-48d6-c68b-6d3164a75892"
+      },
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "\n",
+            "Train Epoch: 1 [0/6155 (0%)]\tLoss: 0.698713\n",
+            "\n",
+            "Validation set:\n",
+            "Accuracy: 0.7588\n",
+            "Precision: 0.7560\n",
+            "Recall: 0.7627\n",
+            "F1 Score: 0.7563\n",
+            "\n",
+            "Train Epoch: 2 [0/6155 (0%)]\tLoss: 0.544273\n",
+            "\n",
+            "Validation set:\n",
+            "Accuracy: 0.8012\n",
+            "Precision: 0.7964\n",
+            "Recall: 0.7932\n",
+            "F1 Score: 0.7946\n",
+            "\n",
+            "Train Epoch: 3 [0/6155 (0%)]\tLoss: 0.210992\n",
+            "\n",
+            "Validation set:\n",
+            "Accuracy: 0.8143\n",
+            "Precision: 0.8094\n",
+            "Recall: 0.8154\n",
+            "F1 Score: 0.8113\n",
+            "\n",
+            "Train Epoch: 4 [0/6155 (0%)]\tLoss: 0.200511\n",
+            "\n",
+            "Validation set:\n",
+            "Accuracy: 0.7997\n",
+            "Precision: 0.7941\n",
+            "Recall: 0.7949\n",
+            "F1 Score: 0.7945\n"
+          ]
+        }
+      ],
+      "source": [
+        "#Lists to store the train/eval batch losses (lists w/ loss for each batch)\n",
+        "train_lossv = []\n",
+        "eval_lossv = []\n",
+        "\n",
+        "for epoch in range(1, EPOCHS + 1):\n",
+        "    print()\n",
+        "    train(epoch, train_lossv)\n",
+        "    print('\\nValidation set:')\n",
+        "    evaluate(validation_dataloader, eval_lossv)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "W8fr0OSRjmaS"
+      },
+      "source": [
+        "Let's take a look at our training loss over all batches.\n",
+        "\n",
+        "We see a steady decay, as hoped: it means that the model is learning."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 30,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 652
+        },
+        "id": "zmEaoKyxjQQ2",
+        "outputId": "64378fbb-5ebe-4ff1-f4bf-bebeeb6dc9a1"
+      },
+      "outputs": [
+        {
+          "output_type": "display_data",
+          "data": {
+            "text/plain": [
+              "<Figure size 1500x800 with 1 Axes>"
+            ],
+            "image/png": "iVBORw0KGgoAAAANSUhEUgAABNwAAALGCAYAAACeUYzXAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjguMCwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy81sbWrAAAACXBIWXMAAA9hAAAPYQGoP6dpAAEAAElEQVR4nOzdd6AcZb0//vfMbDn95KQQagiJgEhXWihBEEQQy1WuYo165XIFRNCroF/0ihVQREF+ggqiWLCgIkVAEAwkEJAWaiAJpJJ++tlzdndmfn/szszzTNk6e3Zmz/v1T/bsmfLszOxm53M+n+ejmKZpgoiIiIiIiIiIiEKhNnsARERERERERERErYQBNyIiIiIiIiIiohAx4EZERERERERERBQiBtyIiIiIiIiIiIhCxIAbERERERERERFRiBhwIyIiIiIiIiIiChEDbkRERERERERERCFiwI2IiIiIiIiIiChEDLgRERERERERERGFiAE3IiIiohi7+OKLceKJJ9a07jXXXIN999035BFVpp5xExEREUVdotkDICIiImpFlQayfvWrX+HII49s8GiIiIiIaDIppmmazR4EERERUau57bbbPD8vWbIEV1xxhfT8Mcccg5kzZ9a8n1wuB9M0kUqlql43n89D13Wk0+ma91+riy++GI899hj++c9/Tvq+iYiIiBqNGW5EREREDfCe97xH+vmZZ57BkiVLPM+7ZTIZtLe3V7yfZDJZ0/gAIJFIIJHg10EiIiKisHEONyIiIqIm+djHPobTTz8dzz33HD7ykY/g4IMPxg9+8AMAwH333Yf//u//xrHHHosDDjgAJ510Eq699lroui5twz0X2vr167HvvvvihhtuwO9//3ucdNJJOOCAA/D+978fy5cvl9b1m8Nt3333xTe+8Q3cd999OP3003HAAQfgne98JxYvXuwZ/7Jly/C+970PBx54IE466STccsstdc0LNzY2hssuuwzHH388DjjgAJxyyim44YYb4C7IWLJkCT70oQ/hsMMOw6GHHopTTjnFPm6Wm2++Ge985ztx8MEH4/DDD8f73vc+3H777TWNi4iIiKha/JMmERERURMNDAzgrLPOwjvf+U68+93vxowZMwAAf/nLX9DR0YFPfvKT6OjowKOPPoqrr74aIyMjuOiii8pu94477sDo6Cg++MEPQlEU/PznP8dnP/tZ3HfffWWz4p544gnce++9+PCHP4zOzk7cfPPNOP/88/HAAw+gr68PAPDCCy/g05/+NGbNmoXPfvazMAwD1157LaZPn17TcTBNE5/5zGewbNkynHHGGdhvv/3w0EMP4YorrsDmzZvxla98BQDwyiuv4Oyzz8a+++6L888/H6lUCmvWrMGTTz5pb+sPf/gDvvWtb+GUU07Bxz/+cUxMTGDFihV45pln8K53vaum8RERERFVgwE3IiIioibaunUrLr30Upx55pnS81deeSXa2trsnz/0oQ/ha1/7Gn73u9/hwgsvLDtn28aNG3Hvvfeit7cXALDXXnvhnHPOwcMPP4wTTjih5LqrVq3CXXfdhTlz5gAAjjzySLznPe/BnXfeiY9+9KMAgKuvvhqapuF3v/sdZs+eDQA49dRTcdppp1V3AIruv/9+PProo7jgggvwmc98BgDwkY98BOeffz5+9atf4aMf/SjmzJmDJUuWIJfL4Wc/+1lgcO/BBx/E3nvvjauvvrqmsRARERHViyWlRERERE2USqXwvve9z/O8GGwbGRnBjh07cNhhhyGTyWD16tVlt3vaaafZwTYAOOywwwAA69atK7vu0UcfbQfbAOCNb3wjurq67HV1XccjjzyCt73tbXawDQD23HNPHHfccWW372fx4sXQNA0f+9jHpOc/9alPwTRNu6S1p6cHQCFAZxiG77Z6enqwadMmTwktERER0WRhhhsRERFRE82ePds3W+2VV17BD3/4Qzz66KMYGRmRfjc8PFx2u7vssov0sxV8Gxoaqnpda31r3e3bt2N8fBx77rmnZzm/5yqxYcMG7LTTTujq6pKenz9/vv17oBBI/OMf/4hLLrkEV155JRYsWICTTz4Z73jHO6Cqhb8ln3XWWVi6dCn+8z//E3vuuSeOOeYYnH766XjLW95S09iIiIiIqsWAGxEREVETiZlslqGhIXz0ox9FV1cXzj//fMyZMwfpdBrPP/88vv/97wdmdok0TfN93t2AIOx1G62trQ2/+c1vsGzZMjz44IN46KGHcNddd+H3v/89brzxRmiahvnz5+Puu++2f3/vvffit7/9Lc4991ycf/75zX4JRERENAWwpJSIiIgoYh577DEMDAzgsssuw6JFi3DCCSfg6KOPlkpEm2nGjBlIp9NYs2aN53d+z1Vit912w5YtWzzZfFb57G677WY/p6oqFixYgC9/+cu46667cOGFF+LRRx/FsmXL7GU6Ojpw2mmn4bvf/S4eeOABvPWtb8V1112HiYmJmsZHREREVA0G3IiIiIgixiqNFDPKstksfvvb3zZrSBJN03D00Ufj/vvvx+bNm+3n16xZg4ceeqimbS5cuBC6ruM3v/mN9PxNN90ERVGwcOFCAIWurm777bcfgMIxAoD+/n7p96lUCvPnz4dpmsjlcjWNj4iIiKgaLCklIiIiiphDDz0Uvb29uPjii/Gxj30MiqLgtttui0RJp+W8887Dww8/jA996EP40Ic+BMMw8Otf/xp77703Xnzxxaq3d+KJJ+LII4/EVVddhQ0bNmDffffFkiVLcP/992PRokV2E4drr70W//73v3H88cdjt912w/bt2/Hb3/4WO++8sz1H23/9139h5syZePOb34wZM2Zg9erV+PWvf43jjz/eM0ccERERUSMw4EZEREQUMX19fbjuuutw+eWX44c//CF6enrw7ne/GwsWLMB//dd/NXt4AIADDjgAP/vZz3DFFVfgRz/6EXbZZRecf/75WL16dUVdVN1UVcVPfvITXH311bjrrrvw5z//Gbvtthu+9KUv4VOf+pS93IknnogNGzbg1ltvRX9/P/r6+nDEEUfgs5/9LLq7uwEAH/zgB3H77bfjF7/4BcbGxrDzzjvjYx/7GM4555zQXj8RERFRKYoZpT+VEhEREVGsnXPOOVi5ciXuvffeZg+FiIiIqGk4hxsRERER1WR8fFz6+bXXXsPixYtxxBFHNGlERERERNHAklIiIiIiqslJJ52E//iP/8Aee+yBDRs24JZbbkEymcSnP/3pZg+NiIiIqKkYcCMiIiKimhx33HG48847sXXrVqRSKRxyyCH4/Oc/j7lz5zZ7aERERERNxTnciIiIiIiIiIiIQsQ53IiIiIiIiIiIiELEgBsREREREREREVGIGHAjIiIiIiIiIiIKEZsmlGCaJgyjtaa4U1Wl5V4ThYvXCJXDa4TK4TVC5fAaoXJ4jVA5vEaoHF4jVE4t14iqKlAUpaJlGXArwTBM7Ngx2uxhhCaRUNHX14mhoTHk80azh0MRxGuEyuE1QuXwGqFyeI1QObxGqBxeI1QOrxEqp9ZrZPr0TmhaZQE3lpQSERERERERERGFiAE3IiIiIiIiIiKiEDHgRkREREREREREFCIG3IiIiIiIiIiIiELEgBsREREREREREVGI2KWUiIiIiIiIiMjFMAzoer7Zw6AGMAwF4+MastkJ6LoJANC0BFQ1vLw0BtyIiIiIiIiIiIpM08TQ0A5kMiPNHgo10LZtKgzDkJ5rb+9CT890KIpS9/YZcCMiIiIiIiIiKrKCbV1dfUil0qEEXyh6NE2xs9tM00Q2O4GRkX4AQG/vjLq3z4AbEREREREREREAw9DtYFtXV0+zh0MNlEioyOedDLdUKg0AGBnpR3d3X93lpZFrmrBq1Sp88pOfxCGHHIJjjjkGV1xxBbLZbNn1hoeH8dWvfhVHHnkkDj74YHzsYx/Diy++OAkjJiIiIiIiIqJWoOs6ACf4QlOLdd7DmLsvUgG3wcFBLFq0CLlcDtdccw0uvPBC/OEPf8Bll11Wdt3Pf/7zuO+++/DFL34RP/rRj6BpGhYtWoTXX399EkZORERERERERK2CZaRTU5jnPVIlpbfccgtGR0fx4x//GNOmTQNQiC5feumlOPvsszF79mzf9Z5++mksXrwYP/nJT3DiiScCAI488ki87W1vww033IBLLrlksl4CERERERERERFNcZHKcFu8eDEWLFhgB9sA4NRTT4VhGFiyZEngei+88AIURcExxxxjP9fe3o7DDjsMDzzwQCOHTERERERERETUcs444134wQ8un7T1KvHtb38dH/vYBxqy7bBFKsNt9erVeP/73y8919PTg1mzZmH16tWB62WzWaiqCk3TpOeTySQ2bNiA8fFxtLW1NWTMRERERERERESt5jvf+R66u6tvHFHreq0mUgG3oaEh9PR4T0pvby8GBwcD19tzzz2h6zpeeOEFHHTQQQAAwzDw3HPPwTRNDA0N1RxwSyQilQRYF01TpX+J3HiNUDm8RqgcXiNUDq8RKofXCJXDa4TKqecaMQzO3TYxMY50ug377PPGmtavdb3JZE3VpiiAaXp/r2lK3fGgSAXcanXMMcdgzpw5+L//+z9cfvnlmDFjBn76059i3bp1AGqf9E5VFfT1dYY51Ejo6Wlv9hAo4niNUDm8RqgcXiNUDq8RKofXCJXDa4TKqeUaGR/XsG2bGkrAJSoeeOB+3Hjjz7BmzWvo6enBSSedgs985jyk02k88cS/ce65/40rr/wR7rjjb1i27FEceuihuPLKq/He974Txx57HP73fy+2t/WXv/wJv/zljejvH8BBBx2M8877HBYt+jAuueTrOP30dwOAZ71vfOP/8NJLL+ALX7gIP/rRlVi7dg3mzZuPL33py3jjG99kb/s3v7kZ9913D9auXYtUKok3vWl/fO5zX8CcOXvayyiKAkUJ79y4g7KGoUBVVfT2dtRdKRmpgFtPTw+Gh4c9zw8ODqK3tzdwvVQqhauuugpf+MIX8K53vQsAsM8++2DRokW4+eabpTnhqmEYJoaGxmpaN4o0TUVPTzuGhjLQdaPZw6EI4jVC5fAaoXJ4jVA5vEaoHF4jVA6vESqnnmskm52AYRjQdRP5fPyvr4cf/he+8pUv4W1vezvOPvs8rF37Gq6//lps2vQ6vvWtK+zj893vfgtvf/up+M53vgdVVe3XbhjOcXj44X/h8su/g3e9671461vfhldeWYH/9/8u8izn/tk0TWzfvg0/+MEV+MhHPoGuri5cf/2P8aUvfQF/+MNtSCQKoanNmzfhfe/7AGbP3hljY6P4619vxVlnfQK/+92f0dPTa2/LNOs/N4pSuE503ZAy3HTdhGEYGBwcQyaje9br6WmvOHMyUgG3efPmeeZqGx4extatWzFv3ryS6x5wwAG4++67sWbNGpimiblz5+Ib3/gG9t9/fySTyZrH1ApvMDddN1rydVF4eI1QObxGqBxeI1QOrxEqh9cIlcNrhMqp5RrRdZ/6QhQCPdlc8663VFKtqXrvxht/iv33PxBf//q3AQBHHXU00uk2fO9738GqVSvt5Y49diHOOef8ktv65S9vwFvecjguuugSAMCRRy5APp/Hz39+XdlxDA0N4Zprfop58+YDANra2nD++f+D559/DgcffAgA4Pzzv2Avr+s6Dj/8SJx++tvxwAP34z3veV9Vr7scK8jmV05a2H/9Qb1IBdwWLlyI6667TprL7e6774aqqlIH0iCKomDu3LkAgB07duCuu+7CF7/4xUYOmYiIiIiIiIhamGma+O6vn8TKDcFzyzfaG3bvxZc/8uaqgm5jY2N45ZWXce65n5Oef9vb3o7vfe87WL78aey551wAwIIFx5bclq7rePnlFTj33Auk54877q0VBdxmzpxlB9sAYK+9CklVW7dutp977rln8fOf/wQvv7wCQ0POsV63bm3Z7UdRpAJuZ555Jm6++Wace+65OPvss7F582ZcccUVOPPMMzF79mx7uUWLFmHjxo34xz/+YT/3k5/8BHvuuSdmzJiBV199Fddffz0OOOAAvO994UZBiYiIiIiIiGiKiWEvhZGRYZimienTZ0jPd3V1IZVKSUGt6dOnl9zWwEA/dF3HtGl90vN9fX0Ba8i6urqknxOJQiViNpsFAGzatAmf//x5eOMb98MXv/hlzJw5C8lkEl/84gXIZicq2kfURCrg1tvbi1/+8pf45je/iXPPPRednZ0444wzcOGFF0rLFeqp5VraoaEhXH755di+fTt22mknvPvd78Y555wDVW2NSQ6JiIiIiIiIaPIpioIvf+TNsSsp7erqhqIo6O/fIT0/MjKCbDZrz4sGlG82OW1aHzRNw8BAv/R8f39/wBrVWbZsKTKZMXz7299Dd3c3ACCfz0tBwbiJVMANAObPn4+bbrqp5DI333yz57mLLroIF110UYNGRURERERERERTlaIoSKe0Zg+jKh0dHdh7733w4IP344Mf/Ij9/D//WagWPOigQzA4OFDRtjRNwz777IuHH/4XPvCBD9nPP/TQg6GMdWJioth91AlT/fOf93mSreKE6V9ERERERERERC3oU5/6bzz33LP4xje+ikcfXYo//OF3uPrqK/HWt56I+fPfUNW2Fi36Lzz55L9x+eXfwmOPPYpf//om/P3vdwAonyFXzlvecjgA4DvfuRT//vdj+OMfb8H11/8YXV3ddW23mRhwIyIiIiIiIiJqQcceezy++c3LsGrVSnz5y1/Ab35zE9797v/AV7/6zZq29b//ezGWLXsEF1/8BTz66FL87/9eDMA7R1u15s9/A77ylf/DihUv4ktfuhD33XcPvvWty+vebjMpphnUBJV03cCOHaPNHkZoEgkVfX2d6O8fZfts8sVrhMrhNULl8BqhcniNUDm8RqgcXiNUTj3XSC6Xxfbtr2PGjF2QTKYaNMLWcccdf8Vll30Lf/zj37DLLrs2ezhVSSRUz/VR7vxPn94JTassdy1yc7gRERFV408ProKqAu9bOL/8wkREREREVJOhoUHceOPP8Ja3HIaOjk68+OLz+NWvfoHjjjs+dsG2ycCAGxERxdZEVsddj64BALzr6LlIJuI1kS0RERERUVwkEgls3Lge9913N4aHhzFtWh9OOeU0fOYzn2320CKJATciIoot3XBmRTA4QQIRERERUcN0dHTiiit+2OxhxAabJhARUYyZvg+JiIiIiIiaiQE3IiKKLUOKtzHiRkRERERE0cCAGxERtQT23CYiIiIioqhgwI2IiGLLZJSNiIiIiIgiiAE3IiKKLTHcxtgbERERERFFBQNuREQUX2bgD0RERERERE3DgBsREcUWQ2xERERERBRFDLgREVF8CXWkDL4REREREVGQV15ZgWOPPQxPPvnvSdkfA25ERBRbhhBl4xxuREREREQUFQy4ERERERERERFRqHRdRz6fb/YwmibR7AEQERHVyhRLSpniRkREREQkee655bj55l/gpZdexOjoCHbffQ7OPPMjeMc73olMJoN3vetkfOpTZ+PDH/6YtN4ll3wJW7duxfXX/wIAMDw8jOuvvxYPPfQAhoaGsNde8/E//3MejjjiKHud8877b3R0dOCEE07Cr351IzZu3IDrr/8FZs7cCT/96bV46qknsX37Nuy000444YST8MlPnoVUKmWvPzIygh/84HI89NC/kE6n8a53vRc9Pb249tof4uGHnTLQSsYCADfd9HP8+c9/RCYzhsMPPwrvfe/7G3GIAzHgRkRELYHhNiIiIiJqFNM0gXy2eQNIpKAoStWrbdr0Og488GC8973vRyqVxrPPPoPLLvsmTNPEqaeejmOOWYj7779XCriNjY1i6dIlOOeczwIAcrkcLrzwXOzYsR1nnXUOZs3aCffeexe++MXP4cYbf4P5899gr/vSSy/i9dc34tOf/h90d/dgp51mo7+/Hz09vfjsZy9Ed3c31q1bixtv/Cm2b9+Gr3zl/+x1v/OdS/Hkk4/jnHPOx84774y//e2vWLHiRen1VDqWW2/9PX7+8+vwoQ99DIcddgQef3wZLrvsm1Ufv3ow4EZERLElJbUx4kZEREREDWCaJsb+9m0Ym1c2bQza7L3R/u6vVB10O+mkU+zHpmni4IMPxZYtm3HbbX/GqaeejpNPPgUXX/wFrFu3FnvsMQcA8K9/PQBdz+PEE08GANx779/xyisrcNNNv8Nee80DABx55AKsW7cON930c3zzm5fZ+xgaGsTPfvZLzJ69s/3c9OkzcN55F9g/H3jgwWhra8e3v/1/+PznL0JbWxtefXU1Fi9+AJdccine8Y53FvdxND784TOk11PJWHRdx80334RTTjkN5577OXuZ/v4duOeeu6o6fvVgwI2IiGLLBLuUEhEREVHjKag+uywKhoaGcOON1+Ohh/6Fbdu2Qtd1AEBvby+AQlCrq6sb999/Lz7xiU8DAO6//14ceuhbMH36DADAY489ivnz34A99pgjzcl2+OFH4t57/y7tb/78vaVgG1AI9P3xj7/D3/72F2zcuBHZ7IT9u40b12PevDfgpZdeAAAce+zx9u9UVcUxxxyH3//+N/ZzlYxl69Yt2LZtKxYuPEEaxwknvI0BNyIioopIGW4MuRERERFR+BRFQfu7vxLLktLvfOfreO655fjEJz6Nvfaaj87OTvzlL3/CP//5DwBAMpnEW996Iu67rxBwGxwcwOOPL8OXvvT/7G0MDg7g5ZdX4K1vPcqzfU3TpJ+nT5/uWeYPf/gtrr32R/jwhz+ON7/5MHR3d+PFF1/AD35wObLZwjHdtm0bEokEurq6pHX7+vqknysZy7Zt23zX7eub4X+QGoQBNyIiii1DeMxwGxERERE1iqIoQDLd7GFUZWJiAkuXPozzzrsQZ5xxpv28u9nYSSedgjvuuA0rV76C555bDk3TcPzxJ9q/7+npxfz5e+PLX/5q2X36BQUfeOB+HHPMQvzP/5xnP/faa69Ky8ycORP5fB4jIyNS0K2/v19arpKxzJw503fd/v7tZccfJgbciIgovqQupU0cBxERERFRxORyORiGgWQyaT83NjaKhx9eLC136KFvwYwZM3DffffgueeWF8tMnaDXYYcdgUceWYKZM2dh5sxZVY9jYmJcGgMATynqvvvuBwB46KEHceqppwMADMPAkiUPSctVMpZZs3bCjBkzsXjxAzj+eKes9IEH7q967PVgwI2IiGKLMTYiIiIiIn9dXV3Yb7834de/vgnTpk2DpiXw61/fhM7OLgwM7LCX0zQNJ5xwMv7+99vR39+Pr3/9O9J23vGOd+K22/6M8847Gx/60Eexxx5zMDIygldeWYFcLidlrvk5/PAj8cc/3oJbb/099thjT9xzz11Yv369tMy8efOxcOEJ+NGPvo+JiXHMnr0L/va3vyCbnZCy5ioZi6Zp+OhHP4Ef/ej7mD59Bg4//Eg89tijeOqpJ0I4qpVjwI2IiOKLETciIiIiokD/93/fxve+9x18+9tfR09PL84440xkMmO45ZZfS8uddNIp+NOfbkF7eweOOeZY6XepVApXX/0T3HjjT/GrX92I7du3obd3GvbZZ1/8x3/8Z9kxfOITZ2FgYAA///n1AIC3vvVtuOCC/8VFF10oLfflL38NV111Ba699kdIpVJ4xztOx7x583HrrX+oeixnnPFBjIwM489//iP+8pc/4rDDjsBFF12CL3zhs1Ufw1opprt4l2y6bmDHjtFmDyM0iYSKvr5O9PePIp83yq9AUw6vESonatfIph1j+MpPHwUAfP+cozG9p63JI6KoXSMUPbxGqBxeI1QOrxEqp55rJJfLYvv21zFjxi5IJlMNGiFV6txzz4KqqrjmmutD33YioXquj3Lnf/r0TmiaWtn2QxklERFRE/BvRkREREREreHBB+/H5s2bMG/eGzAxMY5//ONuPPPMU/jOd77f7KHVhAE3IiJqCYy9ERERERHFV3t7B+655y6sW7cO+XwOc+bMxde+9k0sXPjWZg+tJgy4ERFRbBlCkM3khG5ERERERLF15JELcOSRC5o9jNBUVnhKREQURaYUcSMiIiIiIooEBtyIiCi2zIDHREREREREzcSAGxERxRcT3IiIiIioAdica2oK87wz4EZERLEl/XfIL0VEREREVCdN0wAA2exEk0dCzWCdd02rv+UBmyYQEVFsiX+BYriNiIiIiOqlqhra27swMtIPAEil0lAUpcmjokYwDAW6XriLME0T2ewERkb60d7eBVWtPz+NATciImoNjLgRERERUQh6eqYDgB10o9akqioMw5Cea2/vss9/vRhwIyKi2GIVKRERERGFTVEU9PbOQHd3H3Q93+zhUANomoLe3g4MDo7ZWW6alggls83CgBsREcWWCZaUEhEREVFjqKoKVU01exjUAImEira2NmQyOvJ5o/wKNWDTBCIiii0xw42dpIiIiIiIKCoYcCMiIiIiIiIiIgoRA25ERBRbcoZb88ZBREREREQkYsCNiIhii3O4ERERERFRFDHgRkRE8SVG2ZjiRkREREREEcGAGxERxZZUUtq8YRAREREREUkYcCMiotgSS0oZcSMiIiIioqhgwI2IiGKLGW5ERERERBRFDLgREVFLMDmHGxERERERRQQDbkREFFsMshERERERURQx4EZERERERERERBQiBtyIiCi2pDncmOxGREREREQRwYAbERHFFktKiYiIiIgoihhwIyKi2DKlxwy+ERERERFRNDDgRkREsSUF3BhvIyIiIiKiiGDAjYiI4otBNqKGWLt5GENj2WYPg4iIiCi2GHAjIqLYEstImeFGFI5tAxl8/ReP49o/P9vsoRARERHFFgNuREQUX2KXUqa7EYViYKSQ2dY/PNHkkRARERHFFwNuREQUW2bgD0RUKyt4zaxRIiIiotpFLuC2atUqfPKTn8QhhxyCY445BldccQWy2fJziPT39+NrX/sa3vrWt+KQQw7B6aefjt/97neTMGIiImoWU4gIMDZAFA7nbcV3FREREVGtEs0egGhwcBCLFi3C3Llzcc0112Dz5s247LLLMD4+jq997Wsl1/3c5z6H1atX4/Of/zx22WUXLF68GF//+tehaRo+8IEPTNIrICKiycQMHKLGMfj+IiIiIqpZpAJut9xyC0ZHR/HjH/8Y06ZNAwDouo5LL70UZ599NmbPnu273tatW7Fs2TJ897vfxfve9z4AwIIFC/Dss8/izjvvZMCNiKhFsaSUKHxW5qjJiDYRERFRzSJVUrp48WIsWLDADrYBwKmnngrDMLBkyZLA9fL5PACgu7tber6rq4tfFomIWhmbJhA1DN9RRERERLWLVMBt9erVmDdvnvRcT08PZs2ahdWrVweut8suu+DYY4/Fddddh5UrV2JkZAR33XUXlixZgo985CONHjYRETWJGGTj31eIwmG9l/ieIiIiIqpdpEpKh4aG0NPT43m+t7cXg4ODJde95pprcOGFF+Kd73wnAEDTNFxyySU45ZRT6hpTIhGpmGRdNE2V/iVy4zVC5UTtGlFVxX6saUpLfWbHVdSuEaqeqhXeV6ZpNuQ9xWuEyuE1QuXwGqFyeI1QOZNxjUQq4FYr0zTx5S9/Ga+99hquvPJKzJo1C0uXLsV3vvMd9Pb22kG4aqmqgr6+zpBH23w9Pe3NHgJFHK8RKicq10hnZ5v9uKurrSU/s+MqKtcIVa9r2xgAQFEa+z2I1wiVw2uEyuE1QuXwGqFyGnmNRCrg1tPTg+HhYc/zg4OD6O3tDVzvwQcfxN13342//e1v2HfffQEARx55JLZv347LLrus5oCbYZgYGhqrad0o0jQVPT3tGBrKQNeNZg+HIojXCJUTtWtkZGTcfjw8PI7+/tEmjoaA6F0jVL3h4cL7SjfMhryneI1QObxGqBxeI1QOrxEqp9ZrpKenveKsuEgF3ObNm+eZq214eBhbt271zO0mWrlyJTRNwz777CM9v99+++GPf/wjMpkM2ttri1rm86335tR1oyVfF4WH1wiVE5VrRBxDPh+NMVFBVK4Rql6++KXTNMyGnkNeI1QOrxEqh9cIlcNrhMpp5DUSqYLmhQsXYunSpRgaGrKfu/vuu6GqKo455pjA9XbbbTfouo4VK1ZIzz///POYMWNGzcE2IiKKD87vThQSU/qHImLD1hE88NQGGAbPDBERURxEKuB25plnorOzE+eeey4efvhh3Hrrrbjiiitw5plnYvbs2fZyixYtwsknn2z/vHDhQuy66644//zzcdttt+GRRx7B9773PfzlL3/BRz/60Wa8FCIimgTSbSdbKhKFwur+a/I9FSm/ve8V3HzPCryyfqDZQyEiIqIKRKqktLe3F7/85S/xzW9+E+eeey46Oztxxhln4MILL5SWMwwDuq7bP3d1deGmm27CVVddhe9///sYHh7G7rvvjosvvpgBNyKiFiYGBBgaIAoJM9wiKTORL/6rl1mSiIiIoiBSATcAmD9/Pm666aaSy9x8882e5/bcc0/88Ic/bMygiIiIiKYIK9DGDLdosc8LQ6FERESxEKmSUiIiomqI8QDeghKFw3pfMd4WMabrXyIiIoo0BtyIiCi2pEwP3oQShcSaw63JwyCJPbdek8dBRERElWHAjYiIYkvOcONtKFEYnAw3vqcihZmHREREscKAGxERxZcZ8JiIaubM4dbUYZALW8QQERHFCwNuREQUWyZvQYnCZ3cp5bsqSji3HhERUbww4EZERLEllZTyJpQoFCbncIsonhAiIqI4YcCNiIhaBG9GiUIhBbL5vooKNiklIiKKFwbciIgotpjhRhQ+To0YUTwZREREscKAGxERxRbncCMKn8kMt0hymlnwnBAREcUBA25ERBRbJlNxiBpACGTzfRUZDLQRERHFCwNuRERERGRjqXa08ZwQERHFAwNuREQUW2LGh8kUN6LQMasqOqxTwc86IiKieGDAjYiIYssM/IGIaiVVavN9FRmm5wERERFFGQNuREQUX6bvQyKqAzNHI6p4XnhGiIiI4oEBNyIiii1m4hA1Ft9X0cEMNyIionhhwI2IiOKLbUqJQic3TeD7KjI4hxsREVGsMOBGRESxZbCbIlHoxIAO31bRYZ0XftYRERHFAwNuRERERORgIDuSeC6IiIjihQE3IiKKLXlydyIKgzw3It9ZUcNTQkREFA8MuBERUWwxMEDUAMxwiySTc7gRERHFCgNuREQUX7zvJAqdNIcbI24RYkr/EBERUbQx4EZERLElZ7g1bRhELUXqUtq8YZCL6fqXiIiIoo0BNyIiii9G2Ygaim+x6OC5ICIiihcG3IiIKLYMKROHd6NEYZAy3BjliRyeEyIionhgwI2IiFoD70GJQiHP4dbEgZDECrTxlBAREcUDA25ERBRbUmCgieMgainMcIsk0/OAiIiIoowBtylmeCyL1zYNNXsYREThMAMeE1HNxLeS0bRRkAc/44iIiGKFAbcp5vwrH8TXfv4YVm4YbPZQiIjqJsfbeDdKFDpmuEUGu5QSERHFCwNuU8y2gQwA4LEXN9vP6Qb/fk1E8SSWuzEuQBQOvq8iyjoZPClERESxwIDbFDWayQMAbl/yKs676iGs3zLS5BERERFRFEglpQzuRAYz3IiIiOKFAbcpanQ8BwB4/tUdmMjpLDElolgypMndmzcOopbC91IkMcGNiIgoXhhwm6LGxgsZbqMTxX+LATgiolgRS98YJSAKhZzh1rRhEBEREcUaA25TiDhXmxVgswNvxX+JiOLEDPyBiGomzeHGN1ZUWOeC54SIiCgeGHCbQrI5MeAmZ7aNNTHDzTRNTOT0pu2fiGKM951EoWMgO9p4SoiIiOKBAbcpJCsEtUYzOeTyhh2Ea2aG2w13vohzrvyX3UGViKhSZsBjIqqdmEDFpgnRYbJrAhERUaww4DaFiBluumFiS/+Y/fNYEwNuS5/bBBPAfU+sb9oYiCieWFpF1Fh8i0UH421ERETxwoDbFDKRl8s2128dtR+PZprfNGE8y3nkiKh2DL4RhYPvpahim1IiIqI4YcBtChEz3ABgw7YR+3EUmiaMZzmPGxFVR+ygyFtQonDIXUr5zooK61TwjBAREcUDA25TSNbVmGCDkOE2NtH8DLfMBANuRFQtRtyIQie+rfi+igy7pJTnhIiIKBYYcJtCsvnggFtmQodhhP8NLjNReeYcS0qJqFom421EoZObkfCdFRk8FURERLHCgNsU4i4p3eLqCjpWRXCsEs+9uh3nXrUYf31odUXLM8ONiOrCtA+icAjvJb6tosMKfjIISkREFA8MuE0h7pJSt7AbJ/z6npcBAH9b8lpFyzPDjYiqxQw3ovCZgT9QU7FNKRERUaww4DaFTBQz3Ho6U76/D7txgrsrqh9xMmY2TSCiaomZHszEIQqH+F5i04ToYLyNiIgoXhhwm0KsOdx2n9Xl+/ux8XAz3Mpl1AGArosBN2a4EVGVeOdJ1FAmA26RYXcp5TkhIiKKBQbcphBrDrcZvWmkU5rn92FnuLnnjPOT1w3hscm/pBNRVfiJQRQ+zhEWVTwvREREccKA2xRiZZylkxp2mtbu+X3YGW56BV1P3ctU09WUiMiUJnfnzShRKKSS0uYNg2ROhltzx0FERESVYcBtCrFKSlNJDbOEgFtfdxoAMBJyhlslxAw3ABgJuXEDURQZhokt/WPNHkZLYNMEovCJ7yUGsqODp4KIiCheGHCbQqymCamEilnT2uznZ/UWHoed4VYJT8BtjAE3an3X/+15XHz9o1jy7OvNHkpr4c0oUSikzNEmjoNkVqkvzwkREVE8MOA2heRyToabWFI6q6/wOOw53CohNk0AmOFGU8PjL20BANz16JomjyT+mOFG1FjMcIsQu00pzwkREVEcJJo9AJo8E/lihltSxYweIcOtGHwba1DATSnxO5aU0lSmKKXeHVQJaXJ33oQShcLk2yqSTNe/REREFG3McJtC7KYJCQ3TutL28zMbUFIqBtJSSW9HVGc5ZrjR1MVwWwiY4UYUOnkOt6YNg4LwnBAREcUCM9ymkKxQUrrHTl04+oCd0dWeRE9HCgAwkgkvw21M6DaaTATHdfMGM9xoCmPErW4MDBA1ALv/Rg7n1SMiIoofBtymkKxQUqooCj59+psAAK++PgQAGJsIL9iVEcpTS31Z5xxuNJUpjLjVjcEAovAxkB097BxLREQUPywpnULsDLeEXOLZ0VaIu4bZNEHMcHOXjYrcc7hlJia/cQNRs3AKt/pJN6HM+yAKh1SqzfdVJPA0EBERxQ4DblPIRM7KcJMDbp1tycLvs7onAFaLsfE8hkaz9s+ltukOxmVz9e+fKC4YbwuBGfCYWs5v7n0Zt9z/SrOHMSUwwy16xMAnzwkREVE8sKR0CrGbJiTlOGtH2rkMxiby9pxutRgdz+FLP3lEylTTDROmafp2ZNRdwbhcXq9530Rxwy6l9eN959SQmcjj/ifXAwDef/z8knODUv1MzuEWOVLn2OYNg4iIiKrAb6xTiDWHW9KV4aaqCtrThedG65xDbcPWUd+yUN3w/3qYdz0/kWeGG00hjLfVjxOJTwkGA0BNw8MdRTwpREREcRC5DLdVq1bhW9/6Fp566il0dnbiPe95Dy644AKkUsFZV8uWLcPHP/5x39/ttddeuPvuuxs13FixM9x8MgM625LITOgYq3Met+2D477P53UDCc27X3e5qTVGoqlAZcCtbpxIfGpgds/k4vGOHumc8KQQERHFQqQCboODg1i0aBHmzp2La665Bps3b8Zll12G8fFxfO1rXwtcb//998fvf/976bmRkRGcddZZWLhwYaOHHQuGaSKX95/DDSg2ThgMbpyw5NnX0d2RwkHzZ5Tcz/Yh/4BbYIZbcUzplIaJrM453Cg0QWXM0RL18UUfbzynBpY4Ti4GsqOI54GIiChuIhVwu+WWWzA6Ooof//jHmDZtGgBA13VceumlOPvsszF79mzf9bq6unDIIYdIz/35z3+GYRg4/fTTGzzqeMgJgay0T8DNapwwNu4tKd2wbRQ33PkiAODGi08suZ+ggFtQp1KrpLQjncBEVuccbhSKNZuG8f1bnsL7Fs7DCW/evdnDCRT5eGAMyIGYJg6EGorZPZON76uo4XuAiIgofiI1h9vixYuxYMECO9gGAKeeeioMw8CSJUuq2tYdd9yBuXPn4qCDDgp5lPGUFQJZyaT3tHe0FWKvfhluW3aM2Y/L/aU7MMMtoFOpVVJq7X+CGW4Ugutuew6j43ncfO/LzR5KSYy31Y9NSqcGds2cXHJwhwc8CuTPOp4TIiKiOIhUwG316tWYN2+e9FxPTw9mzZqF1atXV7ydbdu24dFHH2V2m8Aq1UwmVKg+aTVWhtuoT4ZbJit3HC1lx9CE7/Puudrs7elOhhsgBwaJahVUGh05jLjVj5GYKUEO+vA8Tya+rSKCbwEiIqLYiVRJ6dDQEHp6ejzP9/b2YnBwsOLt3HXXXdB1PZSAW8KnwUAc6cVvzOmkBs2neUF3RyHglsnqntecFTqHGmbwMTFNM7BpgqkovutZnec6igG/bM6ApikxmHurNVnXht81EifjQpA4yu9hNeB9EWVRu0bEjwpFjd/xbEWNuEZUocOIqqk8zw0m/h+sNuB9FbXPkTjIG853sanwWcdrhMrhNULl8BqhcibjGolUwC0st99+O/bff3/stddedW1HVRX09XWGNKrmGhwvZI61pTT09LR7fj+jrwNAYU4192s2FecC7OhKo6+7zXcfw2NZTBS7jH78tP2wZPlGvLpxCIZhorMz7dluLm8gmSpcgn09zja7utt9GzvQ5PG7RuJEnDMwyu/hZFKL9PhKico1Yn2GAEBbWyq2x7MVhXmN6ML/Q729HejpDO5cTvVLp533VXtH495XUfkciQNxjt10OjllPut4jVA5vEaoHF4jVE4jr5FIBdx6enowPDzseX5wcBC9vb0VbWPt2rVYvnw5vvzlL9c9HsMwMTQ0Vn7BGOhOqTju4F1w4N47YWgo45lTTS1mmvUPjqO/f1T63ZbtI/bjbdtGgICyz9c2DQEAejpTOOnNu+GkN++GC69+GNuHxrGjfwzT2p3Lbemzr+Pnd7yAWdMKF7f4h9rNW4fR1Z6s/cVSzTRNRU9Pu+81Elfu6zlKdN2I9Pj8RO0amZhwshkzmWzsjmcrasQ10i9kT/f3j0LPeqc/oPCMC8Gd0dGJ0N9XUfsciYOM8Fk3Pt76n3W8RqgcXiNUDq8RKqfWa6Snp73irLhIBdzmzZvnmatteHgYW7du9cztFuT222+Hqqo47bTTQhlTPt86b86z3rU/+vo60d8/6nldbalCRtnIWNbzu8GRrP04M5EPPCZbd2QAANO70/YymlYoS8lmdWm9l9YOIK+beH17IaCZ1FRoqgLdMDGWyaGNGW5N89d/rcTtD63Glz50KKb3+Gczxkmk38NmxMdXgq4bkRi7IcwrGZUxUUGY5yOfc/7Qk8/zPDeaOF9rI48337OVE7vN67o5ZY4brxEqh9cIlcNrhMpp5DUSqYLmhQsXYunSpRgaGrKfu/vuu6GqKo455piKtnHnnXfiiCOOwE477dSoYbakzmJG2eiEd7L54TEn4JYTLsRlL2zGl36yFGs2FbISrQ6lM4QgTaIY+XU3TZjIyllymqbaZaRZfiA21dLlr2NLfwarNw6VXzjiNDXacwFyqsL6sVvf1CD3xuA5bzjT9yE1Fc8EERFR3EQq4HbmmWeis7MT5557Lh5++GHceuutuOKKK3DmmWdi9uzZ9nKLFi3CySef7Fn/hRdewKpVq9idtAadbYVkxzGf7o5DY05piRhwe2LFFmwbHMfy1dsBAP0jhQ6l07rT9jKJYsBDnOwXALI5OeCW0BSkinWl7t/R5LIyhowWuKm1Mjejis1BQhD/y5QqIAbZeMobTwxkM8AZDTwLRERE8ROpgFtvby9++ctfQtM0nHvuubjyyitxxhln4OKLL5aWMwwDuu4Nytx+++1IpVI45ZRTJmvILcPqEjo67p0XZyggw22smA1nZcBZWWvtaSfIYZWU5nUTpmnihdd2YHDUaa5gSWgqUsliwI0Zbk1ldbSt9R7LMEwsefZ1bO5vzvyHYjZlezpSVfPUAHLmU9OGQQ0mnlue58bj8Y4enhMiIqL4idzd6Pz583HTTTeVXObmm2/2ff6iiy7CRRdd1IBRtT4rwy2bM/Dbf7yMdx+7F7rakzBNEyNihpsQzLAm8B3J5Ox1ASCdFANuhSCarhtYtWEI37/laRw8f4Y34KYqTkkpM9yaytCtgFtt3+hfXjeAG+58EQfMm47Pf+CQEEdWmdGM0Mkt4nMBMsGtfsx8mhpYUto8PN7Rw1J6IiKieIhUhhs1T3s6AbV493/fE+vx4FMbABSy2MTJk+UMt0JgbLgYkMsWu5emEk6Qwyop1Q3TnuNt29C4J+Cmaaq9XjYXrQy3R1/YhCdf3trsYUwao84Mt9FiWfJoxluePBlGhLLoqN+SMN4WtqifcaqVFFjlaW44KZuqecMggcmTQkREFDsMuBEAQFUUvP94pxPs1oFCx9Gh0ay0nBhwyxTLT90lpWlh3iyxaYKVuTaR1THhCqpJc7jlo5PhNjSWxU//9gJ+/OdnoRvRCgSWsmHrCB59flNNmQl6nXO4WfsUu0dOJjHDTW/SGCrFOdzqxzKrqUGONfBEN5o8h1sTB0I2M+AxERERRVfkSkqpeU49ak90d6Rw410vYsfwBP6yeDVuX/qatIxfhptdUlr8nRU4A8SAm2kH3MazOpIJ+etiQuxSGqEMN7Gbaj5vQks1cTBVuOnvL2HVxiHsOrMTc2Z3V7WuUQws1nqTZa3WrKYL4jyERtSDpIy31Y03nlMDM9wmmXCMW6GBTktgxI2IiCh2GHAjyfSeQofRHUPjeP7VHZ7f5/I61mwaxsxpbfbk9MNjOZimaZeJynO4FUtKdcMOyI1n8zBNeW4tTVOEpgnRyXDTVCciktMNpBHtOcEsVlmlX9fZcqwYVa3z9jQ/w815zc0aQ6UURtzqxkDM1MBqusllBv5AzSLH23hSiIiI4oABN5JM72kDAGzekfH9/VOvbMPN976MQ/eeaT+XyxvI5pyS0VTSr6TUtLPF8roJ3ZADQQm1sjncHlq+ES+t6ccnT9vP3vZkEbtfRp0VhKjlK7lVOlvr13krG6JZ5ZwjsSopbfYIWgBLDacENk2YZFKpNo93JLBBDBERUexwDjeS9HUXMtyCSkjWbx0BALyyflB6fngs69+ltJghljcMKXPNvfmEpiJdQYbbnY+swSPPb8Zrrw8DAFas7cfN967AeLYxE/SLx0Esp406K7Orlhsla91as8OsXUajpDTatyWMt9WPmThTQ1QnjDdNsyUDUmLwOuIfo1MGP+uIiIjihxluJEknNXS1J+0soT126sLBb5iJtZuHsXzVdrsjqZhFBADDmZxdUmqVhgKFZggAoOump1GCKKEpSFaQ4WZlyVn7uvy3TwEApnWl8a6j51b8Oisl3mjEK8Ot+G8N6zpdSmNaUiqU0UY/w40ht3qZzPqYEsSPo6jMKWaaJr73u6egqgq+8MFDWur9HI0jTKKIxpyJiIioBGa4kYc1jxsAvGH3Xrxv4TzsMqMDQHAAY3gsZ2empaQ53LxdSv1omurM4VZiOWseOHcW3NBI1m/xupnC641ThpudnVDDt3KnS2mN+zbl7Uw2sUtpVG7MaZLwdLesKJYLj2d1vLR2AC+81m//39QyWFIabTwnREREscCAG3lM726zH+/cVwi0JROlL5XhsSwmst6S0oRaWE83nKYKfhKa4nQpLVFSmiv+Lpc3pCy7nq7GtA+VSkpjlOEWRklprTdZ1jGLQkmprkf7pqSFEmKahvedU4Oc4da8cYikay8iYwqL+HL4h4toYDYvERFR/DDgRh5ihtvs6e0AgGSZBgUDIxP2l3K/ktJChlupklIV6YQ1h5v/coZhIl8MoOTyBjbvGLN/ZzboDkwsi8zHKIOhnpJS3Q641bfvZpWUZiZYUjpVRTELisIhBX0iEwAS5zmLyphC0mqvp8Xw9BAREcUDA27kYXUqBYDZ060MNy1ocQDA9qEJ+3Hat6TULFkqmtBUJJOl53ATSzqzeQObhIDbeIlt10OM18Qpw83uUlrDl/J6M9yaPYebuFs2TWh9YqCDN6EtLILxtogMoyHkDLemDYME8nXPk0JERBQHbJpAHtOLnUo1VcHM3kLwrVxJ6fbBcQCAqih2Z1IASKhW0wSjfElpIngOt7HxPHTDCXjlcjr6h50gn9VMIWxyhlt8vuBaw66rS2m9GW7Nuit2TSxtmCbUCGWSicclQsMiirQoThgvJ91FZVThaOXXFldiBi9PCRERUTwww408di42SNhlRie04hxsQQG3rvYkAGD7UCHglk6pUpmcZpWUGmbJSaU1TbUz49wBt/ufWI/zfrgYj724xX4up8slpeONCrjFdA43O8OthnXtktIab2utfTernNN9cxi1LDdpfIy41S2SlYYUOjmTMRonurXn1IpghHOq4ykhIiKKHWa4kcees7tx9rv3x26zOu3nggJuO/W1YySTszPcUq7S00SxpFTXjZJZaAlVcbqUugJzqzYMAgBeWT9gP5fNGdjc7wTcSmXP1UO8yYvTHG72uGspKa2jHLWwfvHfJh0ud3xNN0yUqYieVOJxURlvq5uU9cHb0CkhIvE26WqLypjCIjepaLEXF1OsKCUiIoofZriRh6IoOPJNs7H7rC77uaCmCTv1FZoqWAEvcf42wAm45XWzZPfRhKbawTp3wG10vDAJvtiVNJvXsXlHxv55PJtHI5jCUOKU4VZrSalhmnU3PWj2HG7uO5FIZ7hR/Vq4UyQ55GyyiJzoFi67bOVgYlzJH3U8KURERHHAgBtVJDDDbVq79LPYoRQQSkormMMtmfSfw21svBBoGxlzAm7bB8el7TVsDjexpDRGGW7lSkozE3k8vXIb8q4gohicqr1pQnFbptmUm1D3LqPWqVSew40pbvVivG1qiGLpcEsHpVi+GD0td5ERERG1PgbcqCKlSkpFKXeGmyp2KS0zh1vCfw43K8NtWMhwGxjNSss0rEup2DQhThluxaEGfT+/5tbluPpPy/GnB1fJ64XQ8dEMYRv1cJc/RS3DTSwpZbgtBFGcTZ9C1+zPFT/ymCIyqJDIE/S31muLK5aUEhERxQ8DblQR99xsllnT2qWggbuk1Mpwy5Qp+UxowXO42RluQsBNzHYDJifDLU4BNzvDLeBG6aW1AwCAxc9slJ4Xg1O1ztsjxreakV0W9Qw3qRSIEbe6GVK8LVrnmsIjfvpG5Ty3dKy35V5QC2jl642IiKhFMeBGFQnKcOtoS6Kz2KkUAFKu5aw53DLjpQNuqqLY2XETOV0KGFkZbmJJ5/CYK8ONJaWSSmNl7uXE7KuaM9xQf9CuHu49Ri/DTSgpZcQtVNE60xSqCJaUiqI4pnqIL4dNE6KhpUuYiYiIWhQDblSRRFDALZ1Ad4cTcEun3CWlhYDC2IQ34NYmLKsoCjrbklBQ+CK5fWgcv73vZTz/6g7fDCUrCGftu2EBt9g2TTClf8stZ9GFF1xrFonU3a4pGW6u1xSxOxNxOJzCrX4sd5sazAimk7V0SWnEA5xTkXyN8aQQERHFQaLZA6B4EDPcutqT2GOnLoxn8+jtTKG7PYnXi79zl55qxQy30XG5BBQAOtuSUqAsmVAxrTuN/uEJ3LNsHe5/cj2Wr9xecly9nWkMj+WQ1w3kdcPOqAtLHDPcqrnxcy8bxk2WuM3mlJRGfA63CM5F1TJ4PFuW+DaOSsZVawelohfgJAdPCRERUTww4EYVSQqBrLaUhv898xAAhcy0ro6U/Tv3HG6J4hxufg0TOtsS2D4kPzertw39wxN4ZtU2AMCWgUzJcfV2pbB+K4r70CsOuFlBmXJdIk2paUI8vuJWcxPoLSkNdw63ppSURn0ON858HaoIJj5RQ0Tv7EqNBSI4vnqwpDR6mOBGREQUPywppYqIGW5tKQ2KotjBKrGk1Gp8YHEHwMTw1rTutGc/M6cVup5uGxyvaFydbQloxbLVSstKDdPEd3/9JL5z8xNls8GkpgkxyXAzqihz8paUhtultDklpfLPkctwC+EYk0OOX/KAtiqpOUZUznMrZ7i18muLKcbbiIiI4ocZblQRsRmCe542aQ43d5dSVc4g62xP2t1Gjz1wF+iGib1377V/P7O3rapxpZMa2lIaRsfzmMhVFnAbGJ7Ayg2DAApzy3W2JQOXFW/y4jKHmzSvUNll5Z+NEIJlTZ/DzfWqIxdwq+L8UAV4PKcEeb60Jg5E0MoBEPm1tdqri6kWnjOQiIioVTHgRhVJSBlu8mXT1e6UlKY8JaVyhltvZ8oOuHW2JfCFDx4i/X5WMcOtUumUhnQx4FZphlvGp4FDEDFYE58MN+GHKr+Th5F9FbUMt+iVlPKmKUziu5KHs4VFMMOtld/LUQxwTnU8DURERPHDklKqiKoo9nxsbSUz3ORLStPkDLeeTiE459oOUH3ArS2l2QHAigNuwnLlAkJS04SYZLjVMw9bNeWowdtwHjejQ2j0myY0ewQthnPiTQlSSWnzhiGR/rYRlUE1QKsFE2OLZb5ERESxw4AbVcyax61UwK1chlt7OmFvx11+CtRWUmptZ6LCgNvYuJPhVi74IQZr4tOltPZ1WzPDLVrnTTo+vGny2LhtFF+4dgkefGpDRctLE9fzeLasSGZcRTDrLixsRhI9rVzCTERE1KoYcKOKWZ1K25JySWl3qZJS1xxuqaSKN87pQ1932jebbVp32s6kq4Q1hxsAjOcqKxUdHc/Zj6vJcMvHJMOtngCEWH5p1PiVvvlzuMmiVlJqGExTKOWV9QPoH57A0yu3VbYCAwNTTlTmFGvlDLdWfm1xJQV1eVKIiIhigXO4UcWSCQ1ADm3pakpK5Z/TSQ1nnf4m6IbpyX4DCqWrM3rbsXnHGDRVKRssSae8GW66YeDOpWuwzx7T8MY9+zzrjGYqD7iJ32njkuEmZ6nVU1Ja2/7FfTYj2GXt37p+olZSysyR0qq97lhROjWE8dkUtmoa1MROC89P1wp4RoiIiOKBGW5UsaCS0q52oaQ04S4pdWW4JTQoiuIbbLPsMr0DAPCG3XoDl7G0pRJOhlsx4Pb0K9vx14dfxRW/e8p3nVGppLRMhpvYNCEuGW51BHTqCdb57r8JdwXWPq35AyOX4RbBwEGUWNddpcdGvt55QKeCqLxv5M+6iAwqJMxwix7pPPCcEBERxQIz3KhiTsBNvmxSxXnUJnI60q5gnKa6MtxS5WO8HzzxDdhvbh9m9rRhxbqBksuKJaVWhls278zlNjaeR0ebPF4pw61cwE1qmhCPb7jVNkqQ1hViirU3TYhGhltCVZGFEbkMtzAaU7Qy63RVfmx4DKeCKL5vWjq7soWDia2AZ4SIiCgemOFGFSvV7GDfOdPQ1Z7E7D55Xra2tCY1QnBnwPmZPb0DJx+2B2ZW0LE0nVTtIN94rhBoaxcCguu2DHvWqWoONzHDLV9ZU4Zmk+ZQq6OktNY4lbSNJjZNSISQ4WYYJjZsGw31hpP3rqXZGW4VLy/+EPpwKCIiWYotfV5GZlShYIZb9Mjzs/KkEBERxQEDblSxvq40AGCGTyfR8884CN8/52h0tCWl51VFwUffvo/9czUBmL7utP24Pe2fjNmWSvjM4ebsY80mv4CbUFJatmmC8zguGW5mHXemUklpjYGqegJ+YbBuSqz5A+sZw6/uWYGv/nwZ/r5sbShjA8LpBNvK7MNT4cGJZCCGwhfBjKtWDkrJ89O12IuLqVa7xoiIiKYCBtyoYh89ZV9c8J8H441zpnl+pyqKp0Op5aD5M3HU/rMBAPvs4V03SGdbAl3tSaiKgp36/LPd0inNLnEdF5omWNZsLpPhVuYLrBgciWXThDrWrTUxrNlNE6xdamr9GW6Ln9kIALjt4VfrHpelled9CoN1TCo9bfV05aX4MCIYWZ0q19tUeZ1xwnNCREQUD5zDjSrW25nCQfNn1LTuWae/CR88cW/0dqYqXkdRFFzwnwdjbDyHfz290TdbLZ3UnJLSbCFzTQwardk84llnNFN5hpsYEGlG04RcXsfL6waxzx69xS6x5YmjrDagoxv1ZzU0O8PNGrbVmCOMslZFKb9MpaS5qMLbbMuo+pJp6Ym0yCJ/rjRvHCKzlUtK+YeByOFpICIiih9muNGkUBSlqmCbZd6uPThg3ozA7Lm2lIZUcW45KwNNDBq9vn3ULjW1yBlulTdNyOeNSb/xuO+J9bjy90/j/ic2VLyOVApUbUlpCB00pZvQZjZNCLFLqRJixI03r6U5XUorLCkNeEytxeSZbhoe7WhgaS8REVH8MOBGsSB2PxXnc0snNWiuwIrumiNrc/+Y8LNZVYabuzxzskskB4azhX9HJipep54gVxidAMXdN7ekNLwMNzXEgBvncCvNsANulS3PpglTg5xx1bxxiJqezdtA9fzhhhqEWYdERESxw4AbxUI66VyqnW2FgFsyoUJVFSSKgRW9WPLpDrBkc06R5XhWd3XirLxpAjD587hZr6Wacta6upSGPIeb2HhBNwwMjWVr22h1IwAQboabGmpJqfOYN01e1vGp/MiwRHcqkCfxjwYp4ygqgwqJ3BCixV5cTPFvC0RERPHDgBvFQlooKe0sdkK1nnNPju8OsOTyTknpaCYn/a6aDDcAyE3yPG666f+aSgmtS2mNN1niauK4L/vNk7jg6oexcdtoTdutdv9aiHO4qSFG3KIYOIiSukpKGRhoWVE8z1HMumuEVn5tscLzQEREFDsMuFEsSAG39kKGW1uxzNQqKc0HBdyEINnoeF76Xdkupa47jXyTMtx0vfJv2kbt8TZPOW4tgiYSX7VhCACw9LlNvuut2TSMn93+PLYNZGrbsWufYXQptYQ5h5sxVe7Sa2QdkkqPDA/h1BD1t03rlZSKj1vrtcUVOzITERHFD7uUUiyITRM6PBluVkmpFXCTg2JiGajYMAGoIMPNHXCb5Aw3u6TUqKaktPYstTDKHcVt+B3foGN46U2PAwA27cjgq4sOq2nfALxdSkO4M2lYSWl4m20ZZpURN841NTXU87nWKBEZRkOYLNWOHDl5nWeFiIgoDpjhRrFgBdcSmoJ0sSup1UjByWTyn8NNDri5M9xKf2k1XbGhyZ7DTa8hw62eTBBxzrVaSzHFGwG/7LJyx3DTjtpLTk3T2Xuoc7iFWVLKpgklOU0TeHDIUUelfMNEMQgYmohnFE55PCdERESxwIAbxUKq2DQhmVCRLAbf7Aw3K7BiZ7gFl5QOuybtrz7DbXK/5Vr7ryZoVE9Gl1RSWuM2yjVtKBdwq6cjqLi3MOdwU9CYktKWu0kPQT0lpTyarSuKwS15XrmmDaMhojhn3lTH+T+JiIjihwE3igUruJZMaEgVM9zsOdysktJihps7G0ycd23TjjHpd2W7lJbIlpsMToZb5futJ6BTTQfXINIcbj7BrqzQxMJPXdlkwu4SIc7hpob4SRmXe9cVa/vx/372KFas7Z/U/ToZbpUtLy0Wl4NLVYtkcKuV5zljqXa08aQQERHFAgNuFAtWcC2VUJG0SkpdXUqtpgnuQJEYJHN3yKw2w22yu5Q6c7hVUVIqDDForaCQlhFCuWO5OdzKZrjVEXATz5eV+RhKl9IGNU0IYWgN8/TKbXh9+xieXrltUvdrZ7hVHHFj1sdUEMWmCa08zxkz3KKH2bxERETxw6YJFAtzd+7B/F17cOC8GWhLFy7bns4UAJ+SUj04SGYF3BKagrxuVtClVP65WU0Tws5wUxTF93dhlDuaZQJK5YKWdZWUihluIZaUhjmHW1y6lFp9OqqZPzAM1vVTcUlp4A/USuRyumic6Ji8lWvC4E70RDLLk4iIiEpiwI1iIZ3S8P8+XuhcmZnII5lQ8eZ9ZgFwAit2+WVAGejYeA4DI4U53Hab1YU1m4bLZ7g1uaS0ljncKunaqKqA4VPZGUaGm7ie37jzZY6hVldwS8hwC7GkVAkxw62SDMQosK4jfZLv7OyGvBUnuLVulhE5ohjcimIQsBGicrynPJ4IIiKi2GFJKcVOezqBEw7dDb1WhluFXUo3bivM39bXnUZnWyHWXHYON0/ThObM4VZNswbx5VsPh8eyWL5qu/16ggJIUtOEBs3h1sgMN3F3TiC2/nMWYoKbnEUY3mZDZw0zjAzB6vZrSv+WX967LrWeqAe0Wu3Si2KTiqmOZb5ERETxw4AbxZ4dcLO7lMoBFjvgtr1QTrrrzE67RLBcMMFsdoab4f+aSjF9UkEuvelx/PCPz2Dx0xsBAEExrTDmF6u7S2kd0S3xtcdhDrco3zQZqD67MgzVdimlqaHc50ozTJVgbyu/tjjhWSAiIoofBtwo9jShpNQ0TTtAYGU4WRlV1vxtu83stAMo1TZNaFaGW3Ulpd7HO4YmAAD/XrEFgJzhFpSRVutNlnjM/Mbd2ICb8zihyqXG9Qi1pFRKUwhts6FrVoabFeirLcOtESOiKJD/kNC8cYgqKd+PqwgebuJnHRERUeww4EaxJ875ZQgBN6uzaT4vB9x2FQNuZUtK5Z8nO9vHaZpQTUlpcMmitR0xpmUEBNxqzSKRbtRqCbjVENwaHc/hwac2YDiTs59LhJnhFuInZVxKSq3jNuklpcX9VRFibsg4BkezzOyJkChmk8klfk0bRkO08muLq1buiktERNSqGHCj2BMDbrpu2gECK+BmZbgNjRYaJvR1p52S0jLfWt3BhmrmUguDM4dbbSWl7htTawJ8BfIxc++vsG51Y/Xbp2+GW5nXUkvThAef2oBf3bMC9z2+zn7OnsMthLvFMEtKzRCO8WSwzmN+soPM1u4q3G0j5jVa/MxGXHjNw/jLQ6+Gsj2qXxSbY8jJqlEZVUhiUvo+pTAKSkREFDsMuFHsWZlMQCHAYwV50lbArZhRNZ4rtOVsS2kVz+HmzvLSJ7mktJYupVLTBNdq1usV40e6lNUmrltrhlvpLLlyXUprySYbHc8DAEbGnQw3q9Q4jAytMEtKwzjGk6HZTRMqzbBsROnbr+9dAQC4Y+lrIW2R6hXJWEMLl/hF8nhPcTGZjYCIiIgEDLhR7GlChEYMuLW5Am4T2ULALZ3U7JLKsgE3d4Zbs0pKq5nDTcygcv3O2o7qKsP1W7fWlyquZ41fDCw1oqTUDtIIO3e619YfOAwx3habklK/Yzo5+612+fDHp4VZQ0yhiGZJaTyyVWvRiMxRqg/n1SMiIoof3lVQ7KmqUyCp64ZTUpqsIMOtzI2E9Wu7PHGyM9zsOdwq368cH3Fn6FklpcJzwgp6CGVEfiWl4pbCapowNp7DpTc9jr8vW+ObjVVvl1LxuIRaUhqTNAXr5U9+l1IrSFvh8g0YQy1lzdRYUWxQEMUgYGjEP5wIT9//xHpcfN0j2DaQmfQhESNuREREccOAG7UEK7iiGybyRuH2IJ1KACjMGWaYJrJWhlsqUUXThMLvU4nCW6Vpc7hV1aU0+MbUej3i01KjhFDmcPPuzyiRdedWabDj1deHsWbTMB55bpMnE1BB/Rlu4pjr6ZxaartRvkl3MtyaU0Zd8bFpQFmfpjHgFjVRzO6J4pjCYgYEd558eSu2DGSwcsPg5A9qiovwfxdEREQUgAE3aglWCVje8GmakDeQyxn2PUNbsoo53Iq/T9oBt2ZluFX+TdsoEXCzM858yj7dj0OZw82npNQ9RrdK50sTM6GszdmbVZyAW6UZbsNjWYwV54ID5EBdmCWlUZz83U8t8weGwT6XlS4vPQ5nrGEGWCkccvlmVN45URxTSAKy96rNQKXwNOKzjoiIiBorcgG3VatW4ZOf/CQOOeQQHHPMMbjiiiuQzWYrWnfz5s246KKLcNRRR+Gggw7Cqaeeir/97W8NHjFFgZ3NJJSUik0TrHJSBUAyqToZbhU2TbACbpMdfNDtzK1qupQKj11fyq1sJfEGSsyeKxWsq5Q4Uuv4uoefLZ4PZ19CKWiFwQ5r2IZpwgqn2nPUKYodNKnknOXyBv7fz5bh6794zB5Lo0pKwzjGk8Ea22Rf89VnuIWfZpRgwC1y5PLN5o1DFMUxhUXKgvZ5nZU2NaEQxWQ6AiIiInIkmj0A0eDgIBYtWoS5c+fimmuuwebNm3HZZZdhfHwcX/va10quu2XLFnzwgx/EXnvthW9+85vo6urCK6+8UnGwjuLNLinVTTuAZM3hltcNTGQLmUuplCYFY8rFEqyAUaq4rWZ1KTXNwlgqybypJMPNr7GB53GIXUrd28rmDLSlvOMCKs8ucrpZOs0erICiojhZj5VkuGUm8hjJ5DCSyUE3TCQ0RT7XoTZNEH+K7l1Ts5sm1DKHW1gjZYZb9JT6Q0KzRHFMYTEDPqdM39/TZDB9zgMRERFFW6QCbrfccgtGR0fx4x//GNOmTQMA6LqOSy+9FGeffTZmz54duO73vvc97Lzzzvj5z38OTSsERxYsWDAZw6YIEOfr8s1wK87fZgXhKu5SWvx1UmvOHG7i+HTDgKpqZdcxS2T8WKWpfo0N3I9rjbOIu3cCfPLGJlwZbmLJbKXZZE5gxvSZ4F+xt6NXcGdouI5HQpOPhRli0CmKk7/7aVaGW7WleXITinDGyi6l0VPqc61ZWrlLqXiQDZ/3WMuV0MZBC2dUEhERtapI3VUsXrwYCxYssINtAHDqqafCMAwsWbIkcL2RkRH8/e9/x4c//GE72EZTizOHm2EHb8QupVaAxwrCVds0IZm0SkonN8NNDHZUGuwrlXVRdg63kLuUOiWlpQNueeG4VpvhZpqmJxtLrXIONylIWDzO+RCCj6KRTA6/+cfLeHXjkLPf+jfbMH4NLyZnv4V/K73+GjEnHruURo9c4hiRd04Ll/gFdVM2vE/RJDFL/ERERETRFKkMt9WrV+P973+/9FxPTw9mzZqF1atXB673/PPPI5fLIZFI4KMf/SieeuopTJs2De9973txwQUXIJlM1jymRCJSMcm6aMUsLevfVuKcJ8W+GetoL5z3nG4gZwXhUhoSCVU6r6XOsXXTkbZKSs3JvSakG0ulwn2LsQJFkdYxTBOJhCoFKRRhu+6brFpeq/s+LZFQPUE03TADt62pSkX7VYrbNE3Yr9m6GVQUxQ6SWq+5FHF8iloYszvRrt7z/szKbbj/ifWe56P+GeM+fpP1OWJdO9Wp7NopR+xSGvXzE0WNuEbE96Na4WdEo6ma93OjZQjH24TzGWA9rVT6/1GAVv4+0ijy/6PReA80Eq8RKofXCJXDa4TKmYxrJFIBt6GhIfT09Hie7+3txeBgcAv6bdu2AQAuueQSfOADH8B5552H5cuX4+qrr4aqqvjCF75Q03hUVUFfX2dN60ZZT097s4cQOmuOtY7OlH1nNqOvA0Ahwy2RLFzqXR0p9PV1oqM9hV20fuy/9XnkH5mOrgOOQ/uc/T3btb7gWsG7yb4mxMBYd3c7+nrayq7T3p62H6fTCWm8pmmir69TCop1drXZy0gZojW+VlUox9MSGvr6OmG4SvSS6aS0bV0RAqBJraL9dnQWX6eiIFk8v9b5UlUFvcXrXFHKv46s6dzIWMd5aNzJwlM1tf7z7pN9G+XPGC1RGK8J/zE26nMkkXCyUCs6NoocHAvjeKZSzn+NUT0/cRDmNZJKOX84S7clI3FeOjqcz9r29nQkxhQW8YunqqrC/xGF59vbU6G83lb8PtIonZ3O9aZp0f2/I2y8RqgcXiNUDq8RKqeR10ikAm61siZKP/roo3HxxRcDAI466iiMjo7ixhtvxLnnnou2tvKBCu92TQwNjYU61mbSNBU9Pe0YGspM+uT/jaYUQ0gDAxm7A6YulC1u3jYMoNB9sL9/FNlsHv/ZsQy77diC4R3AyPNL0HPmd6B2TZe2m7O6mxYDX5nxPPr7R+saq2Ga2LR9DDvP6Cg7X5lYRrp9xyig6yWWLhgdHbcfj4/npPHm8yb6+0elMsH+gTH0dxc6GFjNJQBAzxs1vdZ83hnjxERh//2D49Iy23eMor+/w/m5f0xYp7JjPDJc2KauGxgfzwEAsllr3ybGxiYKz+X0stsbGHD2bx3nHQPOOrkKtlHO0HDG81y+xmM8GbLFayGXl197oz9HrGtQN8yKjo04v14Y56mwUeH9EdHzE2WNuEbGx50GSJmxbCTOy8iI87k2OjoRiTGFJZ93zpuuO59TueLn+0idr7eVv480ini9Rfn/jrDwGqFyeI1QObxGqJxar5GenvaKs+IiFXDr6enB8PCw5/nBwUH09vaWXA8oBNlECxYswHXXXYc1a9Zg3333rWlM4pfOVqHrRsu9Litwlc3p9pslKZT7DI4UbtZSCRX5vIG27A7MT26BCUDr2x1G/3qM/PPnaD/181CEbCtrzrOE1TQhr9d97O5Y+hr+vHg13n3MXLz3uHkllxUDYxO5yvYt3yiZ8s9G4WexdDQnbFf8oDFMs6bXKo45ny9sI+easy0zkZe2PZHVpfUrep3FsRpCowwrQKlAsWtb3cfAT04cS/F4ZLPCsahwTKWIr9Fi1niMJ4N1TIOOX6M+R6x5Eiu9/uSJ68M5nuJ/n1E9P3EQ5jUiNlap5D09GcQx5Vvs/1UxkC1+/lnTbYZ1Dlrx+0ijiNdbrf8/xxGvESqH1wiVw2uEymnkNRKpguZ58+Z55mobHh7G1q1bMW9ecGDiDW94Q8ntTkxMhDI+ii5rziXdMO0gmVVmChQmrAecpgm7Dj0HANjaNhdtJ50DaAno65/DxLI/SNu1myYk5C6lY+M5PPrCJs/k/5X48+LCNf63Ja+VXVbqUlph1N1wT6Im/a50l9JwmiZ49+ceuTv4lNf9x1CK+Frs/RT/VRSnvLT6pgnF4KPQyCGMjnxZnw/xKE97bbqO6eTt13pQ5fIh4lwf0RPBJqWRGUcjBDepaM7nArmuNx5+IiKiWIjUXcXChQuxdOlSDA05XfzuvvtuqKqKY445JnC93XbbDfvssw+WLl0qPb906VK0tbWVDchR/FldSnUh20lTFTtQZgXc2pIJmKaJXYaWAwDWdB4ArW9XtB33SQBAbvndGH/0FphGISBkbcvajhWc+vuytfjp317A4mc2Nuw1GabcY1SvuEup2LXRu47p2q4U1BMe13o/Jd6IWds2XUEvT5dSV2ZdJazFDNMJMlrjVxTF7jRZSWdZw/CO2Z1NUK+c319NInzT5D6mk8X0CQqXXF5aN5wxiJOThxFsbRVb+sfwhwdWYmBk8v+I5c5kjAKpI3NExhSWoJdjPd9iLzcWGtGRmYiIiBorUgG3M888E52dnTj33HPx8MMP49Zbb8UVV1yBM888E7Nnz7aXW7RoEU4++WRp3QsvvBD//Oc/8e1vfxtLlizBddddhxtvvBGf+MQn0NHR4d4VtRg7uKIbdoBAUxW7FFTMcNNffwkd2R2YMBNYn94bAJDc5xikj/wggELQLXPv1TANww46pIoTuVuBoeGxrPRvLXo7UyV/787MqjTwIS7md1Pkfkr3CTYV1q0/w83atvtm1B1wE4Nble5WDMzY2VjF4JqiOGXGlRw3v4w/OfOvsjGV4hdwi/JNunVMJnvOC/uGvuLlw78J1YSAW77CQPdU8N1fP4m7l63FdX99btL3bZb5XGsGn8SvFuL/+Wf/oWOSA/EUzfcAERERlRapgFtvby9++ctfQtM0nHvuubjyyitxxhln2I0QLIZhQHdNHn/iiSfiBz/4AR555BGcffbZ+MMf/oDPfvazuOCCCybxFVCz+JWUappqZ6YNjzkBt9wLDwAA/j0xDznF6XyXOvhUtJ10LpBIQV/7DLJP32FnZrlLSnXXv5USM7mCAm66YeD2Ja9ixboBz7pDo1n86u6XsGaTd65DS7kAhDuQJmV3mfUHmaSsDyvg5slwk4M4tZRvShlurv2IGW5Vl5TaAbdwS0p9M9wizLCPb7My3CpdQVo5lDHIAbd4nbdGGhwt/IFh5YahMkuW9/r2UXzpJ0srzhIul7nbDFHMuguL/LbyHvuonIOpRD7mPP5ERERxEKmmCQAwf/583HTTTSWXufnmm32fP+2003Daaac1YFQUdQmfklJVVZC0M9wKN4rdyCD/2hMAgIcn9sGernvp5LzDgfwExh/8ObJP/AV7madgC3ZCyi4pNez9ANVnv2wfcrqMtaX9336Ln3kdf3noVc/zumHihjtfxLOrt+Oh5a/jZ186wXd9s0wAwv1UIzPcnLnV5GWynpLS6jPcDCF7Tgy+AYACOQhbdltihptPMLWCqtSycj6Bmyjfo9sZbpOcyWKXIddSUhrSGMSS0pxugM3kZWWaK1dkxboBbBscx1Mvb8XCg3ctu3wjSofrZvo+bA1BbyyWlDZPK19vRERELSpSGW5EtZJLSguBjYTPHG67DDwFGDqGO/fARn26b/ZOcp9jkdjnOMA0cYZ6H/ZLbnDmcCsGYfI+WVCV2DqQsR/n8v4NF17fPur7vK4beHFNf3G/wV+3y2WpuQMZQQG3WuMsfnO4ubPMvAE3w7OOZeWGQfzt4Vdx+5JXpeWspcSSUmcON6FpQgV3hnKGmxxULeyr/tsbv843Uc4SaVbpWLWxzUZPps+uVl5KCBE3K3tYrzijtfqgfKO1comf+HKkZjrWv632gmPADPyBiIiIoipyGW5EtbCymfJCSakqBNwyEzoUGJi19TEAwJaZhwPrgoMJbcctQmasH6n1z+F/uu/H4Or16FUOQN5IAxAm1jdMPP/aDqzaMIjTj55rzxtm2bhtFLm8gT137gYAbB1wMtyyOf8befc2LLphVlTeJt8Ilc9wC26aEGaGm7yt0fG89LOc4eY8HsnkcPlvnrTHNWd2Nw5+w0xpm6bpvEqppLSKOdykDDcre1EqKS27ibKyPgHWKN+zGq4g5mRxuqNWvIbvw3qI7wmWlHqpIfypzi5ZrvBEy4HVaLxxxHFEeT7GWgQFOKt/f1JomOFGREQUO8xwo5bgZLg55YViwA0A3pTciOTEAJDuRP+MAwEE3yQpWgLtJ38Wj+T3h24q6B1YgS/3/g07G5uL+ynchOd1A1fe8jT++tCrWPLs69I2cnkDl/x8GS696XFkJgoBpm1ChptfAAYIDrhVWr5armmC+zUHNQeo9f5RvAkNapow6OpyKGYKiuGNHUPj0vis4yiOzxDKiO1yYjHDrcaAmx4QBKxV3OZwE+dSm8xggrOr5gVixG3m2DTBI4wMt6Ds1yBRzCZr7aYJIma4RUErzxlIRETUqhhwo5agFVMuxCBWQpjDDQCOTr8MAEjuexyURKFhgXWzd9PfX8I3bnpcCoooyTTuyB2FywffhUz3HmhXc/jPxD9hZjO+nSxfXjsgjenV152JxcezhXGJJaVBGW5KwLtSDEqlk5r/QnBKtQD/G1N34E4qFwp4XA0pw82aj8v1UgdG5O6uUqmosIHRYimwxS8DzzSF+cbsdZ2mCZV1KRX2oXsDAWGUVfoF3KJ802T4nMfJUHXTBGnlcMcAsKTUjxrCHG7VZlCacmQ1cqL8Xq6FnKks/sL7e5ocPOZERETxw4AbtQSrpFQMYokZbt1KBvslNwAAUm883s4iMwwT2ZyOxc9sxGubhvHaJrn7nmma2GxMw6ZD/xvb9S5MV0cw/q8bhAw35xvw1sFxad2X1vZL2wFcJaUBN/KVZLh1dyR9lwHc8+14v6G7Az/iDW9Qtls1/OaQs56zXtvAyIQc1AhoUDDiKj3VfYKJpml6ytPEOdwqydASx+IXTA3jRieuTROAyS0rtc5/xc0zynTlrWkMwoZYUuoV9BlVDbvcvNKAm8+6zdaIay8qpBgb53CLHB5+IiKieGDAjVqClc0kTsavqaodcHtz6lVoigl9+lyo03ZxAm4msGHbqLSOyLqhSrZ14lejxyFvqsi/+m8cNr4UgFNaCgDbBjPSuiuEjDcrYCF2KXU3DrAE3cyOjjvZXqUDbsIPPl/K3c0agjK5wshws0tKi/9O7ynMgZfNG1J5aNDccZ4MN7G5gpUJJWzfKSl1MtzE54PI89h5myaEcYPvm+FW91Ybxy9TcXL2a53XCvfZgKHJwWAG3BrB8AlslxLJAE8Ey1xDExBM5BxuzdNy1xgREdEUwIAbtYSE5i0p1VTFfv7w9OrCk3sdBcCZ9NswTazbMmKv4w1GFf5NJjW8lp+F348uAAAclv83jky9It0s7hiaELZjYOWGQWE7hUy6ESGApBumb5dTNaBea7uQQZfQgt+64o2p302RO7NOD+gQGvTlfvXGIXz75n9jlfD6AvdffH3Wc+mkhs62Qq+WfqGsVC4pdbY14gq45QPGZ5WS2udDkY9juZt6vyChHlDmWivfOdwifAflN6/d5Oy38G+lh0YOBoQ1BmdDfpmJU10oc7i5slLL8WvG0mziKIbHsvj2r/6NB57a0LTxhCnofSVmFsddXjdiNbem6TOXHhEREUUbA27UEuwMt+KXZwVOSeksdQh7JHZANxUk5x8JAFJJ6drNw/Z23F++7Qy3YoDrsex8JA59FwDgg52PYqeJtdLyVsDu1deHpG0Zpon+YqMA8V7Vbx63oPmRxOy4Ujep8n2Q6bkx8pSUSgG68lldP/rTM1i1YQjfvvmJsvu34ol2HExRMK2rkOU2IDROEBsUiPsVs/rcy8mBPXmsiqJIQYFyN4dS+aTuzbwJI97EDLcK91s8KrXdz4czTnHf+XyUz1JzBP1RoBrWXJN6hSfaDPwhGv6+bC1WbRzCzfesaPZQwiEF2fxKSid3OGEzTRPfuOlxfPWGZZP6+VaXRvx1gYiIiBqKATdqCdYcbrliAMu6IUwmVByQWgcAeDm/M9p6eqXfG4ac4ebO/rK+iKeSzltFPfg9eFHZG5pi4sTM37FP4nXM0bYBMLG5v1BWunnHmLQd3TDRX8yA22lae+D+xLG5iQG3UhlH7nmF3N/LPUHFEs0B/AJVI2M5z3NB69jzNFlzuKnAtK5Cw4qBYSfgFtQ0wZ3hJmYE+jU6sKiKXJpb7t5EPCLWPuRsugaVlEb4nql5c7jZt/Rll3Wfl9Ay3ITXy5JSrxAS3Kqfw01q6FL//sPQClleQeSOmMLzrs/0uMrrJtZvHcWW/gwy2Xz5FSLADHhMRERE0ZVo9gCIwmDNvTZRzDCzMt6Smoo3JtcDAF7Kz8ERxeWsYIxumtiwVQy4uUpKrQy3hBNw0w3gLhyPafmt2CUxgHN7/gEAeCq7J7Zuno/dZ3X5Bu6sDLfpPW3oH55ANm/4zuMWNIebWFJaOsNNvlFy3xi5X2NQ0wRrffdwOtoSGB0PvkHx624pzq3ml+EWVFI6minVNEEctzcoIo67bNMEn6CjHjCmWsW5S6nf8W0Up2StgmXL/Fz7GFhSWkqYTRMqDeaKi1U8v1+DRfjtWze/IFvhB5/nYiiKAdyqxHHMREREUxAz3KglWAE2K8PNynhrVyYwL7EFALCjZx97eSuLbOtABpkJJwCVy8mZVtYX8WRCs5/PGwYmDA2/GFmIMbRh1EhBNxUcmlqDPR67EvmNL3oCaYZpor+Y0dXXnUYqWdieX4Zb0PxIA8KcZ6UCSO4bJU9Jaa5EhptrWb/9dLYFN2yw9mmxmybYGW4KpnUXA27DWc9y7n2OFEtKezsLWXFBpafum3ZVUaRMwbIZbmIJoc9k7vVmc+iGEbuMkFIlu5Ox34oOV4MibtL1EKM5niZLCBWlTrl5pddWBAMkERlGw8nxtnpKvqMjinMCliOX9sZjzERERFMdA27UEqwAm5W9ZWVgvKVrMzTFxFBqFv77Qwvt5a3fDwpBrML6/llNmup0vdR1E7phYrMxDVfqH8P/G/ggrho6FZv1HqTzw8jcdSXaBl+VtiuWlBYCbsUmD74ZbuVfb8mSUtfv3MlJnqYJJUtKvdvvaCudGOs395c1hqAMNzmQ5qxvdSntsQJuQU0TPHO4Febxc48jeMxC8M5nDrd678eCJuaO8tRBzSoptTPcKikpdS0T1k0oM9xKC6dpQnUZbj5JVs0Xk0BNLYKOt/V8GEGqsfEclr2wGeNNKOk0InlBleZ3HoiIiCjaGHCjlmCVlFrBJE1TYZomZmx+FAAwc/+j0CFkZgXNk+ZudGAvr0AIuBn2TeJEzoAJBev0mfj+4DuxPv0GwMjjoHW34EOdS3F4ahU6lXGYBrBjuFAS2tedtjPm/AIxldx/Vto0waiypNS9Wb+yITHg5hcw9JvDzXpOVYQ53AJLSp31rYCbneFm+C/nnsMNUIqNE4Jfh0jOljM826y3fCq4E15075rEQO1kZrg510z5ZT3LhJbh5myIGW5eoZSU+mSSur28bgCb+wvzYUpzU0Yk2hCNUTSK//GupuS7nDsefhXX/vlZ/PPJye/sGlgyG2UxGSYRERE5OIcbtQRPSamqQN/4IozNKwEtgeT+b5OWVwNCzVaX0Ymcjm0DGft5RVGgaSqQN5A3TCHg5gScskjioZ7T8BHcjtTWV3FUeiWOSq/EhJnA+KoJ9A/tBqAQcEsngjPcKvnyXzLDTW4v59meO4BQummCd/spobx2aDSLmUITCCBgDrfihoK6lPo1KDBN054rrsenpFTOcJNfkxVPVRUFummWDWL6ZeWJ26w3myMo4Bbl+zwxW2xyM9wq35d70bBGKb5cZrh5TUbThIGRCVz+myexy8xOfOvTR0q/i8r7JirjaAQz4DHgfD7Xa3C08H9AuUY8jSB+vkU501jEDDciIqL4YYYbtQSrpHRCKCnNPn0HACD5xuOhdkyTlg/K0LAy5K6/7Xl89YbHnOVVBQlNyHAr3oRnXfOhjesJdLzry1g6/b34R+YAbMxPQ1rJo3fFbTgk8wgAYHp3mz2H20TOL8Ot/DfpknO4icEreG8mqikp9dtPXghEDY5lPb/3ncPNapqgigE3Z10xw83a/HhWt9fv9SkpFcfmHrdV8lZphpvfmEtl/lUrMOBW32YbqlTJbiNJk+OXfS+UDxDXQnwP5T3ZkxRGSalZfEsEXVvDYzmYAAaLgfkoZiRFZRyNIL3/dRMr1w8il3f+nBPGS3f/QWYyRfF6KksaZ0zGTERENMUxw41agjvDbbo2DH3DCwAUpA461bN8UMDNCoxs3D7qWd7aR143A28S87oBJZHCq8k34LFMD+7MHIrj217Ef3T8G8dpz2CZtnuxpFQt7s+b4VZJ+Z57//94fB22DGTw4ZP2dgUsvDcTfh1U7cdm+QCGmCE3NOoXcBO2bco3VKoCJIvz1+lGIftOURS5I2jxRsIqJ00mVLSlE8V1/OfY85vDrbA/BYBZ9obO8NnWZJSURvlGr1RAs5Hc5WulYjvewxfOOKWmCcxw8wgqya+GFboJurbczTPkCeOjQRyHguiMK2x53cB3fv0EjthvJ9/zUatmfvwZrs+ZOGC4jYiIKH6Y4UYtIWHP4VYIYB2krAQAaLu9CWr3TM/yQTeMVjAqMyFP4qyqQEIr7CNvGIE3iXlX5psJBQ+O74f+afshoRj4dNcDaM+8jnSJLqW1zOH2u/tfwf1PrMfazSOugIW3nNId5BODVe7AlWGaeHndAK79y7PYMVSYg04s//QPuMk3MmK3V0VVpGCnddOT9ykVtTqUdrYlkBAaVtjLlSh5tHZhZeKULykVtmU3TfAP7lVqw7ZRXP2n5VizaTi4LDHCd03NynDz64gYuGzDxuBsOXj+vakrjJJS0yeTVOQO1svldBF547gjbkVx6XpZit8xfuzFLfbzYXwkMMOtOvKYmzcO0T+fXI/lq7Y1exhERESRxYAbtQSrpLQQuDFxIF4GACT3Ptp3+cCmCcU51TwBN2sONzhdSn3XLwZWJqS52RQsn3EKtuudmKmNYPy2b2Gu/ioA/zncKgluiAE3cRuG6c3mct9MuAMIpedwM/HAUxvwxIqteGLF1sL4hODRoCvgZpreEIlhmk5JqeIKuBlWwM07X9popnAOutqTTsOKiruUFpa35uqrrmmCNxBQS4bXshc24+mV27DkuddjWVJa6rpoJL8J2oMXLvljzaSmCcxw8wilaUKZOdysU+AOvBV+WffuQyFeq+Ix0Vvgmgk6xNbzYQSpqmmQEjapuc/k774l7Bgax6/vfRm/+PtLzR4KERFRZDHgRi1BEwJoc7Tt6MMgkEghsddbfJcvNYdbLq9LGVcKCgGchB3UM0qUlJrF7ciBtAG9Hd8feidexR6AnsPxg7fhCz13YqeNiz03LtU2TbAaCwBAKql5/gruvqH1zuEW3BzANIGJbOG1WMFE8di4M9z8Rm4YplBSqkgNKwyfeZyszJeRjJXhlrSDnWJ2Xek53Ir/FtNOygWMTOGQ+HcpLbm6L+umO5834tk0QQxCTuJA3SXRumHgz4tX46U1/Z5lPeHdkIbJktLSQmmaUDyshk9jF+t5cTnx3EZlkntxGOIfcVpi3r8yEbcw53BrRgDVkP54E4/z5c5ebzbrD4t+fzgkIiKiAgbcqCVoQhTn4NQaAEBiz0OhJNt8l3d3KU3Zc6oZGJvQXcsqxX0U/nU3ShBZN+cTWXmZXN7AmNmGvyZOQ+INC6DCwJzEduy16R/IPX+ftGyp4FB7WvMsMyZm47ky3MRyTnssOXfAzQxc1jRNO3iYtwNuwXO4+d0E6IZT1qoGlJTqUoZb4d/RYkmplOGm+5d5ejLcYGW4KZ5l/ZTLcKvl5sYulzXMWM7h5p40ffL2KxUPYuX6Qdyx9DX86V+rfJZ1/dyAMeTy0T1HzRJG0wQpYO7zPrCC4GLXYuG3de8/DOKQxEPSCp1ty2W4hVEGagdVm3A+o1ieWU7U3gHWf5FRCYATERFFEQNu1BKsklLAxMGptQCAxF6HBS7vznBrbytMyp/L6xh3lZNaN5fWHG7u7DWR1VDAWkbMigMARUui7YT/xsN7/BfuzRwIAJh45HfIr3/e3kapG5meDm+3zrFiYKqwrnsOLO/23OMvNY+OYToZcVbWRumAm3fMhiF0KVXkTBD/OdwKj62mCR1tiYCS0uDj5MzhVn5Z97it4JLYjdWsYBtuYvOFSm/A12waRv/wRFX7aRQxe2wyS0rFXRmmmEXhPYZ+AeJQxiB1KY1/8CRsYZaUAv7Xl7vk1J35GDWGmCXbEhlu/q/BPwBa5y6acLiili1WkYhF3MK8FoiIiFoVA27UEqxJ9XfVBjBLG0YeGhJ7HBi4vHsOt45iF8xs3pAzxuBkw1n7mChRPuE0TSgs05ZytgsUsuQURcF45264M3MI1nYeCJgGMvf/f9B3rAcg37i5dXemiss4X3DFklLDMOGeA6vcHG5WYMjvptc0Tfu1WKWWYnBscCznWd5NnFdOVRU54GbN4WZ4M9ys/aQSmh1QDZrDzc0KktbUNMGnS2m5/flu0y6XNQJLbsRt9g9P4Bu/fBw/+uMz1e2oQfw6t04G6RoynfeDfwOFxoxLHELcAm63/msVvn3zv307IIclhCal0ueN3/Vl38zD+7lSy1k3A0pX62EGBA3jds34CcxwM+V/62Eds2YEbMQzFJcMrYjF20K9FoiIiFoVA27UEqw5vqxy0nWJPQPLSQFvhoYYcPNrmCDuwy/Txuo6mrPmcCsu05YqPl8MclnBplRSBaDg8d63Q91pPjAxirFbv4rM/T9BW3ZH4LitDDcxc03OcDPluWng16XUv2mCX6DPNJ3l7e6dws2klYXm7N+7Dd0w7XnZPE0TXMG1wj7ljDtVVeySYd2nuYIfaw9qhRlucklpYR/uAGS1JVTWvGelMtzEINLAyARME+gfiUiGW8B8eY0mlUTDCdb6DcH9VFjDFMcQt/LApc9twqoNQ1i/dbRh+winpNR57BdwkzMd3X9IqP5EX3Prs7j0pselOSvrJY6i1RptVFOGXyunIUbdm6qaHNiPScQoYmM2S3w2ExERUQEDbtQSNFVBEnkcky50J301uU/J5d0Zbk5JaamAmzWHmzdzJF0MrLlLStuLgTzrBswqjUwlCsuP6wra334+tDkHA6aJ/KplOHH99Tir65+Yo23z7KenI2k/tgJCUoabex42nww3T9MEV4ALkEsxreBh3qdpgl9XUzdDmMPN2q51TA07m8w7N5t1E66pStkupW5OSamV4Vb6jsBvPjh3EKDamwqxA2slTRPcgc1mkwMikxdAcN9TOgFhvywo18+hjUEIngScu6iy3kuNLAMOI8PNLJPhJpec1l9SunzVdqzdPILBEbkM3jBNXP2n5fj9P1+peptBgb+WaJoQIMwgi3ONTv7xiljsqiLRzXCLwmiIiIiiiQE3agmapuDo9CvoVsexTe/CmvS+JZd33zBaGW65vI5MQNOERDHLyq+k1MpkK3QwNewbLut5saQUsDLcCplwakcvOt5xITre/w1oexwIFQYOSK3HOd3/wCx1SJqMu6dYUgo4NysZIeBmGq4MIVfGm/UaRYZPgMmar84AhKYJxQBSma6mbu4upYBTpmt9Ufebm82e901VAkpKS2S4WftRKmuaIJWUWpl8riBTtRkdhvDaKgnaWAHNyewIWkpQudxk7tc0IWS4VTCGsOZwEzYTt+CJXSIe8nUkB+QbP4ebdP0VauN9f1epoEDR6o1DeHrlNtzz2LqqtxmkNTLcvMc4oamhBlmsTTQ7w20yM3jrEbVhWhnaURsXERFRlDDgRi1B07M4sf05AMD94wdA0bSSy3vmcGsrZI75l5QW96EFz+Fml47qhlRy2p52MufE/VoZbmLwS5sxBx2nfgH3zP4vrM7NQruaw6e6HkRPwlmmu8MJuOkVZLiZ8H4Z9mS46d4bdCswaBqmvbyVOZPPB9+oiDcxVsMIscxVUeVAmJgF5t6mLgbc7JLSyjLcVDvDDdJ+grjL19z7cr+2SoiBzKAMN3G7dsAtIgEeKetvUruUCo/LlZSGMLeX/xicLfmVlOZ1AzffswJPvbI1pD1W7p7H1uKR5zYF/r7UnIxu9z6+Djfc+UJFAQdxeyHE26TtlcteNAxTmnOr2vNsmk7xtvu11hNMDlo1Ku/hsCUTin0cQ8lws6N39W+r+n07j+MYMIrCmJ3TF4HBEBERRRQDbtQSOl66HdPUDLbrXXhsYr4dMAri6VKaLgbAct6AmxUkSpSYw81qjmCawHi2ECBT4Mzt5ikpLWa4TfgEYgYTM/CLkeMxaLRj18QAPtVxH1IozJXWK2a4+c3hJmSTWeNx32B6mia4M8qETqKGaSJnlZQapmf77kpD8SbGOl553fBkuCmqXOqZ9wmkWePRpAw3sfS0xJd8O5Ousgw3aQ43K/BVb0mpEEgrNQ+Ytd1cvvJAyWSQsv6aNYeb6TSfcF/HmYk81m8ZkVcOaZjSBPg+79GV6wfxwFMbcNvDr4azwwoNjWbx+3+uxM33rghcplQJrtst97+CJc9uwotr+ssuK27P/QeLWpSdw82dzVpHgEQuH5RX1nyauNS0YUHc5v3z4/fSCp/p4WVQNrNpgpRJG5OAUdTG6WQ7NnccREREUcaAG8Wevu01JFctBgD8fvQo5KHZDQ6CVNWlVLFKSoPncLMy3AAnAJZKavbNXM5TUqoFbsswgCGzA9cPvw1jRgpztc14f+djAIBuYQ43vww3053h5p7TDaWaJjgZZVbJWC5vSIEjd5mlJ8NI+Nk6JhM53R6D6spwGxrL4Xu/ewr9w06jAL8Mt4TPHG6l7o1LzeG2bTCDPz24Stqn3xxu+TqbJogZblaQ1i8zyLqJsoKy7gnim0HMCAImLwjod70GZbj9342P4Xu3PN2gcTiP/YInVtZnqczFRrA+L0rt156DsIprqJLXIb73JqekVFzWXWpc5XvRFcQVif8XVFsKGjQKvRUCbj7PJTTV/twNM8OtOSWl/o8jrUTguBnqbWRCREQ0FTDgRrGXW/koFJh4OjsHK/K7AvBmsLl5upQWS0rzenDArZKSUsAJgKWSqn0z5y0pVaXnRdYX1w36dPx85ASYAI5Kr8IhydfQlVY95Zhyl1KfkinXz+4gn3vOJ1VV7ZJMMZtP103PfFalssCsctrxCV3KnhP/ferlrZ7sGrN4c20F97TAktLgL/j2XHE+XUr/+cQG3PXoGjzw1Ab7OSmjyaeRg/u1VUJqmlDcVnsxE9Jvu+LNvl/Gz2Ryv9bJGo97L2I5sju7Y9vguM/64YyzXMdJv3kPJ4MToPDfb+F9YwXQS29LKv+uIGNN3Ge5z9dKiO+5sk0TTLnbcvUZbvK2RJoUcKt2w/5Px23eP3/e15BMqPbTYQRYmts0IfiaiKqojdI9fQURERF5MeBGsaevXQ4AeCo7137OCo4FcWe4dbY5gZCh0axrWWubxZJSnyBZKqnB2uKYFXBLaPaNaVUZbsK32FX52XhCORAA8Mnuxei+92vYNTFQWM7KcJtwz+EmZ3OUKyl1AkOFfxOak+EmBhfzhn9ppLtJA1DI5LKCkONZ3adpQunzYwrjUpWgktKSm5D2J96sD2cK53dAzHATbhecpgl1ZrgVFy/M4WZ1rQ2eW1A8L80OuIU5z1U1PDfxwvVbyRjCum8Wt+NXUlrNPGlhsvZrBaXd3POelSJeb+VK8MV9A+HM4VauKYf0OWaYqOeWXp6jUf6dlOFWZTfeoM+E1mia4H0uqanORPkh7qMZ8a44Zri5/29vNvH/TWa4ERER+WPAjWLNGNoKY2AjTEXFitwu9vPVz+FWIuBml5QW513LeoNkSU1Fopi1NmqXlAoZbvYcboVlkong4J375vNf5hF4cmJPTJgJKJlBfKLzAfQqY3YG1pjYNMGovaTUel3t6YSdGTYuvFZdN30nA5cmPy8+VBXFntduPJsXsufkktKgTBAxU6eQ4VZcvsIupfZccVbTBGFZ6zUNjTnn2S9QUfccbnamnNM0QbzOnO0WlhODmZUEcjb3j0nZjfV6dvV2XPHbJ7Glf6x5GW7eeFuoJWyVEq+XnN81b/pfI40mZXn5/F4v0UHYTbzeypXgA+451couXtX2/DPc5Md+jU0qVWnpW1jNDloi4ObznKYp9i/CCDY72auTz+8PRXEShRHHMWhJREQ02Rhwo1jLrytktymz5iNjpu3ny2VQqa4rPy3MtyYGYsRtWVlW2bw34KZpit2V0ykpdbaZDygp9WvA4L75HM1r+OXo8bh04H1QOqdjljqEb/T9CckHroKZz8oBN6EED5AzxcTnRNbN4Xi2sJ22VMLOcBMz8PK64Xsj6Xcz685wsya+d2e4Wdub3deOL5x5iLAdeU456ziKN8SVzOFm7c/0CbgNC+dZvvmXu7L6LVMJqWlCyYAb7OWcMZTe17bBDL58/aO4+PpHqxpTKVf94Rm8tHYAv7pnhecGdPICbu4gp1BSWsEdXXgZbs6G/K556xqZ7Aw3s0zAWZrjsMzYxM+eSjLW5M+VEIItZQJo7gy4eoIiYuKa5/NQ+LHaudeChtQSJaUBGW5OADyMa6Dy93bYSs3rF1XyOJs/aM7hRkREVB4DbhRr+deeBABoexwkPV9thltCU+2ss8GRgAw3K+DmEyRLaKrdldPKOkonnPnWxGwta/nC834BLPnnA+fPQGdbAnPm7IL2k8/DFmMaDBPQtr2CzNLfYh+8ire2vYCF6ReRHNzg6r5W/ouwdXNoBaLa2xL2DbhUUqqbdvAhIZTsii/B2pWiKL4lpU4gzNpmYeXdZnVh3i49wjZdGW728arupt9umiCM0QosDo852WFSR87ADLcqA27Cduw53PwCbsV/81WUlK7ZNAwAGMnkpIBrGEbH897GBZMUWHK/HcSS6MqGEM44y5VmNnsON8A/SCBnm5bJcBP+cFDJ+ZXee2FkuInvuRJZhPbjejLcEDx2Kbha5fkMWro1Mty8r07uUlr/PqLTNCEewSJxlFEYMjPcpp5cXsfDy1+Xmk4REVFp3rs/opgwBjdD3/A8AAWJeYcDeMH+XdmAm+oOuClIJlSMZ3XPTbR1E2aXlPrMu5bQFDuIJma4uffjDrjl9ULmhtj1z30z2dmWwA/OOwYJTYWiKLgmdwZ2zb6Kz3TfD/2lB/HpbmHhJx/HIYmj8TLeAKCYIRTwRVhVFBimKWS4FQNuqYQdKJRLSg37xjiZ0JDX857xyhluQkmpkK1W+L2c4aYqchA0MMOtwjncnEw6eVziawoqKQ2aw63aGwo7cKcbdjDNL+D2l8WrsWnHGPbYqUsYQ+kb9jZhO69uGsL+c6dXN7hS205qnmtwsgJLvplO1WS4hTWOMoGroKBso3k6e7qmBBQDRuXGJpaWV/Iy5JLSELKbfLJKRaaYleb+HKty96XOpzRfX9WBMv+BtELAze+lJRKqMO9aiNdAE6I1UZsPrSKuP6Y1WyyPIdXl3yu24sa7XsRxB+2CT562X7OHQ0QUC8xwo9jKvvBPAIA25yAkp822g1iAM1daEHcgLJlQ7TJPNytYUqpLaUJVkXRluIklpe79ihlinsn5XT+rioJkQrODVJqq4KXcbhif91YAwMb8NDwxMRcvZgsdWo/KP4pdtR2Flc3gGyMro8+6ObReV3s6oKRUyNRKJZ1jJQUBiv8GZ7i5S0qdoJp4ygzThG4KGW4+JaWlbvis2J1il5Q6vxuf0IuvzbDnrZOybQImxK913ijdMO25+vwCbvc+vg7LV23Hky9vdfZVJgIiZsOt3jhU1bjKSac0z7GtN8NtIqfjz4tX47VNpcfql31k7bqSIYRx02eapieTxFvqWhzTZAfcfLJJ5d+bvo/9ZKWAW3Mz3HyzCN0lpXVM0F4qE8evYUot2xW1Qkmp3ytw/1Gk7n00L94W+wy3KETcxLByXDq9Un1GM4Xvt2Fn1hMRtTIG3CiWzGwGuRWLAQCp/d8GRVHwxjnT7N+XncPNt6TUv4Oku+GBX0mppil20wTri0g6qUJxvcM0ez445xfubAj3F1dP0K7448ib/gNb3nElLh96N341uhDXjbwNQ9PfBA0GPtb5MFLIFSedLxdwK/x+vNjttC2t2QGr8Zx/hpsYnNR9Ml9UaQ63vNBMwfrXleGmKlKWnzh3l+oqKbX2UXoOt1JNE5wvilaWm7itoPm5qr0ps45L3jCdDLdUcJdSscS1XHaSeEO/esNgVeMqJ53UPMe23sDSc6u3446lr+G2h14tuZy7jE0sKZ2sm2K/3bifikSGm1/mnTjHYRUZbmYFryPsDDcpq9Rne/JrhXQSqt17qbmm6slwCzoMfhl7ceP/PjBDfT82s2mCNEdgE/ZfE+k90PwAV1wClRQe+49NPPdERBVjwI1iKfvcP4BsBkrvztB2PwAAcMjeM+3fJ8oE3AA56JbQyme4OXO4+ZWUqk7ThAlv0wR7nz4Zbu5sCE+GW8A2dBMYk/7IqGDDvP/AKNqxa2IAZ3Y+Ahh64E2hO8Nt3CfDTezIKs7hlkxosEZl+mS+KBC7lOqeklJ3hpumKNLE7YbpHAcxw63wu/I3fEFNE0zTlMpkrSCXew43w/TezlT7/dLuZKkbdtC2zSfDzZKZcE5m+YCbkOH2+lDdNz7il2e/DLd8nQEE65j7deWVxuET5HSaJpTfTyXH4Y8PrsSdj7wWPAa/4E9AFurkZ7iVDnrpUpCqXIabEEyvcg63MJTLcJMykAwTcul6tfvy36/756oDbgFBD3cn6HgKiDxbN9wh7KG5TROcx3EJHEUtww0xPIZUHwbaiIiqx4AbxY6ZHUN2+d0AgPRb3gOlmEZ2yBucgNtoBenuYoAnmVCRFMokxeCbneFWzLLy+7qhqYpQUloMuCU0TyadneGmqvb+Pd0wXTvwBu0K+zEMOXgEALlkF27XToFuKnhL+jV8IHcr+l68Fe/vWIaT2p5FGs68ZdZrtAJM9hxu6YSdiSY1TTAMO/CSUBU7aOZ34+LuUmp9SbPnVnM1TVB8Mtz0gICblcVT6nufk+EmjzGvG1LgwMpwc8/hVq7ErRJWjErXTadLaYkMN3Fc1QTchsdy2DY4XtXY3MaFYF9bUgu9aUKlN9becj85WFpOuSW2DGTw90fX4tZ/rQ7cnt/zQV1bDbO+7pnVkrJyfHZbTUlprsqSUk/GWZ2MMte7/FrNukoAS841JWa4VfvCAjPc4n9T6pvhJvwhItwupXVvqmpxnH/M3RCp2eRAdvPGQZOnmWXgRERxxYAbxU72hQeB7BjUvl2RmHek/fz0njb7cf9I+Q5K4g1fQlOQEkpK29ucTCQ7w61E1pzYpXTUnsNNDWyaYK0D+GS4ub7JKAFBO90wveWohon1yq64efRYZIwkdjG3oHfDUixsW4F3dTyFz/f+HTPVwjxaSbEsVDftbDYpw00qKTWdjLRiAwdrn87YnTFb2VzjE3mn1NTKcCuu65TrKiWbJvjNeVdZhhukZTOuAOXwqFVSKtz8u4Io1r6rvaEQy6VKzeFWat0gOdd53zFUX8BNDFArxWYa1YynnErnPPOU+8E57hUNocwyYmAxaFH/QJb758qDo2Eqm+Gmi0G00tuSAm6e7rAmrvjtk/jhH59xSrjDbpog3qz7BrjFx9559araV4mxy8H2cEpKW6Fpgt9rk/+4EsI+DGtbk3/3Hsc53ERRGHIcjxvVp5o/gBERUQEDbhQrpmki/8rDAIDkgadAcTVH+O93vQmzprXhtKPmlN+W8Lgwh5uzrXm79HiWE5syuPnN4VaqpLSwvWJZpeENmknb9szhZgWATM8k34Vufiaeyu6F7w6+B0vUI7B9z5NwT+ZADBjt2FkbxGe670OHMiHNWZfXDXtus7aUkOEmlZQaUnmtdej9upSq7gw3Qx67YjdBMOTnhTnX5Aw375xxJTPcrH9dQUF3RuBwxqekVDelIIqd2VhthpuwvHhsK1GuhLPayd3LESdA1g3Dc2zrDSrZJZjllnNnuEklpeFl1BQ2GLBMBdmN4hxdk1lWWi7gUU2WpDgXpfvYjo7n8dLaASxftd0OsktzNVYz6ABmmbFKGW5Gfdk90uTuJZqhVNvsIKikNJ+P/82o32srNRdeLewMt7q3VL1y2aJRJB/y5g9aHAFLDaeGZr5niYjiqrK7P6KIMLavhdG/EdASSM473PP7o/bfGUftv3PV29VURQq4vXHPPjz1yjZ5Ga1MhlsxiGRljqQTqudGUgwcFR7rUsdJoPwcblYAzjBMb7DOdL6UD5odeFQ9DLPmzsVdTz2Hpdk34rNdf8dMbQRf6b0NalbDc50744HxNxUDbsUMtzb/DLe87uwvoalS4M9iz+Hm6lIqBuIK/1rHypv5phfLx8QMN1VVoKDwJc8K0pX6gq+4SletRcUMJwAYGvUpKTUMKeMnoSqYQOkAnx/xPFrBjbZ0cElp0Lp+3HNE1XvDaHXWtfYddpfSyktK3RE3Z91KbujKLSGeV8M0ocL7nvbP7Ak+HpOa4VZmjjZxLNVkSXoDit79hJ/hVnqshnsMNWQkPfjUBtzz2Fp85O37ONtyLSNuK6ymCfXOeRgJZTLcwrjsK/njSaPEfQ63KAw5jmW5VJ+4BKeJiKKEGW4UK7lXlgIAEnseCiXVEdp2FUUuadxvzz7PMqmALqZAMeDmarqQSmplSkrlxgGWsl1KhZJST4abK1hiwvkinNG6cMPICZgwE+hWx9FpjuLI9Cp8rvtu5Lets4Nr7SmnS6lUUmo4XUqlgJvPjXhhDjeraULefk1WZpsVd7QyhVTXnGumadoTwGuK1dnVed1A6S/41vit/Vn792S4WV1KXY0fxBtmK8Ot2qCTX0CkLRlOwM0dGKj3hnFMCETmXRPUAyFmuJWJQ7j3awrPVfQSyyxUycT7lTRN8AtITQb3dVrq9+XGlcsFN03wmwtOD/nmWirjLtc0wXQ1TahwH0+s2ILN/RmsWDvgrOtpzOE8DitztCVKSn2ek85BCHfezSxPi2ewKFoDlY5bfA4i1cHpEs/zTURUKWa4UWyYho78ykcBAMm9jw59++u3jtiPd5vZ6fl9W4kJ7xNC0wRLMqF65tpS/eZw85SUytsuleHmbbhgegJg1hejhKpgY7YP3x98J2Zpw9h5p2k4aOQhzNW2wnzgh9hPPxjZRAc6kLEDYGJJqWk6c5EVSkr9Am6Ff90Zbna2mqJI/1qZWpoqZ6QZhilluBWWUZHXdXti85JzuEHeT1DAbcjuUiqvL2YdWmMLKh8L4hc0S5e4hqT9Vx1wq3xcfqSSUt30bK/ugFtx9aqbJpimPc+T9bN7TkNp+XLjqCBLy+9598uXgkUhl/eW4le+Laomwy2bDy6L9cvgKxfsq1a5Bg/uDLha5tyyNisHSOVlxB+rDZQF3XRWW5oaF2GXYYrzXE62Wq6nZpPH3LxxOGMI93qg6LM/q3m+iYgqxoAbxYa+4QWYmUEo6S5oux8Y+vbFL7B+N/WlgiWa0DTB0tGW8AR4/JomuG/Y3V/+gzLcCiWlrnXdN6Zwbgqt/W0xerHF6AWSfXh64u34dOpO7IoBLMTDWNgDmPfch3cre+KB5J7YkJsnbd+ai0zTVN8upU43UidAmc0b9g2ou6TUuhEuNpp15lwTfmeV4drNIoo3xZU1TbAy5uTxW+wMN9e3x5wwt5x7G5XyC1KlQ8pwcwdy671hFJsmWPMABo3nlfUDmDacxazuVOD21m0ZwQ13voD3LZyHg+bPFOZhKz0Ovwnt3VlpJeJtZbcvBY2ClpE+Bwrb9JbYOo8nt2mC8DjMgJs7o9Gn3FOawy2UklJhf2Uy3Aq/dn2wVbIP32Bh8OdtWF1K457hFnR+xeuv2j9A+O+n9P4aKZ4Zbo4wjn/dY4hh0JLq08z3LBFRXLGklGLDLiedfyQULfxY8aJ37Is5O3Xh4o+82ff3JTPchKYJls62pCdY5l9S6s1SE6mK/zZ8u5T6BCisDKGEaw46RVGQ09rxg6HTMHbwB/GauQu26t1QTAPzjVfx6e4H8UntdkxTR+11rIy3pKZI2Wji/qxtiw0CMsWSRaekVM5wczdNECfLtzPcXCWlpe6NFdf23BluvV2FYNGwleHm2pg9LtW7jUr5fSHt605j/m492GuXbp/Zwxzlsqa8zTKqGpqHWFKq68FNE3J5HZf/5kl89fqlJQM6N971ItZuHsEP/7gcQOVlKH4ZbtWUSZZTLkNMfF4MtpbKAJvMpgnlMkqqOVZiFqd70cnOcCvbNME0a5o/zDoG4vvFU7Ys/Fj1HG4Bz09m1mMjBI0+7CCVFdhtxr17ufkQoyhqwxSHE7WxUWNYgV6ebiKiyjHDjWLBzI0j/9oTAIDk3gsaso995/Th6586wv45oSlSaVCp7KSEpnoCWp3tSU85qPizNTeYZw63Mk0TpAw3n+w4dyc562ZCc2XgKYqCpKZgCAmMzTkKP32kE6PjeVx71r5YdtufsF/2OczRtuIrvbdh2cR8vJrfCfnMTHtbqmt+NGt/hW0XSmo1VYFumHZAxy4ptYOG7pJSJ5tM7FIq/mvdzJb6C6s7k87JcCsE3KZ3pzE4krUz3tw38E7ATchwqzJpxb1NpfgavvLRt8AEcPb3HgzMjrKeH8/moSiK59oLO8NNbJqg+zVNEAKW2ZyBbM5AXjc8wWBLUBC53DhLzeFWWL/066hm+0GLWu8/RSmcf73MnHb6JN5pVlNSWrZLad7Jvq0koChnB4aR3VQ6aOmeL0x+vZXt39qGWLbvF9S1VB0oa9EMt8AOvhUErKvaTYWfC40QxwCRWUOWZyPJ88VGYEDUcNZHaRzfP0REzcIMN4qF3CuPAPkslN7ZUHeaPyn7dJeIlspw0zTvHG5dbYnA7LTC9v0z3LydTYMz3HRPl1LTE+hxl5RaFEUM+jldSjt23hOPpI7F94ZOx2v5mUgreSxsW4FFXQ/huHU/wy5af0VdSgHnmFlzhHnncDOln+1sMsO0j4M4h5t4fEp+4fPZHuB0KZ3WlS7+rHuClIVxOZl37sYLlXKfx0RChaIongYd/usWAlr/72fL8PVfPO4Zn7uzbb1ffqUMN8N7DfllOemGieGxrO9x6emQy00rLSn1xF1M/5LlWlWSpWU9LwZbPe+pJmW4lRu/+HlQ7liJJaWlmiZYAUW9gmNXjXJNE9zn3Qz4Xcl9FF+iGEjzBpOdx1XP4RYQZIh7wC0oeCKXNAvLmyaeXrkNWwYyVe2n0s+FRohjhlvE4m2Rm1OOGq+ZQXIiorhiwI0izzQN5J67FwCQetPbSk6aHqakT9fRIAnVbw43n5JSYZmE6gS7RO4vMp4MNyHQ5delVL6RcL4IuzPwVEWxxzye1e2b3rZ0AoqiYIfRjauGTsX/N3QSlo7vje16Fzr0YXyu+2705bf6Zn7Z3UjtgFshidbOcFOtfRf+teZjs16j2KU0uKS08jncxO1ZrxNwAm4mCp1Y3TdcYjMHa6zVfsF0B2LcAdlSl7FRzArsH57A5h1jnkzG0LuUjssBN/f2rPMkBkZe3TiEz139MH5867Oe7XV3JKWfrdXKl5R6M+sqaXTg/L7kryuag8q5hp3r1V1yLGa1uRuXNFK5DCPpWJUZVr7UHG7lMtzCCLiVmY/OlMbg2meF+7eOkRyI9CxlP6o6UBaY4Rbvm9HgYLT/9bduywiu/tNy3HjHC1XtJzpNE5owgBpEbZhB1wO1Lp5mIqLqMeBGkaevfw7GwOtAsg3JfY+btP0e8cbZAIBdix1LEz6NESzuOdzSSQ3JhGo3A7CImU3W8uXm4wrqUho0h5t8Yyp0KfUJ+FhBuJGMU1LYntLg7FLBivyu+P3YAnxv6J3YnNgV7WoOR2z+IzrV8eI+vV+6rfXb0oUgZSagpNRaU7VLSu1hly0pLXVrrMK1n+KOrBLS7o6kHfAaz+qeL5FWwM3KSCu8zhI79OEOuLnn+CsVONYNOZjqPs+eMuR6M9zEpgmGt0up38T59zy+FgDw9Mptnu11CxluEzmnS225cfp9ma+qpLT0ryvalu8cbu5AoBGcHdZIUpDKZ7/VlZQKZZbuDDef7DMpwy2EW//yGW5yBlItN/f2HG4lgrblmjeUErR03DPcggQFfIeL/38MC/+PVMLaRPObJsQkiuAaZrPHLQUtmzcMmkTWZ8Ak/rdHRBR7DLhR5GWfLWS3JfddCCXVPmn7/c8T5uNTp+2HL37oUPs5sazU3XFUzCDrbE8Ul5HfYtI6akDThDIlpXaJo1B2Ka4rz6siZLi5tyNkuFkBt2RChaapvsGgjJnGXW3vwla9Gx35Qbwf90CD7ltq5i4ptTiBNf+sPbF805Ph5ikpLfGNz85wg709wMlwa08n7Oy7QsBN3pY1v5WmKlIjh2q4gzRJd9OKEusWAm7BQZ3QM9xcTRPc16CV0SU+n04EZ3yKc84Njjplp+Uz1EzXz3IwqPzrLP37SpoKGMI1bAdb3ccjxEYO1SgXMKxmXNIcbgEBVvFxNYHPSpQryxX34Q4Cl9r96HgOdyx9DdsGMr4lpd6mCfVkuPmPJO4Bt6DzK5eRio9ruwmvaHqABolnhpvr2m3SOCxhfyZQ9NnnnCeciKhiDLhRpOn9G6Cvfw6AgtQBJ03qvlNJDccetAt6O51sHTGQIJaYapoiZZB1thVK6jxzuGlykA4A8iWyS4BqM9y8JXjWz96mCc4YRosBNytAFpR9NZhL4qfDJyKnprEHNuGDnY9K2T5i04TC9uS+LO7Amvs1+jZNUIJKSn2HKO0/qGlCW0qzX2tmIh+Y4SY1Tag2w821QsIdoCoRcdNdwVR3wM3TNKG6oXmMik0TTNNzY2ddQ+K1mkwG//chBjGGRioPuHmbJnhLpOshHceyGW5OxmWpgNSkZriVmXfKL4j1wms78Jt7X0Y2p0vL5nLVlZSWyhKrRaMy3B59fjP+vHg17n5srVBSKqzrioWJm6q2FDTo1Me9pDTozREU/LYnUq82Q9D6XGhC6CiOc7h5hhmhYTc7244mhx1va+4wiIhihQE3irTcc/8AACTmvhlqz04N2Yc7g6wUMWMrJQQcNFWV5ujqbCsEmlR3SanUpbSyDLegbDDD8JnDzTQ9f7m3vgi756QrZLjJJaVWgCzokEzkdGwxevHSnP+EAQVHpleh+7UHnP1b24aT4abCwIltz2H/5Do7kOfevnUOxIw0d4ZbwlVSWrpLqXd7gFNS2pZK2OdyPOszh5s1t5xSR4abZw43d4Zb8HVnGKYU3HLPE+ZtmlDf19+MOIeb7i0p9WuakBICiEFdSQFgYGTCDnIYZRJ/3Ps1zeqaJpQ7DLpPcNjN6VLqNMzwzGnXpKYJcsDD+3u/DLe/Pfwq7n9yPV5c0y8tKwZtS3Yp9cludO975YZBrN8yUuGrQLFRif/+/Pbh+VwrsW0rWzMz4byv8yWaSUhdSqs+l1Mtw80/+O1kuFUbsGSGWz2a3RmUGW5TTzPfs0REcZUovwhRc5i5CeReWQoASB5wcsP2484gK0UMuIkldQl3hlt7IcPN0zRBnMNN82+a4L7nC+5SatjrphIqsnkDpuH9Em5tz70dVchwGymT4aagcGs5UQxYDU/bBw9qx+JE/SFMe+VOZMztMMcGMDOfwJ7a7phj7kDu5Sz2zm/Gfp3P4/D0agDA1o29MOef5mS0wYAB1Q7AiXNmWV/sPHO4VTgfmLg964YwI2W4WSWlec+2nAw3CHO4VRtwk3/2m0MviK4bUpDNnQXpncOt+m+/WwcyWLVhEG/ZdydpPi934w3AP+AmBnBHx/NSJqj42qWS0nIlnz4lpX6BnqBgWbmjIJcW+i9jbVruUur/nnJvs9HKBR/9siKtc5tzBWmzuRIBN58gVFCGW2Yijyt++yQ62pL44WePreh1uIfuF3CTbuYN+dyWutydzpdO0L50SanzuNpAWdA4Yh9wC3o+ICus1iozs4k373Gcw83vDxLN5FdWTK3NyXDj+SYiqhQDbhRZ+bVPA/kslJ6doO2yb8P2U03ALZ3yLylNaCoSCWEOt4CSUnFfTsCtdPDE06XUnufMuQlOFgNuhcwwZ1lTKMXyBnyUEiWl8utuSyeQmcjbJZkJTcVy7SBgZDtObH8B+ZWPAAA6AHy+91nAAMYfBBYAQNrZzqxX/oqRlbfj6LZ9cHj3DsxNbMW/xt8IzZwr7Ve8QXa6lFoluOW7lDoZbvIcXH4lpX5zuOXtgJsqBF0Cd+dhmt6glbdpQvD6uukqKfU0TXBnuFU+Nstv/vEylq/ajs+l5f8G9BJNE/IBzQLGxnNywE3YwOBoVgiClB6T54bSVVJa9ga9bIZb+QMldSm1rx/XMuK5mcQbzXKdQsXrxLQD01awU5aT5nArkeHmE2wVl85M5JHXTQyPZit6DX778zsv7uBOpQESK4tRDNr7zTNp/yyuW23ALeD52JeUBma4CYv4BH+rDfxbh7spTRPExzE5XVEOcsTlGFJ9mhkkJyKKK5aUUmTlVz0GAEjOO6JkR8d6uYNipYhzuKWFktKEpsglpe1WSWmpOdysEsnqmiZYPxuGad/YWcEcz40pnC9GCXdJo9Sl1Cm1LPxOXraj2G10ImcF3BSomoLbModh3SGfQXLfhUgd8Z8Ynbk/8qaKHZgGbfcDMJjeBWNGCr8eOQZ/zxwEPdkBmDr2zLyINyQ3I6EYeFv7C9jv+Wuh71hv71cMKAV1KS31hc+Zww3SsmJJaXvaaZrgPuZWVpA4j1c1N4V+iyY9HW5LdCnV5XLhoKYJ7gy+agyPZYv/yp0F84bpOR5+GW5ixtRoJi8tL45ncGTCtyzRj+d1BGS4Bd3Yl7shrWQeMjvDTVHskvBKAlKTodz4/QKBVrAw6BoHSgfAnAw3/3JcMaBXcfdQz/XlDXRJHVlNs+IAiZiRZzdNKFFKLDdN8P7uiRVbsWUg47uvoNfr93riJOh95J4f1P241rL7Zty8B3VcjbSIZbjFcR48qk8z37NERHHFDDeKJDObQX7dcgBAYt7hDd1X7XO4iR1LVSmDrKstoKS0kgy3cnO4+TRNSBUDbqbhzUKwvgirqmKXhgKFOcS8c7hpxX3Kr7sQnJpwAnyak/k11rMX2o44EgCwqetIXPOnZzB3l1589bTDcN/Dr+KvD79qb+dN7/o49usZwUt3/wHrd+Twcn5nvKf9CfSNb8fYrV/FmcruuE07QDommqrAHB/BLsZGvAytui6lQtdTAPbE8Wkxw61M0wQlIMupFL+bD88ceqXWdzXEcJct5oo/J5MqJrJ6TV9+rW26gwOGYXiOrV+Wk5ghJTZdAORrcHA0i+k9bQDK39i6r33T9C9bqjnDTQ8OMrmfV6UMt/IBqckQVNJnj0X8vet94j72OamMWN6O4bOdoOw69+NK/n5RSUmpHNBx/Vxi2+J47TncSpQSi6/VnTn62qZhXPuXZ/HGOdPwpQ+/2eeF+I8h7hluQe8v9zmxWMe02rdCM5sm+I0/6nzeJU0YhbD3mBw3Co9zznnyiYgqFbmA26pVq/Ctb30LTz31FDo7O/Ge97wHF1xwAVKpVMn1TjzxRGzYsMHz/PLly5FOp33WoCjLr3kK0HNQemdDnTGnofuqrqTUectYQa5CJowilQxac7i5M8XE4Flg0wTXt9hSGW7Wzb41gb1f6ZXTdbEwTmsdVXHKNEfGS8/h1u4qO9Q0xRmHe39Q7ICdGJQECiWa2sy5eGLmu/Hg+o0AgJdzu+Diec+ip/9FzMc6fL53HYaXb8AhyWkwoUB/6q+YeOE+nJ7N4B19KjZt2AEc/KGSX/at46xCLgd1AoaK06XUp6TUCkZoNTZN8AvCVDOHW96QS0rzroiIVfKa1FRMwNv0oZoxusfqV1JqLZOXAm5Chps74CYsNziSRV934TO43I1tuZLSoG6nViC53FEoVVro3odSfL/47U/szDuZGW7lJimX5ipznV9PY5ASGW5+XViDjp37/KglQ8n++/MvKZXH4xd49SNmwNqT+ZfKDBR+dI/D+kPEcEa+vn1WleTzhaB1IzOzm8GvUYL4uOoMtyaWp8Umq03kvnSb/RLKfB5R63EapDR5IEREMRKpgNvg4CAWLVqEuXPn4pprrsHmzZtx2WWXYXx8HF/72tfKrn/KKafgU5/6lPRcuUAdRVOuOCdYcv5RDb9pqSrDLenNcLOyxPy6lHqCZcIyiWK9mniTLHbvm9GTxuBoFr1d8jWsigG3YrBOLCmVbsrh3GwqroCb2KV0IutkfhX24ewvoSme7KyEqnrmRyuMH/a2AW9Wlz23mnBcRs02rN//Ezh8N+DR39+IA7EC3VuX45Pdhd/nny78m1VSSCGL3dffg5FnZ8MwOxDEumQU1RqXleniBKpKNk0oLqcIE+dX8/3SLwjj1yW21Ppi5pk7w80KwKWSKpCp7WbHCp65s3EKATf/AEylJaXyHG4TMIwuAOVvcr3lfq7yTdN5XqQoivTeCSIGDIMWtTqqFjrURivDrWTgCP7Hyi+oYZomsuIcbiVen+ETsBMzksqNyfd1lAjw+S3j7lJa6s1ol9Kapn0MSs7hJvzsnRvRe90HrSs9X9y/FtOAm/i6OtsSGC12MZYzLCE8rj5wJr5fm1JSasjXVxy4MwGbPWq/a4Bam32eebqJiCoWqYDbLbfcgtHRUfz4xz/GtGnTAAC6ruPSSy/F2WefjdmzZ5dcf+bMmTjkkEMaP1BqKGNsEPr65wEAyTcsaPj+qoi3SU0TrPncrCCaOD+b3TShZElp4XFOnOhc+BLzxQ+/GSqA7g454KZJJaWFFaxsO3cmCExhTipVkcajKN6sq3afOdxSCc2zXCKhCs0bvDfc1uqppCvgZnUnVbzHRe3dCXdrJ+KuHfvg0/tsxfCGlTChYO83zkdi9wNxy0s96Hv1XpzS/izMR36FE4wD8HscDB1yFh1QKJcV92OYhQCWNVRNU9GeDm6akCuWnmpqbRlufsu659ArRTcMeQ43d9MEK8OtmNlYS7aGtU33tnXdhPWMVgzQ5u1lnf1kS2S4mcKd2PBYTphUvfSY3FW77uYTphBMESl2rXTpHUhNBcqUlCrC/H2eMkThiRdf24FbH1yFj759Hxwwb0bJ/ddLvsH1/j7vFyjzCZa6sxir71IK38eVll17Anw+50IK7riCwKVu7qWSUjuoXFlHVm8DG/lfr+Bx5HUTnmkbY8N5Xd89ewGefmUbbrzrxcB5z6wgdTXZntI11OSS0rjEijzDbPK4Y5klSHVxguQ890RElYrU18HFixdjwYIFdrANAE499VQYhoElS5Y0b2A0qfKrHwNMA+qseVCn7dzw/VVVUipluBXePr4Zbu0VdClNWBlu/qVdXW0JzJzW7h2vkHVjZzoJATeRGLBQFEgZF2KXUvv1+ZSUJpOqJ1MvoSm+HRzdGW5pd0mp4h9wU4TnN+p9WDf33bhq6DT8ePQ0tJ/4P0jucwxUTcNdmUPwQOZNAIAj1efwoc5H4HfX4TRNsEoC5ZvpQkmp0zTBE3ATmhIEZTmV4pf15G6aUOqy0w1TCp54mybIgdZavvv6lYkCxeBG8TkrKy9vz/fmLCuXlLoz3OT9WNdItRluhee8j93LOaWfJTdfUUmpXYItZje6SyCFnx98eiO2DGTwgz88U3rnISiXleP3e2eeLId47vy25bedoEy2WiZOLxXA9N9u5de4WEJrjdOdRSwSf3QHn+1jV2WGG+DNlosT8WW1pTTs1Ff4f8jvsx4QrrUqIkDlyqMbrdKut5Fiun9s7rj9rgFqbUFdr4mIKFikAm6rV6/GvHnzpOd6enowa9YsrF69uuz6t99+Ow444AAceuihOOuss7BixYpGDZUaKPdKsZx078ZntwGFecUq5dc0wQpaJSopKRUCTVZJqV9WChBccmhnuJlOJ0sr08kdPDHh3Nxac7hZVMWbddVWzPoSj0gqoUqlsNbYnewf7w239TtPGWXxR/cht16Tu0upOF5NVQEo+GvmMNww/FbopoLD06vxwY5HMEMdlvdjla5aYxTKb4HCuRKbJnhKSoWmCdYYtg2O48U1/fYyr6wfwC33v2KX44r87s8TrmNRahI393jd59UujbUDbtV//bUzl9wZboZTimdd49bxEM+1WJI45s5wM/3HW26Y7gwpd0lp0PwxlVbuVdKl1FpEURRP0w1nnM253SjXWbHU3Gvi77KegJu8Hblk1vA8F5QdV3uXUr+Am7y8GFyoZA43sWmCWJ7t3lXpLqXWOgEBt8BRxLtxgrdku/BvYIabdZxqbCzTjICXPB/dpO++Ju5hNnvc4u6bPRaaHEHTOhARUbC6Sko3btyIjRs34rDDDrOfe+mll3DjjTcim83i9NNPx0knnVTx9oaGhtDT0+N5vre3F4ODgyXXPfHEE3HQQQdh1113xbp163Ddddfhwx/+MP76179ijz32qPxFuXhukmPMKX2M7mvSBzbB2LoaUFS07XMU1AYe/77uNPqHJ/DmfWZVfJ472py3jFXq2ZbSCusLN/293WkkEiqSSW8GmbWvVDHgYxim/ZxYXiouK0oIQRa7aULKaZrgZg1LbHQAAKqmepoadKSLmXlCIC6d1OxMKnFs1nWkKM6Y7JLRYhMJd7OFZKLwmtyZdcmkKpepWmMWmlGIwbvluTn4S+YInNGxDEe3rcTh6dW4bvgkrMzvbL/WhBAoVBT55iCd0tBRzEKcyOme8Vg3y5rqHLM/Ly4E/S//zALsMqMTty99Dc+t3oF99+zD4W/cSVrfLwCUTsrns1SQyDS9N1fiPH3WebcyCBVX045KON1e3c8b9nlICftUVUUaU14I2oxN5KX9u8cuZh2VGqc729S9T+u60lyBYjFjstT2xfeHqqm+y1pjEM+9osjHN+hmo+H/Xwgv292oBQAMyEGQREJ1sk6F5f0+J+RrU8iEhf+1Zb/nNfkzRXzfBf1f4z7P1liDKIq7BDF4eSswVwjWFp4TA3ri55V7LLphyMdBCLj67a9cnDeu3x/E91cy6Xxeu4Ns1usTy+4rfc05V6B/so+VIuzOfU1Elfv/jETC/zNssojj0Wr4P6icOHxnnWqcUy6/139x14tYs2kYlyw6zPN9qpF4jVA5vEaonMm4RuoKuH3rW9/C2NgYbrrpJgDAtm3b8PGPfxy5XA6dnZ2455578KMf/Qhvf/vbwxhrSZdccon9+LDDDsMxxxyDU089FTfccAO+/vWv17RNVVXQ19cZ0gijo6fHW6YYFTue/TcAoH2vgzFjt10buq+rLjwe/35xC976lt09pY9BZkx3roeD9pmFtrYk3rDHNPT1dUJNOm+n2bO6oSgKxvLyje306Z3o7Sp0bOzpbgMAKKpqX2dJoRve9OldngwxAOjqLKyfSGr2jXNXMfjnl62XKga9OtpT0hek9rYkurva5PFNKzQiSAndWNvbkuhol+eRm97XiXRxu+m2lD3+9o7C2FLJBPr6OjFz+oS0Xm9vO/r6OtHhmpeup7vwvBWgtPaf0Jxj0+la56HxfbFV78IpbcsxL7kV/9X1IK4bfhvW6LPQ0Z6S9pNKJ9HZ1W5vc/r0LsyaPgYAyOkmUin5uJnFb5XpdMIbjEPhcyFndTwtvlZRzudWvKsrLS1XqllHIqkhXZwHEADahGOczTmZZVbQsK0thZGsgXRKw059wc0kRFaWkea69g3DRGfxGmtvSwDFv3V0drehvd0Zk3i/PJ4zpNeWSMjbtAIXpomSn6mdnXKmYldXmxQQ6S5eJ0pC/q/LChCZKL19cVzd3W2+y3ZsGS0u6wSk2zvkcxcULW30/xeplHP8Ozu9408Kn0GqVrhOrU+gtrakvfxI1nCtp0nbahOvvfbCeglh21Cc17ptJGs/3dPTbn++WT/7yZqugKnwPhfHZBHfC0DhfAcda614jlVN9c2ITAvHAQDahc8V9/XT2WG9Fv/9JVPBX6E6XO/3OBH/L+vr60LPSOH/JSkrDKbwuZ8qPlf5e0DMim3Gd622Nue8u6+JqEq5rrfe3g57+opmEI9hZ5f/52kYovyddapJJJ3PV/F8P/biFoxmchjXgT1mTv57idcIldOIa8QwTDy/ejvm796LjrbmfRZTOBr5OVJXwG358uX4+Mc/bv/817/+FePj47jjjjuw++6749Of/jRuvPHGigNuPT09GB4e9jw/ODiI3t7eqsa200474S1veQuef/75qtYTGYaJoaGxmtePGk1T0dPTjqGhjKeMLApM08TQMw8CAJR5R6K/f7Sh+1MBHLHvTIyNjKPSs6xnnbmqMmNZnPyW3QDAHus3/usIpFMaBgYKWxwZzkjrDw9lYOQK28gWbzgy4zl7/eEx5+Z1aHDMd365iYniepmcXepnFlM5xifk0j7DMDFWDOJNTOSlMFA2m0cu51peLwRzdKFcUFUKzUtEmbEJ+xoaGR23xz8yMg4AyOs6+vtHMT4uB9xGRwrLTkzIc36NjU2gv3/UDgINDRe2oyiKve1czlu6+VJuN6zKzcY53f/AvORWXNDzd/w7Ow+p7Qns2DYbE9YxzmSxfccIgEIZbX//KPTieRgZyyLpypjKFNczdAN5VzZQ/8AY+vtH7WWGhjOea3WgXz7vAKDndGm5UiUZY5msfQwAYFDYx5gwX5qV/7VjYAwXXPUguttTuOr8Y4M3LLDKPMeEaw4o3FQPDhXGL5ZAb9s2Io1pXHgvDI1MSK9tIitfV9axMk2z5Pt6yPV+GRrOSAHGgcEx9LRpGBiRrytrlOW2PyYEtAcHM+hPewPtw8UxmMKk+8Ouc+x3LQLAlq3DvkHysIxlhM+HIe91J/4+my1cb9b7dHTUOUfbiu8FZ72ctK1h4fgOF89tRti2rjvHeXDQOWc7+kdh5PJl/6/p75c/cScm8p7XIn5GjLjOt2EEn+fx4rWWzeWdeQrFbMyxrLSuuO2JrPweta5HXTd89zfh+rwV9fePob2KRilRMjTqnOuBgVGMFN/3plRqbAqf+4VjWOq8uI0L76F83v/4NtLY2ITwODvp+6+F+//N/oFRZMebd5M3lnGOod/nUb2i/p11KrK+Y7rfs0bxO+jgUAZdqcnNcOM1QqU08hq59/G1+PU9L2Puzt34xqePDHXbNHlqvUZ6etorzoqrK+A2ODiIGTOcrmwPPvggDj/8cMyZMwcAcPLJJ+Oqq66qeHvz5s3zzNU2PDyMrVu3euZ2myz5fOt9gOu6EcnXpW9bA2NoC6CloO5xSCTH6Ml2co1x91ld0vN+TQys31mxjFxet5/L5Zzt6boBw/C5Yfv/2fvvcEmu6mocXhU63Tg5z2g0MxrlMMoZIYn4I1uAMBiME9g4AfZrPr/O2BiMbWyD/NpgY0AgMgYjkAwooJxzmNHkoMnh5k4Vvj+qT9U+qao63Ns31Hqeme5b4dQ+oU7XWbX23o0iHdKPTC0l2uP7NEaXzwlzfN+HKSixQtdRYnbONqUkBz0FOzzTcaI60es7jscRNkAj0YPjSWyT7/ncubU6S1oQlakThNVh4/Nj1+JtPY/i4sIOXFzYAWzfgaGdX8EZ/WdgV24+Tj6+D3jwTpye68Veay3q1SpKu+/HBvs4DlRXYbAvH9a17njh9Q3IbmOVatBfddJnYrvXFISMaRipx7Tj+txYqNWjMVIhiy4WB3BkvIZa3cNxp6K9xm0P7cbmPUP47bedjZxthoRbnYxH1i0sLh0d75Wqw9lEA++PlevcdV0hflWN3A9xbSDuc1yPT9TQaGtqB7MdAODHz9l1h1/kq46lZbNi68KxYkw9hmPDZSwanLw3ZK5wf4n217k+CPZT0ikcQxV+fLqeJ927tEzH8bgkAHQeo9cU7wXdb42YtMFRHEevJ8WcixlHbLvrRplYaQw38VpcrERhX5idV3O9uFh+dXLPzjRw7eNEGZPFmF3hvO9GMR5Tz3HkuGbO6xQcIQv0TOgrTwiS52rmsKkCned182lnrjMz+mcuwGNzgXDPsrnW6dK8l42RDEmYjDFy79MHAAC7Do5m428WYDLnkbZeQyxYsAD79+8HEMRfe+qpp3DVVVeF+13XheM4utMlXH311XjggQcwMjISbrv99tthmiauuOKKpmw7dOgQHn/8cZx99tlNnZehe3B2PQEAsFefDSNXTDi6OyiQpAlxLoHRMabwN4k1ZfEZIIEotpJh6JMmhHHOuCylllQWELj9RIkMDM7l1FRkKS0qspTmbYtLrmCZBvp6clHSBEUwdUbQabOUKmJ1AdGExBZwtL3i2rvsF/C18Svxj8OvwyPVdahbJcBzsGz4GfxK/89x1tCdyO9+CO/tvQfr7IOY+N6fo/TUN/Ch/p/iXGwGPA+vLz2J1xSfhgU3XOCbpiH1g0hUqQO+y9ukBBJxWUoFoolb2JC2YbbReGy6AOTfvns7nt1xDA8+f7CRwZEvj9oXJq0wonFaF2yiSRPGyw6fuVIMis+SJiA+QLq0y+dVNVF8Lv5A6lIahzRJE8IxbBrKYPGAvPBlGBqtKbd3CmLmTmm/Kruowq2SEo/ieQDfTmyf6j6Xt6eLpJ0maYLuGkB8P7uk3mHSBFdte3Bc9F2XNEE7VmLs6FJejY6Amm4YhnauCrO4hu2U/hq68TRVUCV9mO4Q7ey22VwbdtGODFMH1s/SWPT5/RkyzAXYKdaBGTIAbSrcLr/8ctx8883o6+vDww8/DN/3cd1114X7t23bhuXLl6cu78Ybb8TNN9+MD33oQ/jABz6AQ4cO4e/+7u9w4403YunSpeFx73vf+7B//3789Kc/BQDceuutuOuuu/CKV7wCS5Yswd69e/H5z38elmXh/e9/fztVzDCFcHY3CLe153fZEj2KueYINx2xBEQZQqmSgy1CREUZRZil1IuylDJlmrhwDQiY4Lth8DYbqiylDcKN2pm3TY44HOzLB+QdIzkU2ebY2SLJRAPSq7ZHWUp9yY407b3bXYzd44tRu2gdXr3Ow+47v4Px44dh9y/EMvM4esaP4FfNH8E7gUBJ6dbwzp4HcLi6BUtKxwAA6/pfxm3ONTiEYlBH4bKhss3VE26qbWJbGzEh113P58YFLY9tt21TTXoiPpj76ERNIPCC7znLDJV9NEtszjbguMFx9Dp1QaFSqblhkgw562s6+yRiyxezGaqPS52lNIZ4EW0wjGj8+QK/plM2ia6unQafWTF+3EXZSeXjqwlZSmn7itlOAVHpJJN8SUiT9ZW3QVTu6q+jJAgTrpV0HW29YqrbrUy2HUHK+8v3g30i0Rv3+0WP01xuSsARujOEcZPeR3TZ7KT5KMPsA7vXxf6myWoyZJgrUIX9yZBBhbYIt49+9KPYuXMnPvWpTyGXy+H//J//E2YErdVquO222/DGN74xdXmDg4P48pe/jI9//OP40Ic+hN7eXtxwww348Ic/zB3neR4XU2rVqlU4fPgwPvGJT2B0dBT9/f249NJL8bu/+7ttZSjNMHXwRo7AO7YXMEzYa87ttjlaUIVbGohzMV2IWDEKt7hJ3KSEW+PhJxcSbsKCEdGDUUCSRfsMpcLNbuyLtuVzJkcWDTYC6tMMfvR6rOzgXFHhxj75+jEyjdUtInwi+5rJHmMYJqwla/HiSe/Ad3ftwJUnLce1K0ax8NF/DcpddBIKr/0I/ucLX8CrSs9hCY7B8w3UYWN97jB+0/82nu1bDWtiBQx42GmuxHGvn7MtdF1TqJ1Ui+2mFG6kbwHe7a1OCLJI4caTtmZM7KhKzeWOZ99p+7IxGY0Rl3NPBOQH6/FKPSTcxIdxkVTW2Sc/rPvcoo6NNd3bdXZtnTqUJ400qiXufpHHuFgOxYnRSSbcFAo2Cl6ZFnyqSKOyEAvKF+rDXUepcKN2QPk9Ds0q3FQvEnRgpGrd1fSv0O+0XXQKN42gMZaomSkkjgrhPB5+qu8nrxGWQHrpkoJw45tn6ttqJircpp18aCa2YYa2EKpape38/gwZ5gLSCAEyZADaJNwWLVqEb3zjGxgdHUWhUEA+H2Us8jwPX/7yl7Fs2bKmyly/fn2Y9VSHm2++mfv7vPPOk7ZlmFlwdgbZSa1lG2EU+7psjR5FQriJizMVRJdISgTYpoIsaRQZR7ixMqnCiJE58oIxIiwMw+DKNQw5Jp3KpTRnWxwZM68R7ywkIxQkADtdUrgZvJJN3o5GPWSXUjHuUxxEYs/3fUzM34BHyudgbc8ELnr978Mo9uEnzoXYNboY1/e8gJ+XN2KidyVeUbsXZ+Zfxnn5PcDEHgDAuoEcbhm/As/W10QKNxIrSoTqmVNsaxUs04DbCNbPxZ2iCrfGdW0rcvWKI8JEBIQbJfP88NosjhuN68a7lOr7YLzsYNFg8F0kG/j4X3rbpLfmvkD0KNRa4t8+9Ao6N4UdqvsljSIL6KzC7cCxcdzx+D68/tKTsGCgKNmhsl91L4ZKN3K8SLiJhBYth/W5box5ItmSApJbp5Jwk0m/NNdhLqW6wLdxZK3jiso/maxMi5mscAur27iR4hRugEC6ekCadyP8WG3exnbBZ1ydGRDJ4m6TG9yLjhnTihnaQXjfaObRjG/LMJfQjBAgw9xGW4QbQ39/v7StWCzitNNO60TxGWY5fN9Hfcs9AAB7/fTO8kJJkzRubJRYEkm0KIZbcy6lrBwaQ4spySSliE8VOzyBZRoGbJsn4BhBRk3N27zCbV5fgbNDtRAPY7UZRpiIgJ6jc7WVXEpJO4xONBEfSyD2PD8o8/byeThpoB8XN0jdYt7Gc+Or8dxwoIRdOdCLz5+4Dmtzx3GqtRenLDIxv34Qi+oH8Ct9d+Pe6mlYvXsLqoX16PUqqKFPubBWKXZyVrLCrZi3MF5xGi6llBSTA7nbROFGbTg8VMZN33sWr754Na45b6V0jUrN4UhCl4w5yzTguBHZZxhGaLeYwEDEKMliKbaJGHBfB5HY8H0xbpkfbufPoydBy7i5CkJKBL1fIsJWXw5FJwm3v/ryY6jWXBw6PoGP3rgpsCMhXporzCU6MoxmugXiFXxqF01KguqJMR3SKAZ50i/9Ko6dJ5JnqnIBWenkeX7kSuyrz6HHa+2YBStPpmzTKUajGG6tkK7Nn9NJdPv6LUH+ee8quu0WnGHqoXOzj5Rv2UDIMHeQKdwypEVb1OyDDz6I//iP/+C2fec738E111yDyy+/HJ/4xCc4188MGVRwD22FN3QAsPPIbbi02+Yk4o2Xr8WlZyzF2mUy0SyCI7i0hJu8YI2bw0OFG8mmyEgRUdXhkzKVCjfislnM2+HCikuakLO445jCzSJkVng9QeEGkMynpFzZ1ZZ98i6ltP1GJupICyMsL7LLDWOfRWUWBRdh1ie76gvwv5Vz8eT8V+GOhe/CvZVTYRrAK4qbseLYw6g9eAv+aOCHWG6dUGasTJc0Qe5kSpyqSDGAJ9xY/ej+LXtO4ODxCTy2+bBUPiAr3CL33SjJB6dwY+pJx4slVMZI/4iHOSlip6n2+fCVroxyrDc1GSQijRKQ3i9h0gRRAaY5t5MupSxT7L4j4+S68fa7Pj+XqFxDgUjh1ltkMff07RnGcNNcm7//9fXhypfaUz6RbpEUeDHXCbOy6lxKNcoMBu4FyJxVuPHzuO7nKFK4NU+8qEIRTCX8FsZttyGZOY3snjGk5RyF7gVEs0ia1rJhkGEuISPcMqRFW4TbZz/7WWzevDn8e8uWLfjzP/9zLFiwABdffDFuvvlm/Od//mfbRmaY3ahv/jkAILf+Ehj5UpetScZbr16H33jTmdq3/hRckgSJcOPJJSBlDLfGdWngc1ubNCHKRmmaBqcYM8DHcKPkk0iYcTHc+lgMt+ga0fXY+TxhF9ke2cLVKVS4BX/ToP3hdXvySIvQRZW4BLIkB5Q8FLOoUjIOaLhZmja+M3Exbhm7DI9X12LXgsuA+StRMuv4QN8dKJUPSddXLbZFl1JVDy+ZF4x/1+PdN3mCzI/KE7KU0v26BX+15ioVc0ZD4UbLCDLZNghe109QuEWEm7j4qivGuAoqhZtqfElCzpQutRwhrTmOu1+adintfJbSvlIuui5HdKkUbj63XxenihFurOzYGG6+PJ50iRJaTZqQqHCTyLMYUrVxrM79WRpjQlkqclgch7qy+H3aXTMPmp8jVQbctGOg24RXK67Q3Yb8QqK7aIVszzD1uPfp/fitf7wHz+081nZZKlUr0N7LiQwZZioywi1DWrRFuG3fvh1nnXVW+PcPfvAD9PX14Wtf+xr+6Z/+CW9/+9vxgx/8oG0jM8xe+E4Nzs7HAQD2qVd32ZrOw2xZ4ZYcw61WdxvlGEqlE8C75CmzlGrUXnwMN1OI4VbgbIyL4cbOD8tlLqViDDdhO6sHtffNV52MK85qLiakSVR4bkhU8XH1KES3T9NgcfcMPFw7BV8ZvxqbF14H/7o/wCF3APOtCVy2+z8w+uUPYeyWj6L6yHfg18rwHAclgydfbEHhRhtpxaJefOzd5+P6CwPXVk9ImuBwSROC7zlbrcBiRIOOFKrUhRhuZMxJSStSuJSyRCLjZapwEwiVlC6lKvWRSkEpP+xri+TtSOFSymUpVYxxsRyKptyeU6KXEm4J9otumLr6TjCFW6NssTrqbKdq8i4t2amzM/hbJsdoH4vkWVx/s3rqFG4qUpeCXqudwPozeeEZvThhnzqXUvbZPHnFtU/XXUqn/PItQjFBdhEzsw3nHra9PAzH9bBz/0jbZYVhHcQdvvCZIcMcQJalNENatEW4lctl9PVFAe7vvfdeXHnllSiVApXG2Wefjf3797dnYYZZDWfvM0C9AqNvIaylG7ptTsdhGlF+N3FithrEjyqQe5ospYxws0wzIqoUbgNc1kUxhptG7cXFcMtZHDEVJk1QZSll9tPkEITECmO7iQq3FEkT+ko5/OobzsDqJclJNSIXVWaXH5VJ7LGEbJmiCs00DYhrzbrjoW6V8NmR1+D52kpYcIHqOPyxY6g9dSsmfvhJLL33b/Dxed/CVYXNYE+gUgw38j1nm9i4eh7yOeYa7HMkG1X4sKQJlmXChF7hxrkXku+Vqsu5wYaEm2mE7VF3iUspIdxUJN5gbzAeqMJN5E/4TLxSESHkxbrgFhkel3SeGg5HDsUTMiZ1KRUO1ZGZnSJZqG28wi1+gSv2Oe0HFeHGyo5LmsC+65MmqM+LQ5r2jC035jKhC2xql1J+g879Wen2GjeWZ7DELVL9GeR//XG68RCHbidNSOrb6Qh5duwueM6029Zk0IEqdSerLB/q7RkyzGZYZls0SoY5hLZGyvLly/Hss88CAHbv3o2tW7fiyiuvDPcPDw9zmUszZBDhbH8EAGCvuyiVi+ZMBCOXZJdShcItXOzryxOzlNqWESrHRFWH5wtZSqlLqcGrrnQKt7xtcufJCrfoeqoYblRRJhJrYp3CGG6O7FIalpHijZIYi87zIgKLEl/ij6VEuAkkJRAQT3XXw6hfwufHrsVdy9+Pnl/4OIrX/RaMYj+8Y7thV04gZ3i4ofcRvLPnIRjwJYUbbQN2CdYOru8rVUbs+qweqiyljHTVxe+q1h2lSylNquESN1Nmd91RK9wY4cbHcNM/dTfjhkcVmkBEYkgKt9QupcmrAUoah6SyQNRp1XGdCZODcjWKfcrirKnsEOEKalkdQVeusBhuTOEmzxthmUlJE1pwKRVtV40rX2GD7nwKppZLUjBGf/P7XY37szKTqoLysBQvImYcwt8M/lOEKqFGay6lU99WMzLgv2J+7Ca4eaCLdmSIRyfdPZMSpczoeS9DhiaRuZRmSIu2spS+8Y1vxE033YRDhw5h27ZtGBwcxHXXXRfuf/7557F27dp2bcwwS+HXq3D2PAUAyK27uLvGTCJM04BLMt8xMHInUKIE+2nA9rjyAKBGlU6KWF4AIGYp5ZMmGBwJWMxH0wEl2HK2hROjlfDvvp5cww6E9oeXI+ReeD5VuJly+fT4UOGmcClV2aaFsFD0/YiMtGJcSkVSzDQNGB5/TN31QkIQMHDcXgJr4WpYC1fDXLAKlZ//J4bsxbhzWx1vKj2By4tbsdgaQXF7Gf7818KwbK7O9HtEePFJExyOIAu267KUhgofDWEnJk1g16Ex3OpORJwmuZSGhFtMDDeKWFWQ6O4HcTGvLkM+Sw3qLqhT1ahcStMuKDpFHIwQ11RKAicpiUSSVUcYRS6lwViMi+HmN5pMr3BrnrigKkLPV8cGpJskwi2m7KSMprKIkt/gpKintiwE/eV6bqId0xnMcjZDJbqUovUx0C10m/BrBdPNypnYhnMRUbKh9stiP6G0qKzrM8xViF4yGTLo0JbC7YMf/CB+4zd+AwcPHsTy5ctx0003YWBgAAAwNDSERx55BNdee21HDM0w+1Dfej/g1GAMLIG5+ORumzNpCOOTSWqqaKJmhIoqdpkIcZ9lGiGRJcY6ooQFJVSCv+MUblEZhZzJkSmhW6iC7FEp3KwULqXMLrawUyVNEI+Ng2ij7/twvCi7Z2SbGMNNji0nrjUd1+eSAFBizJq/Ar1v+VMcOfUG3FU5E18dvwKeb+CU3CHkn/4OKvd+KWojhb1McUcVeYAuS2lkm6uwR6tw02UpNYxwjNJEClFyD18Za2uAuZRO6F1KKZqL4eZziwRdltK4MihcxViVzqcx7cIYgPFKp3Bfpwi38Yhw08VhUyrcPF6dpVP+iUkT4pIYMDdVsd6qvkidNKFhJoshqXYpVRPG9NoqJBNuYln8fi6JDXcPKQuTNoUKtw6pHbuBsFYG9yEfF46NaFt6t2KZSJ9KiCT6M9uP4fhIJeaM7kMeu90mLZsnWjNMPSI30PY7KVK4kW0axXOGDLMdWQy3DGnRlsLNtm18+MMfxoc//GFp37x583D//fe3U3yGWQzf81B75nYAQP6sV81ad1IgIlN0LqVAQGbkc0SNFjOJi20VJE1Qu5QC0WKGZl1kdlEbCjFJE85atxD/c/8uDPZFLuKqGG6ROogq3AzpHG3SBME1Vq1wkzZJEJUZni9k92zATnAptUwjjJPG4Dhe6M4L8HGzwm2NRn+8tg4vuwtwdm4v3tD7NJyX7kPF91G45O0ckce+s/oHWUrVhEOYbZUqG4kNjFjUnV9zqEKPxnCLxih1MzUt4lKqGF9M4TZeSadwa4awklxKffVx3DnaPTw5qisidMEmRHac2oo7t0MkCyXcdMSpyn5XIIh0rn6hwo25lAp28wRjYzwp1IcGIgVcYFNzZEvOMlGrq5WTnEupEJsy7jJJhI+UsEEkG+kYgbr9ov0yGEE9oxee4UsBdQgAhkhx2vyCmx9zU99W1MydB0Zx5xMv48y18/HRGzdNuS0zFUkK0E5gbKKGHz2wCxedtgQLBoqTco3Zjk66lIbTp4ZsncHC3gwZmgZdozBPpQwZVGiLcKMYHx/HwYMHAQDLli1Db29vp4rOMAvh7Hoc/shhoNCL3CzMTkphCWSSuB2ISJJmspQyUOKFHiPGXqIucsEGXmVHFW5i0oSTlw/gL95/ERYOFskxKoWbfH47SRPajeHGCBPf90OSKTZLqRRnzYAh6IDrrkC4KUgoqvQ76M7DQXce3nTdWfAevBnO1vvh7H4Sp/hXYx8WAzCIwi1yDVbFZQOowi2K4ZbkUiqSDJQco1lKLYHwpKSs43pKcnGwEdNvdKIO3/dhNNwEdYh1KZVcB30hC6b8dl0uRL+Ly0CpOZDGUaTJSB7fchgbVs2TVJDcpTu06BxOoXBTqsKEcaBSxDmuh1o9aAedwk01npQKN6Gv06qbWJ+GbvXKukTfVdmXdUiK0yerKPm/qcKtFZdSi4QKmKkILY/eXKiPU9yPrcTx67bCbWS8CgAYHq/rDp8WSBq7U42puP6/fOspPPjsAdz5xD586oOXT/4FZyF0oRhaQXjPc9t0f2TIMLtB1xCu58E0rZijM8xltE24PfPMM/j0pz+NJ554InwTbpomLrjgAvzhH/4hzj777LaNzDC74Ps+ak//GACQP/M6GLlCly2aXIjqLQbm4ul6UbwumuAgqTwGyzRlAosSbiReEudSCkHhltMnTQCANUv7lXaoFvX0fHqNUMklVI8RY0xRwQgmpcItFeHG18NL6VIqJ02Qyc+6qHBTrBbZtrxtodrIJls445UwFq9B5YGvwju6G2/B7Xjt/BwAH+WJfnjlDZxLqauI20a/52wjrB8lGVRJE0QbR4j7J3UfNQWFmxjDLS5LqeN6qNZdFPN2k5lII0jnCQo3L1zgxync9Pt0cch4+4JP04iSkfzk0b2o1FzM7y/gL39FH2/Sb9jWrmKXU7hpCC21Sym/n7Yn+87cSYEohpvYryqyVkd6tRPDjd1vSQo3ieyL6+MEIyQVpVAWT7iRuiXYyBC5lE79wtNxPTy19Sg2rpmHgZ42Elax36HGn7rYI50YA8E5U99WtHsc4bdyukKeHrtr71QEy3/0heBF/pGh6e3uO52hSnTQKqLfYLl8AOiQyDtDhhkBmnit7vjIdUzGlGG2oa2h8fTTT+OXfumXkMvlcMMNN2D9+vUAgO3bt+NHP/oR3vOe9+Dmm2/GOeec0xFjM8wOuAe2wDuyE7ByyJ15fbfNmXSIGSgpWIBttsgLybGY6IpSDDdLjjNmcm9dGAkGwaWUL4smTaDl5XLqNzbqLKXsfN4lNSpX41Iabg/+DhVWLSZNiIg95t4VkVIc4ZbCpVSO4eYJMdzkR8zQZc42Ua27MFhZy05Bz5v/FNVHv4vyMz9B0QiIr6J/AtX7vwpr0/uCMj2fC97OxVxzZIUbJRlYPeMUbqMkKH+kZosIyDoXw80Mt6nUQ6WCjZxtou54GJuoo5i3leREaIt2j7yA9H31+IpVyaVUP+kWH5witEE5VGoBaXpitJoYI8zzfVhtEm60f3T9qDJDdCNWEXSMcCvkrJBMjcvcqVe48Z+qcnRgRbEYksoMoAobVPukstuN4aZp47T8WTezlD7x0hH82w+ex9XnLscvv+70lsthlofDWDOcVXH8WnIp7QJv5CfMmdMSksStO2aEl/fV3zsJVZiMDM0hJMY7wIZF8z6557n9WX9lmDugaxRnJgduzTDpaItw+8xnPoOlS5filltuweLFi7l9v/M7v4N3vetd+MxnPoP/+q//asvIDLMLTN2WO/UqmKWBLlsz+WALMDXhZqBaj1QVaVxK5WynhpbAEssUs5SyoPiO6wsupbLCTbKjcYjqLTc1RySxAITKIbFOhqCwUhEXzbiUUpfLKPYZcSkVkyYospSKbeu4HuqOG/6tUtSwNs/nTKAcEAuhTZaN4qXvxKdfOAkTR/djvjWOD/TfCWfHI8jN34BrCi9hbe44HnWuia7h6VxKZTWNiiARbaQJDtxQmWyEbBgj9YLEGo0+cdTZJC3TQF8phxOjVYyW61g0ryRloaSII+Pk9aSvHF/Nqod++thePPnSkTB2mepa9JoAU7jJ+5MJnaZMU2JYF8ONLnAVq22xf1xFAgDWBqWCpRw/0jW1Cje5L1KrmxrnMPdcH0HfcvNWgquqTknYbP+If7sahVsSKcgQucnGmjEpYMrIobFawpHxiOqtfkHCwKpI4/ilvTW771IafY/mzOm9YBKbqdvUBjcHdduYFvHU1qNYMFCQFPyzCWzumgqF20wdBxkytAL6y5gUziLD3EZbWUqffvppvPOd75TINgBYtGgR3vGOd+Cpp55q5xIZZhncE/vh7n0GgIH82a/ptjlTArYo1CncgOgtbqRwayKGm8KllMaZ4gg3gxJujfIaNuiylOZttcLNUCg5Qnc88jNkK2JeaZMmdErhJhzr+5GLpsUlTZDJS9EucVFfd/zEGG6szft78jAA9Pfk5GNMC4e8edhcX4mnChcBAAqP34K39j6GTbkdeHPthyggWDjTt/x1x8UCc6wRu69hA1XApYjhximoXEaSGmHb0MylnEup4oHdbBBuADDeyGYbugzaCkIkzh1UiiWmjhXTTKZTAPj6z7Zi856hxOOCa0btoRprYiZggCeVO+FKODKhI9ziCSBxmyMkiXhh13E88dIRAEBPMad0CxfLSVa4qe2Lg+hSqi5ftoHbryjX99WksOraqusAfJvp2j7Ohm4q3Ji9jkJ12wqSZtqQdG0hSyHfPlPfVvz4kt3wpyWkFxLdRSvq1umEPYdG8S/ffQZ/8V+PdtuUSUWa7N7NlqX6XQ6u0fYlMmSYMaDDvVO/uxlmJ9pSuJmmCdd1tfs9z4MZ5xuXYc6h/uxPAAD22vNhDi7tsjVTA13SBCAieCSFWwzhJsVwUyjcqFKLqZsMwYWUEUk5y0QVrjZLaT6nvodpgH8G9sY7SeFGpwUDNGmCoHBTtINqmwhDKM8DiX0W41Kak2K4yS6lUtIEFfHRaPP5fQW86RfWYl6fHKeQFvtk6XJccuoC1J+5HY5voubbWGoewe8M/AT/MfZKuF6kBD312F1447yHsOP4Mexack1wPUWChbgYbrzCjRGyCDvOISQc71IqP1BYhHAbbRBu7AGcZaGkaMYdUEeOxD/WpHvi1xEDkVu0+j5ULcoLOVNyC28HI7qkCQlqMrGf6QOg43r4+288Ff5dKlhKt3BATeyJZe8+NIqDxyd4t8uUqy12nE3nKc8H5fZVMbY4+JAYoTRtLxYlKdw0bawsWxXDLSYRxGSDzfU0C3EroPdA8Kmec9Vuxc1dQ/w+VeDcphvznXKcTSNMN+v47LRdNKRFHDpR7rYJUwLWNZ3oo6gMdd9nLqUZ5hLoeM8ItwxxaIsN27RpE772ta/h5Zdflvbt378ft9xyC84///x2LpFhFsErj6C+9X4AQO6cuaFuA6JFu0juANHiTEyaEJulVNhHY3mF28jKlZJ4Ygy3wIbgC43hRrOG6giuuCylXNIEhUsqrZ/o5goQEkhxbdEdVQUxOYPv+RGJF+NSKtqqUrg5jhDDTaF4Yk1imQY2nbIYJy+XXadpsaZponjpjfCv+wg+NfxG3DT6KkygiNX2cfx+/22wnSBgtHt0NzaMPAwAWHf051g09lLDBvqj3yBIYtRQVOEW2mPSLKVM4RaRt47rKclF0zRCBd9Yg8hj17MUZGszGUx1sbs64xqj207uF6XCTT6REtydWG9QQpS6uSXFyhLHIn0AZMk7GEoFW6vG4mLBadx4v3TbZnzpts3YdWCE2KSpkIAwxiEZH6JSlHfn1MdJ5LalIEwkFWWMuo+6zCkVhYry2ZzSTYVbvU3XFvFs3c+R0q24SdIV6E5bqRSU013hJt3zinbbe3gM//rfz+LAsfHJt4f7Pr3bToU0avnZgDTJhpoti79VfMW3DJMF3/fxr99/Dl/9yZZum5KBIHMpzRCHthRuH/nIR/Dud78br3vd6/CqV70Ka9euBQDs3LkTd9xxB0zTxEc/+tFO2JlhFqD+4l2AW4e5+GRYS0/ptjlThohwi3MpFWO4JZfHYAlEGiAsZDUucoxImtdbwPBYDQv6C2Rf8Jm3La26gV1zaKyKL/zwebzy/FWaGG7xbqEqElBXV6BJhVtIKEREFJ80QSYvRTvFyzmuxylI4lz74shBg+uLxvVWnI7D3lEAwOedt+A9xq1YZI3h9fXbMfaNH8IfOwoTPsa9PHrNGs7a+y1ckL8MW73TwrJU7lGijTRLKa2rSLhRhZvjqAk3yzTQW2y4lFYEl1JF38cq3GLID7o/roz0jzxJCjdDmbxE1d95klikE+SB46oVlKoEEnG21TXlAEBPweZiHOrKCRVuwgVZX49Xorh4aeseKiA5hRtPX8UpNHVIE2A9iVTRZdxUnqbYxtzUmyVvHNdrJGlpnQRg7VRvU+GGcB5vzKOaw1SxoVKPgS7H/2qVsJ1OUFn71195DHXHw55DY/jkBy+b3OvPcIVbmmeJ2QBGgnfGpZR9ibZxsUVn4kCYYdhzaAyPbT4MAHjPq0/tsjVzG/SeypImZIhDW4TbGWecgW9/+9v4zGc+gzvvvBPlciDPLpVKuOqqq/Dbv/3bmD9/fkcMzTCz4bt11J+/AwCQP/s1bS0qZhqYIi3WpdTj3dGaiuFmmQqXUlUMN9GlNPj84FvOxJGhMpYu6CH7gp06d1J6/s4Do9h5YBQPPn8Ir71kTeNaNIabyqWUkmwyCcigeiBO84wcxXALPj0/UrjRuG1S0gRFllJl0gQuS6l+4Rb3QE/3qOL8Han34uv1y/E7Az/BWuyD3xASTaCEvx95HT6yfjP6j72A9/bdh53uVnzTuhgH3PmRWjJGQTKWSLhFxGmkcPOVC1LLNMJ2FJUiqr5vJv6aSLSkeVOf9nk/KYabaagVECryJ69QlLYDjujhFKTxxIbsUkpIK8Hdoadgp4rh5nk+PN9HTVDIhW54miQDcaD3B0usIZJltCg3zKRrxI6BNAtK8ZDYulNCQRlHTnE/hJlfE00JMTJRwx/924PYtGERfuNNZ6Y/UUCnYrjJCrf0LqWpVY6UPE5vWseQxiV7ukGyWWEuI1sPD02+u+RMJ1roc4guCctsAOunTgzvpN/gGTgMZhzGytHz22wetzMCZLxnGZUzxKHtAGsbNmzATTfdhMcffxz33Xcf7rvvPjz++OP43Oc+h7vuugvXXHNNB8zMMNPhbHsIfnkERu8C2Osu7LY5U4owIUCcws3hiYpmspRaVrzCLVKdyVlKAWDp/B6cdfJC/hqhwk0/Rahs9MNrqW1RnWsqSEDVvrhtIljdVEkTqNuo6Oardinly04Tw42Li6Y1klyHufeSE2p1F9ucZbircjpc30T+vDeg98ZP4wv2e3Dc68Ox896PPUuuhuObONk6hN/rvx1XF17EmvpWmAjUaKw/dMQVZ44RkQWsfmYjiy2rt86lVIznxw5TEW6xLqXCClJUPbFTO/EisVJz8a27tmHby8NKG3RJE1T2U6VWRxY1GnUXF1tNQRyJplElpvgwaJkRUS+ShKI7crXmymQoixdGM6GmJVvIiwUxjqV4DEBdzKP9rRIm4kIxjoBLjuEmbwrddD0fT287ipePJrv23ffMAVRrLh564VDisXFwO0S4sXqFw18zj0XuZc0r3JKSV0w2lITtNCfcRMRZOxXqrRmvcCMv3KY72doOwkQHnVC4MVUr2ZYU6kDE/9y/E1/88YszkqSdDihXm1eVZ5gc8C8GM4VbBj06ltHANE0sWrQIixYtyhIlZJBQe/EuAEDuzOtgmG0JK2ccGEEkZsQEIkKrUg9+QNMo3EQSwzZNidjhCABC4sWRWxRhQgVNhlKdjaoYbqo4XgbZZHLEUxqFWxrCjbfD86K4RvEupfzfYpsBARlFCTdVoG32IBlnK+9S2lC4kevXGtf4/sRF+Fv3/ShcfAPMgcUYqwX2lwp57Fl+Hf5q6K3Y7ixFyazjF3ofxRtqt+H3Bm7Hu3ofQOX+r8I9sivVQpLGLGvOpTTKkiu6mCW5lP7P/Tvxya8+HsYXk4L3SzHc0ijc0j2A3vrALtz+8B584ubHhWsGn6qEGSobgSArMDu23UWE7/O0oz5pgl6ZxcAlTRAMP3B8nCjc+PM4ws/3Q/dRW5H9mM+EGn0fHqvivmf2S7Hj6Lnc+HJFclVBuJEOSeNSq4KcNEFPwCVlSlVdjtXn8FAZ//ydZ/BvP3gu2aYOLfajGG6dUbgl8G3KmIrpFabxxOdkY2Yq3NKTlLmYl2Udg6/8OilQ/Za0CxoPdzbHXwoVbh3gA7zwnicbuTkzuYwfP7gb9z1zACdGq+0bNAdRrhHCLeN4ugr6tJYp3DLEYW4xHxm6Am/oALzDOwDDRG7jld02Z8oRp3DrbWR3nGjEQWIPK3FETalgo7doh7GTbEuO+2MrY7jFk1sUYQy3GJfSOPUP3bV4XlE6jhJdOvdS3TXSxXDjP30QhVsTLqWmKbtT+T5QrUUkQlxA9zjilHcpbVxP0yc1L9o+0Xi7WSxYMGBg2O/F58dfhVfln8Ryawjr80ew1j6KtfZROC9sg/PCHRhYcSFKxgaU/bzWHtOQXUMNI2oTx/WUxABVuLH9UQy3eIXb9+/dCSBQ+Fx3wSppASkH0mdlaKuReuGnc7miKs20WUptO1CLub7a7bYZSIornYujqDhTPOzFuT5fcdZyiShVXtPzw/mpp5gLM6iqXErpeX/27w9ix/5hXHf+Krz71Rv58sN5jmZq9pXHAJHSkXMBU/R0mkVzosJNEzNPrSRQEdCBjaydRsflBCUiOqVSCBVubWcp5SVuWpdSsPs92pZa4aZQ3Zpaaq/zmIkx3JqxbioIt6l0KVW9uGsXdD5xPA8F6F8wzmSEL6o6QIuqXnpx31OUweap6U5wT1eUq9HzZ6YS7C5o82dZSjPEIZOiZZh01Lc+AACwVp0Fs2ewy9ZMPRiJoiTcigHnPV7mszsmuU0unlcKv1PXMAZbpXAjxAgQr3Bj5eVjFG4q4sv3WNnRvvM2LMIbL1+L33nb2VL5zC6dTaprpMtSKrqUkqQJpG1s0aVUItzUKqcJIumPdSlNSbix4wzDUNaZEgmVxtvNnoIdEqhVz8QPyxfg82PX4YvGO3Bn+Qz8b/lsmCdfAhgGevc/ht/rvx09RkVrjzg+gIZLaaO9dC6lNM5dlNEy2KdSdfqKZ5LhBimRFMMtlWtMm8+fIemtzVIqV8C2iMovxrYXd5/An/7nw9i6b0h7jJQxlHPvjDmOtFXo4kvGDSW0Pvbu83HJmUu5GIecDYJLKyPceot2OG7ZObzCLSpjx/7AVfexLYflOpL7w7bVCjfOTTGlwk1M7KCC5Moo7NcuJBXjVnW50AW7QXqlyRjaKaInTJrQoQf/UOGmmcbUCrd0den2OlHnITydXbRE0+JMVb3s6DQogTPZzaYKTdEu6O/zbFa4Rfdp+2WppipO7JbiIqp5I0N6VDKX0mkDnnDL+iKDHhnhlmFS4fteSLjlNl7RZWu6A7b4VZEPUXbH4Ac0VewvAEvmE8JNFcPN1ijcFDHcVGC74t6Sq85nUndqjmEYeOvV67Bp4+JwG0e4xSVNUDxkW3FMYVgmKy/49LyUSRPEGG6GAUOhuqAxNOKSJsS6v9J6k2uoSDqafZD9qBfzdthe9Ef/hNeLH5QvxI/Lm2Bc9evoeeMfwykMYLk9hA/03wkbsotfYKtMcBoGzaTrK8km6nYruZQqxo/qAZE9QErEj/R38Bn3WBNHoKQBVWmqxriKHMlZJnEp1Zf95EtH8PKRcTy17aj2mDhX0bhYOXQfJUkZWN8V8hY2rp7XyMCrVriJMdzGQ4WbLbUJHRNJ8e1E203DCElv2aWUXIMlTeCCnEvFpiKuZNJCr6xLiuGmupol1CdNXJdOLZpCN1+nvfJCc9g8qlGeRTHcZBuSMB1juAHTW+UmKpTiLJ0MgkrClCrcJkH9OEfUKeF92pGEPuyeV5OtaYaBShmbIT3oC9/MpbS74MNOZJ2RQY+mXUqff/751McePiy/2c4wt+Ad3gF/7BiQK8I+aVO3zekK4lxKe5jCrREjKY0rIsAr3IIspfx+LmkCiZdEkwTEcUGlQmBXf09Oe4wqVONoI/tlUtYkqlLj3UuFayjKSZM0ga0U2bG+H2VBtGJjuMmEm+p6VNLPyLD9R8dxz9P78frLTkrVj7x7b/TdMg2IOUTZop3G7ijmLWUfui5PgFjLTsH+c38DCx/6F6y1j+JVpWdxW/k86TxxfDD7cySGmzZLqZQ0oUG4pcxSyuolqbYkN8M0Cje98ovCgHrB6hEySEl+EkKOXYq5lKrqQMHi/cWpKURzdUkTZJfSRtw9BKRyFUIMNzdKhMGQJkup6/mYqAYjsqeQC8acZqGalnCjbWyTLLg6G9i3RJfSlpImxBCc5Bqqsa8ah6LCLc1b7049p9P7z/U86X5uFqkVbp5+XOogx9JrzrZ2obuc6/mIEXZ3F/LbBO2hU+NSOnUKN1GN3glw8ZdmMfvT0aQJrAgN2Zop3OJRd1xU6x76Svpn6yRUyHNgJ9yEM7QO2vqzmbTP0D6aJtx+4Rd+IXUK4ixdcYb6jkcBAPZJ58Gw9fGjZjNiXUrFGG5plFEQXUoNyc2ScymlBAJH8uivcf7GxXjXdafgnA0Ltceozh+dCFwDk257nR2ikkKZNCEF4RYp3CJCgS1qc3FZSi35+mqX0ogSY4vcnzy6F/c8vR8LB4tc4P000BGQ4jWYEqyQtxrurvKxjkCWAECltBTfHL8Mv9L/c1xffA5P1tbioDuPO89UuLMaBmDbDQLB9ZSEClVYeo3MqOwwpdtxYx8lMCoNAjPZpVQ+N7QVwcOPuEf3Vt8wDOUDP3WLVg01Vl7ONlGrN1STll4tRsFIsbhj4uKp+RryDeDdmFl/OIpsuhzBTRSS9PdaF8Ott2hL94POpZRBSbiRrKNMcRqXNCGyl+6Xr5VKTSbFDhP2a0iE9FlKeXVhMPf4sfNWpxVuQKBy8y0PP7hvJ85etxAbV89LXQ7N1Bt8ao5Tql3S1cXX3NtTBV2bi4rSStVBT7H1xXEnIfFtMceq1MWdBq9smtwOnIz68Cra2btYViY6aLmsBnlHtjWjcKPjZBZznFr8wzeewu5DY/j7D10eerg0C/rCdzorcucC6HjOXEozxKFpwu1v//ZvJ8OODLMQvu/BYYTbuou6bE33ELmUyg+MoUspi+HWmK+TiOolnMJNjjVlm2ZIQETujeldSvM5C6+6aHWsDaoFZFqFG5coISaGm+oa6bKUGtyxvh8t6CnhkORSamjiePEKt6DcWiMbY7Xmhg+lcQkeaBtxBKSGcPN9P7xuKW9J54XHkh99msTg6foavFBfhTNy+/Ch/p/gR+VNqPk2THi4pvgiVuwfQc3qwZH8OXi8ti6wEfosktReixCb9IE7Tt1EM70yF4mkzJvRm3qFIY0Bn0TaRXYDnsK7lqmaxPtFLC9vWyHhltalNE2w6Dj7OXdHT30cJUAdRQw33Vjz/ej+o9ekMdxKoUsp2a9JmsCgdiltXN8wQsVpnEup2l75gDTElTSKYwk3PcGpOBVANKeI6sK8qZdNdTqGGxAQflv3jeBHD+7GS3uH8P97zwWpyxGrqnMpjZQq0ba0VUlyH59s6C5H2/C/fvwiHnr+EP761y/B0vk9U2RZDCR/aP2hU6FwazZYfjuYjCylc2WxrCLG2y2LfTcMg4/llzASppKknY7Yf2wC1bqLEyPV1gk3qnCbe004rUCbfzaT9hnaR9OE21vf+tbJsCPDLIR3eAf88eOBO+mqs5NPmKWIzVLKXEqFGFZJ3hM0hpsquLttGSEBEcVwE5ImNFcNCXEKtyQRmi5pgthGrSrcwthDjU/PJzHcmnApDRICyMWrYrhFQeQj10sj5ZqHtoeOpHM9P3QlYC6/KmKTxpFg34NPAz90r8KAcTtW2Sfwrt4H+RN9oOSM4L199+F65zkccOehUh9EzloW1kvscwNyDDculpjSpTT4pPHFylU+S6+qLnS/auFgwFA+7GsJN9E3kl2DqEzjYrjRBW3apAlhXK84hVuci6PG3ZHuo0ksKOkTupxqsgK7RIUlEk2qpAkMdZdfgIlQxZIK4+SZBnLaLKUqhRt1KZXRaZdSrh1SJk1QqQsd10c+Zm3VMYUbRyB4Yew9Ol81g7C5J0Hh1u1g32liuO09PAbX83Hg2MS0INySFG60TacihptO5TQZmBSXUqpwm8Xxl1jVOtFHHGGGxmNmMwq3KUy0MR3RCfKT/R63W06G9kGbP02CpAxzF00TbhkypEV9+8MA5rY7KRCRT2rCTVC4pXQpnddXCL8Pj9ckgs62zJCAoC6ldLHdrru3iheqNRaZiQq3lEkT1Aq3FLYJZft+5GpJ35RLLqWqpAlKUkuhIiPqpTT9KCaWiGzSEG4uUbiFhJv6OJ1tTn4A/zL0Wryh5wkstUZgwEfJqOHF+koY6y/HKbUXsPbovVhhD2GFPQR3x7/BX/K+oAzHwSJ7DJ5RQNkP7mfWPzSGG13IqlQJbD9VuI01xr+4CBYJlCiGm7KJlNDGcNP0Tagy1ZCtrDy6oOViuMW5lAr9oUJcG8TGcAsJNzPsj7rLkz6ASHZH59OyJYUbF8ONbxQ+ZqBcn5wiIBadk5pRuNFLq11KkweGuK6WXUrVx6oVbvw2w4CS7HQSFvOqDKitgPab43ioOcF8UXOauwCrKmtu3ZwbJUkh29ISboJJU580Qb2dn9vZ5/RYSEkCN2FDvR416tQo3PS2dAKUBJsUhRv5PqsVbmGSgvbryN0LDcaNlpp0jbmucGNop+rjlHCbJnPTnAV9bsoUbhlikBFuGSYFvufB2f4IACC3/tIuW9NdiKQEBVO4sTdWaZMm0P0nRqpKhRsT8FC1lcURXU1WJMYGEYkx3DSJEsQiVW0W56YZXd/g7PB8P/wx5BRuwkO8+Bbd1MRwo/DBlF3B364bkZyxtnJEY7SZS2yB6GHW9bxQqcJcSpPIQNGFsViwcBg5fHfiEum86/ILsWfhdfjKtkVYYo3guuJzOCV3CP6D/4mPDCzACusEcoYH9ALb60tw8/iVGDcHAIBXuJFnDpXCLXIpjfw5RxrKyDh1F0BdSuWHTDbeJcJK8xCk69eIDFITpmFCCI3CLdal1GX9oX8wkwggDeEmZRalMdxC0oeOBdmlmtZPq6TzxCylvH30GlTlyaCO4RZdP2erCTelitEwontC5VLaisJNzPyoVbj52H90HMsW9kTtJlwuUHsG3ymhnEQETkYMt7rrhS7P9WYJt7Bi8RI3Vio3LlNWRe6HqYVurNB7MyQqZsiitkrmVNXc22lMtkspHbeTUR9/jiyW45ThzZXjS+SaCSEWasIleJfUtsyZkQjj6bVxx0xUohjCc7ENpxPoT0OWNEGPsXId37xjK648ZzlOXTO/2+Z0BVOQNzzDXIR7YDP88jBQ6IW16qxum9NVxBFuLBhzzfFQd1wSTDw9G7ZiUa9EvNgkplS4EBeyLratcIsj3BIcVrVJE9Io3FIRbnzZnhdlKaUP7rZQlkgOmEa6dnK9yI2UupTGKdzoHp2LbS4X2eN4fhi7oxincItR35Xy+ncshhmQfce8frxYX4mbRl+N/QsuhAEfJ9nHkDM8VP3g/PW5w/iDgR/hvPxO+L4f2u+mcCll5tHFVK3uNWLf6etCz23mGTPepbRRnsIlTpelNHQpJXXLWQZH7ibZEh/DTSDSNG6NOldIiyZNSFS4qduAV3lFLqU9BZlw41R3jROpC6NKmUJd563QVjW5SmGAJkKRdnNtpYPYP+IpOvLorif24U/+42Hc8fi+6FzRPiMiO+tc/Lz4B/FJIdyIwq1Zwo1VjPV1UtKEZrMUAsn9MNlI41LaKaIi7nrtlCEWWau52mMnA5OtVqLjVnw51glQi2ezwk2lRG0F2tPT820tqWFnE2Lj0KY8P3MpnU6gv/NZX+jw9LajuP+5g/jpY/uSD56lyBRuGSYFzraHAAC5ky+EYc3tYVZskBzFvOxaVSpYMA0Dnh+oSKirVRL+5tcvweNbjuD6C1dJLqWBm1agBWG/x2IWynYTCKd1l1RBl5VTLLPVGG6hwk1BPHAupQIhJGcpNVP1hUNUbQ4hncTssSobxe90YZGzTLiuD9fzGy6lTOEWjKkk20QXRuaKqoI4PnwY2L7yDVhz9gX4rx89h93OYhzx+rHAHMP7++7BGvsY3l38OSp3VmEt+v/C6yTHcAv21wUSYniiluhSGsY/UbAtuqQF+qQJUV0d10fOZuQsK0+dMCN0Kc1pXEpjCbfkGG4SAaRRXInHOUTBpiLcGHQx3KhJskspjeGmH3PstGpNkY2CHkcIaZ3CTe1SGil348qNQ5JbHkcgkgsdPD4BADgyVNaeSxNtiEkT4iCqGNNmNxbBuZS6flMKN9fz8OBzh7Bx9aCCSFSfExJSCjfMJMQRnVMBnZmqFxZpYgPG4XPfexbHRir4k/deIIUx6CSq9anNXjjZGSfpuO083SYo3GZxDLc4ZXgz0CnO+ZcU8dfgSdq2zJmRaJfEr9ZdbZiJDFMPTuE2i+eQdsGe9+eyG3mmcMvQcfhuHfWdjwEA7A1z250UAF578Wq8+cqTcemZy6R9hmGghyVOKNc5V6skLF/YizdcvhbFvK10KRW5HsPA1CncmojhZsSQgKp2SJellB0bfNbqatcUkYAUSRbDTEdMer7PKdyieFrp3G7p90IuImYtMyLBXNdDpUFkFAuWdJ7OruAz+Dtn6wlElaLLMA0UNl6Kx2rrccQbAGDguNePfxp5LX48cS4c34Sz/SFseO5f8Yu992NB/QD3EK1UNzW6gvYJAIyO1xLJMrZf/aPdcOkU6AJ9DLfoOyVE2PmmoU56oVK42VbUrmlcSuMWw+I+naunTuHGuZQqiBYd6a4iGgA0XgY0YrgVc7FjjtlUqdEsvnJdqes8IyAkl1INqRoRq/L+NDHcdCoh1i68ijD6zhRrvmZ/YJ+67ZPefMe5CjcDz+NJviiGm5v4oPvirhP44o9fxNd/tlWhcFN3ukqt0XLSBPLnC7uOY8ueE6nKaRXpFG7J92saPPHSEew+OIpdB0fbKkduMn5DlcypU+EFSy8x2Qq3dkvfvPsEPvvdZ3B8pBJtpIvlWaxOURHj7ZSj+zvYGF9GM+TcbAS7Z1utOlW3tVNOhg6BvqicxXNIu6DCj7mKjHDL0HG4e58DahMweubBWnZqt83pOpbM78GbrzwZfSV1mrowUylVuDV5Z7LYRgy2ZUqvhE2BTGo7hlucu2RC2VxWzhiX0nYVbtTVkUEXw40dawrqO2qrLhA1jdvmun5TxKl4TZoQw7LM0EbXkxVuScSm6MJomQbyOXUdDFN22zFgSMo3AHBh4X8r5+IW59WAlUdp/AAuKWzH2ya+Ce/J70f2K/pKp3AbGZcVbvo36gr72aVE0k6jLqJ9Q8meMOahRuGmylKaIy7caZImNOVS6gWJKFTxc1R2BQo3Vi/5OmKyDlWyB5F8K3Mx3OIUbsF5zPUZUD+EMtLKMIyQlKW2inWl9rKJ7ehwRSLp0iiRxENCF2JFhlb6nS3+eQUcD9Mk5ZDtyQo32Z5WQOtfd6IYbr6f3DYscclYpR4uCtmviq7HQxfvmDbRQXdvv3x0HH//jafwqVuenFSVlq6ZXY5wCz7bIkGpiqrNBZl4tuRSShVuU+xSOhlB3OhvRLvV+fnT+/Hk1qN4cuvRcNtcib/USrIhFXRxF7k8Ck0p3OYeQRH/0pDHy0fHpRcP4wLhNlPiS85W0CeV2TyHtIvoubrLhnQRGeGWoeOobw/cSe11F8OYRPeJ2QIWx228Uk+dpVQFStrYliG5fhmGqG5pb+aLOz1R4UYTJcQp3JRZStVlc4oxTXmiyo8mSWA2iyQcVTmp3IIBPjOp63nSIl5pr8b2eX1RRl9LUAClyVJKIcZwMwwD+Zy6DqZhcORnsC341AWs3mWsRu/b/xoHN96Ax6onBzG2nvsRLslvxXLrBC7edhP+aOB/cGVhM95QegKvKLwAe+IIANnNbWSiliKGG1s4KNRPjU9xj45o4AkReZFtmgkupdqkCXGEW7JLqTIbpp8c84qpW3K2SeKiyQ+AYp3YLaAjmhzXD7Nc9iqSJvC2B5+VavzCnyamYMknGDF6fKSCHQdGlOUbRjQmP/m1J/BfP96sLDcOOoVbmPhDozZTEW5iJzCCWkQzSRPa8UqRkyZE/ZDkVsrGpONGYQjYTZWkcBNj/qWBTuB295MvSzZNBrQKN4UCJ01sQB10CtWWkGBHd11KO389TuHWZvlsfuHHVOfI0OkMletnK5B/g0L2iByTaA05vy1zpiWeeOkItr08rN3fTAy3f/720/j015/CaCOpFMAnTKDlZegOaPPPZpVsu0ibEHA2Y24H18rQcfj1CpzdTwIAcpk7aSr0lphLqdPWpGSQ4EY0aQKDaYpJE1qzl5an3deEwo3LWNqGws0yjfAHL8pSyh+bE4gjPn5c8GmbBqrEHmpTKW9jdIJ/4AGCh3n2oOm4Pthl4pOUqus9v19UuEULhUpDOVRquJQmEbOUBAQaCjeNSs80DFnh1qhAzja5xVx4jmnAHFiCsZWX4OaHelDvXYLLnIfxi30PwvUNWFUfPTbwdvuRyKbHn4S7+k/hOD1cWWqFmzquF/ssFWyUqw5ed8ka3PFEEIxVfOTRLTzpdk7h5kdv4lREAzuPS75hq5ViIpwULqWsbtHdHO+WycAexHuLuZBoSYrhBrAxFBHGvu8rr2cgSNYRN+JY0oQKp3CTbaDzHCO9mZrlD/71AW35BgyOqT5wbJzbnybToFi1MOts477XuZQ6igW72EqUEKRoNoZbq6DEkON4HGFRdzyUCqqzGueyuYLYyr0UgF5h1amkCZ7n44HnDmqP6SR0tyCvcEu+XxOv08F4S0ln0zl6apImTC554jidU7ipxupcib8UKVHbK0fnUtpMuc2o4WYahsdruOl7z2JefwH/8KErlMc0o3ALXkIGMVT7e4IXsZLCbXY1oRb7j45j28vDuPLs5dOKtKHdOJszHbeLzKU0U7hl6DDqL90HODUYg0thLj652+bMCPQ2FG4TlTrnatUsqGrMMmXCzTA6m6U0Nj5Zwg+ijmQTT1P9sOquqyITJQJPJNwsuT04Es40uHZisdMYmHum61OXUi8VccrHcFO7lNqmEWZS5VxKC825lNL4XjqFm6j+A6L2U8ViC8ozueMeMi6Ae/LlAADL8DHStxY/LZ+F7fUleKByCvY4C2H6Lsp3/j+4lTGurJGJemqFG/s8d8NC3PThq/H2V26IFJ0Kl0wVXCHeFQN9MFAJdBmpQePrcS6lyqvxtqRRuNGx6hEFpWgnwzhx+2T9KLrtMrsp2L2a5HZUKgSxItO4lCbGcCNKXruRrCKNwkQkQcX6pVFE+ZpjLKEdxO+q88VFk2EYyrmvmSyl7ZAyIolcbVnhxlhfhWyYQKlwS2m/rDT08cKu41yG28l1KU0m4tnXdpR2utiIrUBHeDJMtcKNI08mofxOxnBTzm/cYnn2MhedSpqgUwfTrclJE9SE52xAperAhxxnjSJ0U09Rd/aIQpt0XFC4zRWX0lt+9hK+dNtmbN031G1TOHAupXOkL1pB5lKaKdwydBC+56H27E8BAPmzXtU2oTNXwGK4fePObeG2ODJLBz7WmAFxhSQSKp2O4faqC1dj96FRGADOWbcw9blxbq6qdtANq8D10uOOEY+Vs5BSco19CoQbOZ7FTmPn5iwTtboH1/XDhbjj+TAJwZUG9DBe4Ra5lAZZShtJE1gMt4RyxSx7sQo3ojZiYO2ncyll7ReRFUD9ol/C/31iNRbkq7jm/PNx655oXPcYVfzV0tuRGz6EjY9/Ghflz8ejtfUAgvhDyTHc+E8DRpR5lfFtgo26t45iRkfxmoFaSa9wY7HtXM/nkybExXALVVJ68oOdnrMNNGLew/V8aSxLCrcGUdFTsDHWUGE6jmyLREIbUd+pymVgyV3SuJTSGG6qh9A4hVscDF7gJpFIaRYfOtdcRnByMdoUxcXt17khJyZN6BApI8VwI+3DEihoz220v6NRuJmGIblW+ooxk3ZNr7q39x8dl7ZNFnRlqxRpcfd0EmjbtL0gExVGwobaFCdN4GyZDJdSVyM3bQEROaQmzGdz/KWkub3ZciLIRF7SJXiP/NlFUMSFvGBohvxUHVsWkyZMCtU9/cBeKE5U9WRmV0CafzbPIe0iSkY2d3mBjHDL0DE4e56CP3IIKPQit/GqbpszY8BiuFG0QoZxJJZlymoxIUZX2zHchAu84fKTQtl74rmG+ruksGpC4cYRd42loni+SBxZNIYbDGmb6IZLY7itXNSLofEgtobrCQq3xjlxPy6mpi+4pAlm5FLquF5IZJTCLKUpFW6E4Ih1KRXVT0bkUqoCO561EVP6lf0Cjvo9MC1eTTfhF7Dr1F/CqXu/B3toP97V+wAOuwPY7S6G40YqLua+Jmcp5R9AKT+oawld/CXKefEKt+jBQDX+uGygjf22bUpKMaUtguJQBT8kR00AblimaIl4GepSappBJj6Vm5RORZqkvosIN/2YY21XpQo3BdlEk4owEjyNO4YBXmEnEm5pYm2Jh3g+/yAYp2ALjo+xz1DPT0kP4pwKqo31k6hwq7egcAuSdATbEmNEKhaE6RVu4t++1t13MqBb8KqSJrQTw42W137SBIlx40Bj9k1m/Lvw8pPsUkrHbLtLWZXCjZo8m+MvxSUbagbSy4qwfPlaWls4u9qzZ7ohSb1GkwGlqbtqzIovpmaxJzQH9rs83cZMJ5PizGbQONJzFZlLaYaOwdlyLwAgd+rVMHIxwWIycFARIK3FcIu+24rzRYVb2zHcJPVY+unEMIzI7ZMjyngUFO6POhLLUtRNnNwlhZsln8MnTeCvUSxE7yjO3bAovKbreeGDj+NGC8dYpSIlGjUKN8f1IoWb56MiuJQmDRN1llJN0gRTJpiSFG7s+FDhRlwfVQQeAIz3rkDPDX+NI/POgmX4eF/fvVhiDsNxPSmAveRS2mjjKM6ays+N/1P3EKSP4Yaw7LikCaJLKatq3KImipOlPyhyKY3UlTQpB4O4sFG5lDoKkkV2G26Ul0AG9qRI1BG6lFbpwl+2ISI1o6QJdYUaT0SSwi3NA69e4SYTpqrSPAUhw6AjaZPiQ1GysWMKN9dHVYjhFodQDet6mgyxinPYQr4FIZJq8a4Nyj4JSKNw63QMt7YVEPF8G+9SOgUrU96ltPPX48Zsm8VH6mg1oR6nOp7pUNW9nXKkcptIhNBKvMeZgohMU9eLJxvTvxyKIymn4j6fDnA7MBdPNjKFmx7Rs3137egm5nDVM3QSfnUczt5nAQC5jZd32ZqZhdPXzpczB7adpdSUyAhxMdjumwbRRp0KKun8OJdSlWKO1oGeq4rHlkQKqgghrkzT5H7gKWF33imUcCMKN88Lg/3H9SPdQ+tdIqTe6EQtrJfreWFsrGIuncJNzFKaFMNN3MfsL2mys4oKN4+oY0xDvUj3fcAwTby47P/DUbcPC60x/OHgrXjliW9jTXUrV55e4RZdg9oPKFxKG2WcvHwAf/SLm3DpmUsDWzl3InkRYJpqQpOqBVn9m3YpjXU5YXUzuHYVixWLKBPCLTZLaUIMN90DPIs1GTfi2KnUpVT1gBwSpsSlNM2ClxL1QGsupVIcIkQEalCGbKfKdnY2b596zKtce7n9CpfmViCSO81kKWXujo7rhx1J5xfVXKNacKddAKoIZHHbZK6tdHaqYq51qk+S+iAJkhXCBi5pwlQsTKdQ4dap+GO8Giv6PpvVKdE4Vu/3fR/bXx7mkt3ElUPPCz7JtgRmlB4728iixAykXN3jy+Ld9PUk5WwjLXUIkzp12Q4RtB8zwk2P2JfkcwQZ4ZahI3B2Pwl4Dsz5K2DOX9Vtc2YU1q8YxE0fvhp//ssXhdta+VGh5I4qS6khKI7aVrgJyrRm486x83nXSv6YvpLK3ZYo0DTJF3QKN0t4vUIJuEiVRlxKDf7BZ8+hKND/Scv6I8LNjQg3qnAz4mbYmHozjE7UQ5Kv7vhhTKZ83oo9j0GtcNO7lBYFYo2VT4lPSqyaAuFGiUdKSFGwB8SKn8e/jLwGLzkrkTdcrKzvxivHb8VSc0ib8VN8U8/3r8HtE9sgZ5s4dc185G2ZPFRnKVWrlWhb9vcG7TLQm+uYSynNksorKEUygv+bBVPuKdph+9UVi0gduR8RxtE59Mg0LqXMxuaSJgTjKY1Ll5g0oebwcf/SuNHpiEt233MLnRjbVWWJWY0ZkhRudH9bWUoFcqfOxXBLp7JzvEjhJt9dPJQL7pREj0otI9Z9cpMmqLe7no+xcp07plNJE9LEKYyD1GbCk0K13plxlBa0NpOx8Odc/dssKyl21mzOUsrGiY4Me37ncfzNzY/jG3dsU+4Py9Gog3UkZlIZ01is1BJULyAodCSa8lhePipdQ3ncLIYXjrVpVl/64naO9EUroM98cxUZ4ZahI6hvfxgAYK+/ZE4z2K2ikLewemlf+Pfug6NNl8Er3AxpgSQG9G534uOuZ8uKusTzDZ6sEb+XCpZSNccr0NTf9Qo3kYCL/g5d+QR76IKJqaM2rp4XuExakbsn+0Fx3IgcEQk+CmqbzoXY9fywDPr2uWC3qHAz4mO4UXUd2wYAfT0R8UnPZzEBaYZHGqtBGQOt0Zx1x8Ow34tv4HX4h+HXY6+1BiZ8vLXnMaywTsCAJ7uUNp48qdsng64lmHIqVOOpFEiKLKUiuRPaQNSCv/WWs/CRd5yLRYOlSOEW88zFHsjSuJSKCjcpoYTwN8uM1lPIRQRoCoVbRG4K9TMMTjWaJmkCM4mOVWUMNz+yhbm/p3k7LCrIfF+Mf5b8wKtTCKhcSlXPz3GXEN32GZLUM5zCrY0FBa/abE7hFsWgJMtFTkGqV7jFkZBpbAUaLqUJbtOdhK6df/LIHvzuP9+Lnz66N1H1meo6HVS4ibSTaBaNnTg1AjdKIHS+/FoHFW7Rgp1uo/fL7F0sq+pOcXQkiPl5vPGpg0z4ss/0RBJPzs2uNk9SuDVHTEbf47JYz7Im1IJ5jUw3VSSvkp29pH27oJ4bcxVZ0oQMbcOrjMLd9zwAILfuki5bM3NhGgYWDRZxdLiCjavntXB+9N22TGll3PkYbmqyK/X5LCuoRunVX1InYDA0JJsqA6u4SBQJPEoohMHqLb5MumC6/oLVWDa/B6edNJ+7vut54UOt6/qhy2DaZpHpUWJjoxCanSnXUKmljeEWEYCGUuEFBHXVK9wiwk2pcDMihRt191T9uLKHOvP3cQABAABJREFUUqb2KBZy2DOyCHfnrsa73Vtwen4/Ts9/H3vzC/CUdxbOL53AzyunY9wvSgo3pUup8DzGyA7WjiriQOXSp1MrUYXb8oW9WL6wl7MlVuEWZinVH0MJP+qybBrxD9psfPQW7dAWlaJGylJKSD36aZqN/m20TU/oUhqjcGPqxYQYblEbgyjcUrqUCtvqjhcqVdM88KqUVYDcDsE+FVmo36+L+5eYNEETw+3EaBU7D4zgvFMWpXpQpcRe3fGEGG5JWUobhBshd7krKi6vSpqQdhEtKw2nR9KEl/YNAwC+fsfWMIZoxxRuCX2QhKTmoJlop0L50gyB0Ap4l9L2ygrJEM3+2ewOlhSLkN77cZDuxwQ33Thb0hw70yCSieKzRjPzpG7ukxRus60RNWCPEdOtutSc2UzatwvquTFXkRFuGdqGs/NxwPdgLjwJ5rxl3TZnRuNP3nshXtx9AudvXNz0ufTH3bIMaWKTYrjFRmNKRtuEm0rhRsqkqioKvcJNkXxCaARR3UX3KxVuBq9wy9kmNpG+4RRIofumF36PjeHGqQ35fYWcFcbjYQRguUGo0HhhiQo3wU0wKYZbKW8L24LyKfmZI4SdKoZbsktp8MkWU0xVd8wfxCP5y3BG5XEUjTpW28exGvcAJWBj7gBuGnl1tHAISSlF+cLflCDzKqNYUN2LNdZxHPEGYMHFmF+UspQa8DFw7AUMbn0Kbyi5uLW8CYxxYIsTsW+ZLXEL3Whho1/ccYQfbVczXv2jTpog25IYw81T91+apAnMpjJR2ohuFnXHDfvEMIyQLFMleBBhQO7zuuOh1MgzksqlVKOiYu2StHjkCDlhnzZpQsJivs4p3KLtf/mlRzEyXsP7XnsqXnHeytgyANl9sRmFGz03Wjjo5yiAKNxacBNTKTVkFWe6slpBmoVbSNK0wcWIbr7tQDRZbK+pTpow2WqlTrqUqlzSuAyDs9gdLCIr1HV0UrwIUp0fHt7EOJhsN+RuQkweIf5W8qq1hLI0xKTorjpnCDfFy53pAGrPbCbt20X4Ir6FteJsQUa4ZWgbDnEnzdAeBnrzuOSMpS2dKyVNEPcbottlS5ch11NfO/358YRbvyJ+m3iMLoFCRObx5+ZsUcFFCDdPUY6gcBPB3OHEGG6U4NKB7jGE4950xVp8++7tuPC0JaH6ZbwcECoFEoMtbQw3XuGmdynN54LYf6L8m5KflmmE7cLaylIRblqX0mA/W3wyIqfu+HiydAG+fnA91vTV8EbjbgxaVfRhHCfbR/H7A7fh6PD5qO8YhekG7tdLyjsw/t2vAr6Pt+R78OPamdJK2vN8nJvbjTeN/C/Gv3IIVwO4ejDaf8AZRHHz0xh7+mXAtPCq6iBe3T+ClS8cAgC8qgSM+wVsqS/HUbc/fKiSXDMVhI1oh0++60Dj09HYeJb4ZlsI7s4I2Z5i5FKqehgXuyRU5jHCmPYfGWC9aWK4NS6ncymt1V380b8/iOGxWniN0KU0xYLXMAxJaUVJjFQupRq3PFvRZskKN9E+Ncme9OabKtxoDLSR8aCdHtt8OBXhRsdEpepy9iXGcKOEW+NYvip6tWorxIvKtXcqXUrTlK2Ka9gsOupSmmBGrTbVCjf9vdAJTEbSBK5ZyPfZ7A6W5OoYxXqNbwPtbxsdB8nGJJY3UyG6gYpP4c243nKZn2OywM62NtQhTJowzepL7ckINz0yhVtGuGVoE97EENz9mwEAufUXJRydYaqgylIqxtTqZJbSdhRulkFtivarMpQCMSSbgkxMcimlCGM5CeXHLbZUWUod1+NUXjpQ08RF+msuXoNTVs3DmqV9+NLtwf01Vg4W31ShljqGG7FHp3AzTQOGYaCYt0PyRuVSajWUT57nS6Sp5/uhGsQ0NAo3jyfcmMLNcb3w4WXM7MdNI69Gf08Oi2v78MH+O7DKPoFVw3eg8rM7cIXVh3m9i7Dp4O4wrtvFNnDh4Evwf3IPapteD3vFGai9cAdWHhrFBf0PAS4AGJiwB+DWqug3g3g1y+1h4Ngz4SPtRhwGcoBn5uEsORX5g8/iLT2PAwAqvo19x8/E08YpslKMEVeaJ0K6mEnjUkoVZp6SjIi+06ygvUWbu6dE6IhCUeFmmYLCLUUMN3ZuVbPwPzZSCcm24Nq8S6m4CBHvP5WbMnWbTZNpUOXKyK4l2qt6fOaDWfOFBSSzfE7Sg7gqaQcFTUIRB5r9dqKRRIOhOYVbg3Aj+1Xdzi6nUw3FQTWepzJpQpqiQwVfx1xK21W46ecAYOqTJsQpbzoBzgW3zeIjW9XkxWx2B1MpUSnY/Z40zmVVqnx8skupvryZjriXMeK2pJrrSLapnCOnEzoRT3MywCvcppdt0wlZ0oSMcMvQJpytDwDwYS5ZD7O/eTfIDJ0D/eG1dS6lZFv7Crc2CTcWU4ssUCmBpHMppZeibqQ09hqrXJJLKQVrPYtkLhVdSkWwYx2SRdLx/PDtZLzyT++uZZoGNqwaBIAwjtDIRF2qQ9oYblRxp+sr1lTFvBUSbqz9qEupZQVl1BH1OyN4KPGoU/vQpAkAT7hRdRwQjOkdzlL81dBbcWlhGzYtGMNq+ziKY8dwQSHIGGtvuAy5dRfjhdu/iZPNg8D4UVTv+wqquRJQL4M5ub/UswmbfuH9uPX+Q/jpY3uQgwvb8HBZ4SVctLYH6y+6HADw4G23wS2PYtE178LgkhV45lv/iAsLO1HxcygadWyYeBp/Mu95bB+1AawN66XLrMpAH8bixpSq/Wi7MtAHPeZOms+ZAdkeMzC0SRMULqUmR7g1YrjFTBwql1Iu66khXztKmuBLixTLir//AJ7ESKNEErNosrPZvcwtihTlcXybsE835ttNmpCWcKNjj8Z8BJIzZFKFT2hPwu+FSjWUdj0kEZ/gVR3NlNUKmlK4tWEIp3BrVwGhaDMKzqV0KhRuMcqbToBXr7ZXllKNSeyfzeqUJHc8dr8nzVPyywr2ScdBetJumnEn7cPX/hFsaaadPHU7iafFEVCHh8r4wb078NpLTsLqJX3a42YCpq3CjXyfzSrZdsH6bS4nVcwItwwtw/d91DffAwDInXpVl63JQH94lS6lJk9QdVLh1pJLqSGXwyvcdDHc5KD9AK+UY0eIVcxp1F18+bw9a5f1a4/lY5cF26h7aXwMN/pdfxwj3EYn2lC4EdWSTuXHbKWJE1QKN6pckxRuJOC6SNgwsEUOUy+UCsH1HNcLF1isjszNcMwv4WeVszE+fxl+7fWn4P4f/gC7du3HqvUb8IpXvg6GYeCLtTGgPIz/e9EJFLfdAdTLMBesxmG3H/fu70F9+StxQWkAhnEIgIE6bNR94M7KWVi4fD1OXXkSAOBOexy7x0fx+z0LYZoGbh6/Et8Yvwx1WFhvH8KNC57FEucATt/9LdSes5A745WAYUVZShv13NYIvs6IUy6bZhqFG2lnz5MVbvRPpmbqKwR9G0eAi2OS9h21U1Qo9qZRuDWMrxCyhyr7xEWGaRqcwk1cPIj1MISXBkDzgeJ1CjeReFQdK+4XH/5bjeFG20jl1UVddOPAEW4VgXBLCNhPz40UbvGKaHZKkhuuCkqXUlG9MakupemPaU/hRhNXdDaGm1gJ7l6YgoVpK67EzYAnKNsrX6WQoSbP1hhufsJ8BkRjNIlYlu5ZKEjMhGaczQo3vm7yfq+Junuae0ueN/VlPPT8QTz4/CH0FHJ496s3xl5vumP6xnCLvmcKNz0iL5suG9JFZIRbhpbhHtoGb/ggYOeRy+K3dR30gTFYqMa7lLYbu5JziWxhFmULOFXsNSAuS2n0nXP/tOTFoeRSaiXbGZJJRuBiuXH1PPzOL5yNZQt6tMe6bkSIuK5HSAv9dXjCTX9cRLjJCrfkGG58MGTTNMLyRLC2Z4qzoPyGwo0QbtW6G/a3GMPNJcSQzqWU7WeLqZ5Q4eaH21gdJbcz+DCsHPb1n4s7Kwvw+v6Toj42DIz4PfinbQvxa2ttLC+UUbjsRjz/2GHcvXMHrmr0varNHEWsoIg8Ccg5ANjuLMOtfafjzEO34pLCdlQf+BqqD30D8IHXWsuxoLgExZEeOO4y/MM3nwIAfPb3r4Jtmdz9mUbhlkMdZxpbYJSG0P/cdpjFPlhYBBcWZycQkCsb7IP4tfzPMXHbo+j1rsIF+R14prYmtJ1BItxCZR6rf2O7qHBjSRO0lkdugVxdFRlgGYbGalg8rwSAdylmMBDEkePjf/AWOE7ginr3U/uxec9QjHXMRvWChc0fiVlKY/a3mqW0TpJbtKpw84V2H2vDpTQkOlIq3LiFZkriotsupc0s3Nqxg56bFEcvCaLJolU6V+7JAkcETEL5ncxSyppDRw6lcUefiUhDcLkxCret+4bwlf/dgl+8fmP40kUsmx8HCaQdd/7savNmXjwkE5NqYlhSuMXc57WGi3m1zezI0wHTN0speVGVEANxLkN8sTkXkRFuGVoGU7fZ6y6BkS912ZoM1P3JMGSX0sDdCdwx7YDLitqhpAlpXErTZCkV46OxB6F8Lplwi+yKtm06Re0uTYmmcPGJSFquypwa2si5lMYo3PIC4daGws00DORtTZbShqkqhRtNNjFRcUJyInILbqi7/OgtudEgLEWwBybRpbSuULjp4papArCyrweOl/Hx40vxxY9dC4BkKQ0JN9kmLksk4xo09ju+ga+PX46l60/DycfuhV8eAQAsd/bhzT37gBefQHn0QRScUzDi96BW9wLC7fg+nJ3bg23OMpS9PHzf17SPDwMe3ub+GKvxMlACsCfY96ae07GjvgQn2UcwUC/CGzsZtWd/goV7tuLX+/egCAfu3mfxGjwL9AH3VTbi2xOXcuXLMdz4NqVZXSmR3pMqaYIvLdp8IIz3Rx+Wc7aJs05eEJJRgUupSGAF9nku+1ue1+qOh/1Hx3Hz/27R2iXayNnHCDdl0gTF+TELHHGOZYh78+37PueKoiq/XE1DuAnnCAq3ppImNBnDTef+FAeZPPIlF97JXFwl8VGGEV2/HfUTVQ2lycQbD/neomhFadiWNRoVTqfAEW5tlhXap7F5trqUpnHhjLKUym3wT99+GuWqi09//Un8+S/zcZp94TPuGtH+5ueKmYKkujVzf/LZsPUvZOKUcuEL11kwttkcPN1I2rlA2ncCbDhnLqUZMjQJv1aGsyPITpo77eouW5MBkBcQqhhuncxSStFO0gTONTWFS2maLKV0UjcMhE+EcUkTonJMqWztsQ0SR4yxxRa3RtzlmnQpdQT1V3BevH1hDDc/IlFyGtIxVLjlbWkbxUTFwUBfPiyPfgKA4zByTz0u2ANTSLg1rudyhFvUrhRiHI80P97soZPZojqDyxKJyH7VEHBdDz4MHFl2Gc56zVvgjw8Bnouf//h25I7vwNn5fTD3PY3f6N+Lfxx5PVzPg3t8H+yffgq/1l+F6xu4v7oRXvkiWD2Ru3Lt6R+j+sQPscbz8bHBApb5w6jBxiOVdThnw2IM7Lsf1xRfxDXFFxuGAONffxrwXfQ0KnbEWobFxgnAqQIALsjvxPcnLuRUbtoYbgpylh2as82QdE1SuKkWrq7nwTSt8B4Z7M3jkx+8DIWchQPHxgEEZIS4eDBNphiLCFaxy2uOF2bzTAOJ6AnvDVlV2XyWUo1Lacybb8/nNSEqwi2N65V4r4gEW1NJE1RZSpUupfIiKHXSBAXxObUupfFlGzCIy1zrdvBZSttTmkhWSGoX8n0qCDd67Um4HJ1L2s9SGnzqMmrOVsItTdwwMZs5RbUm/zaK5WUupTKSEko0005x58WVw170zAZXR2WW4ekA0gFsHTCXVVw6RAq3LhvSRcxhb9oM7aC+/WHAqcEcXAZr6YZum5MB8sOSkeBS2sk3DS3FcEtQuHUiS6m4XafuogjVWynah3eljLazhVVsDDf6PYVLKQNVuCXZqAqEX9C0gTqGm0oN5hGizZTsCNUxmhhu+qQJPmqNoN+6fvKFBT5XvKYpqGIrrk6hfZ4fHqd0DySElGHlYA4shjlvGbb0Xogvjl2DZ0/7Lfj5Hqy2j+PNPY/D3fsMyv/7zzCcKspeDpbh4+riFkz895/BPbIrsPHEflQf+S5QL8NyK1hmDQMA7rJfgW9PXIqjG9+K8bXBi41xL497KqfiOOYBvgvYBexY8Vp8a/wS3L3oRvS89c/x+PJ34ITbg5JZx1n5vZz9pgF4I0dQffhbcPY+IydN8KOxwtqspyi7Gavgeb5SDeQKRCl1baaJR1QEFkeeQ1Yd1h2PS9KQBirSLFK40eMU55L7XNxtmur2iVvwiPtaXYQmuRAmEm6qpAlQz6kMEYlB7EhpvtKlVDCxmzHcaH3bUrhxhFunkyaoCRDxupOFZoLAt4JOupSqySFCMk+7lXxnwN2b2oQ+DZWxYj99HpDeG/jsI/04mM0Kt7iEOkBzLyZ0ajixfWMVbqFyceY3dPSydXrVRbQmU7mpQZ+r5yoyhVuGllDf0kiWcNrVc/oGmk4QA96KbpWAQFB18NqtKdwan+Rc+oDdX0pWuOkJN/VCMY3CzTblttIhItx4dQ6LuRQXM47aGEdYFvIC4daCwo0mTdC51TJ7igWqcFOXK6oAOYVb46nc1BBWosKNkjms3XQ2hl5BPm8zIPNtzGWTPQBFhJtcLn1IoqSQql/YsbJrZvD3eHEJ3PNvhP3QFwM12s9fDNwqexbg4y9fj+XWEN7R+xCWjp/AyH9/HPYpV8A8vgvwXVirz8H2pdfjkZ/fj8H5g9hibQQwAs/zMXzqm/GFZ3qw35mPKnJ4ujeHP7hwFNv9Vfive0cwUl2C63p6YM1fgSP9EzhaW4/XlJ7FO3oewquLz+KOyll4rHYyTh59AuPf+lngp/n0bdhUuAJbsVbjUtog3Li4fnL70TZXua+EhBtRqjGwe8RVuJSaBu/abRhyP9cdr2l1iu/7oRGhwo3FcOMUMCqVgn7xY2jiFsa59Ij7dAsonQtyWE67hJvCvU7lsi3aRD/F73FQKQ117r6TgaRYUwZRVnYqhlu7WUolK4QNPLnS1qVSgWuWSeirzrqUsnLo/R1hti6U0xBccTHcigUrzHgsJ02Qy21OuTW72jyprZtrJ3VZOoW2CoxAnenqTaoCn25DRrTHcb1U64y5Bvoid64iGxUZmoY3dBDe4R2AYcI+5Ypum5OhATH+DV0tscUkT0R1buJrz6U02jZOAn0X82qVk45ks001+UJJnzQ/hGFcsmYUbq6vjGOU19QhKF/9XURBIJ+4GG6xDn7RYo9mnmQEXl5oC0ZsJCncgmN5oo32Q+hSaqrHhU7hRu3UKdxEFRbfhvy1qg21XBTDLaXCjZStOtZVkBEAn+WyvvpC/PfEhdjrLIBfHETuzOsxfMXvY9wvYpuzDP848nps9tbAhgtsvQfesT2AlUfxiveg2rMM91dPxbbcaWHmXdfz4cHETmcJqgiI6ArysM95Hf75juOhSyULam2ZBh6profrG+gx61hhD+GX+u7DHw7cirOP/S/guTAHlwHwcVn1Pvz5vO+hOLQTtWduw6JHPoezcntxur8Na7EPgI/eYkR+q4ZEyajitNzLWFHdDqceLM5sQjazhVwYH4+MW9YvrkIdJ6oMWSITirrjpkoqQMG7NTXsYHEIiQ1J7p3iXhPqB8o4okVSuJFDaVWTYrAlKSZqCe6MdLFdV8Vwi3UpTW+H7jhfsW0yA/+nieHGMF0UbjrCQ7V/SsgMTrHT+eLrHXQpVY1V+n02xLlSIY2bsSO8mKMokhATOrKnmfufV8PFHjrjQKujaodm7k+dWk5SuMUM21DhNsPHdlKYh25ClW07g4zoJXl37egmMoVbhqZRb8Rus1adCbNnsMvWZGAQf+DpvKYiRrodw80ISZtoYc5IEkBP9hgawk1XN1qOSDKpYAkZOGOPtaK4T6oHrELM9XSkoFSG5FLansJtybwSrjlvBRbPL+Hbd22XbChp1EyFnBX2j5g0gSPcQkJKrRALFW4ui+Emk2vJCreIQNRhouKgmLe5mGRAcgw3mvBCqXDz1Ndmf/p+cMzdlTNwd+UM/M07L8HAwl44+0fCYyt+Hl8qX4dV7j6855QTWLJiOez1l8IcWALv5UON8qNCPY36p+54YSYyAFi1uA9AoBo76g3gH0Zej36zglXWcby69CxW2SeC/Wdci8IVv4T6C3fixAPfxTxzAv0vfglVt4oigF/v3x485deBTf2LUawXUXv6MHKnXY1l/mHsQhGLzFGcl9+FldYJnJ3fC9vwgBHAvWcLSsa5gF2C7xsckcb6TaVwA2RCQkWwqZImiGSUZRrxmWA9HwiHHf/mlVvoKIrwdCsh6N2Q49QzovqA9nPOMsO6jZfr2gzDQDIplBSwn0+awJ6Oo/3xLqXNL6JVCxXZzXTyFi/SCyoBtL7tuLZ2Mktp4rUoATYlLqXk+yRI3Lj5oM3ioyyl6ht8trqUpiG44lwPOZdSjQK1mfs0U7jp91PoSCaxi+LmptkSwy2u/t2G2PzTzb7pglDhNocZt4xwy9A0nO2PAABy6y/psiUZKGR1SPQ9JNwMAznbRN3xYHdQ9txSDDeFwu3SM5biJ4/sxXmnLIo5L/rOFrie72uTJtDjUyVNsGQSSXts4zqO5ysfoPIxC2RwNjbjUtpEDDdR4WYGBMZ7X3safN/nCbdGfekDNi1/0bwiXj4SBLgXkyUExEiDBHKJS6lS4Ra4DtKMpCJBIhILbH+kcAu2x6kEJyoOFgyQpAlhllK5nWiWUqaWKhUsdcZJISYcA00+QOsSJq4QXkVXax62+sux46RrsPq8leH2SGEXJS1wPTmDo0faEAA++YFLsWR+D4Bo3L3sLgRcYHN9JR6prserS89i9fL5OOvyd8MwDOTPvA7ffn4Q1x39GlYhIOMqA6uB4QMYNwcwzx/CutwRwAGqD38T1Ye/iRsBnNu3AmvtIyiZkSL1iNuPeVYZuUMv4k8Ht+Mh90zc4Z6Bcc8KF3TsHllsDqHy0DfgHtoGb/wEfqs/hzsrZwJP/QBvKu3BAXceHqudjFXGIQzaQ/AKZdjwYLqn47DRx7VD3fVQrvEZOXO2CTdG9aZa+NgsaUKCCiHO5TS4v+Trxbn0iPt8xdgBgLFyHQsGitpydAQLI8oTFXKqpAk0hpuCqm7HpVSdNEE8JlVRLSFZ4RbVtx3yqrMKt/R/+0h2Q24XnnjBDqNOXiYkkZ7P7zqOvYfG8JqLV2uzPwef0TbarTPd7U6HNAQXI2RUWUrpb7HWpZRsS1S4adp/NiCprZuZJ7ljyXZ53tSXw+aeuKQ9MwF0Dp0MYr8diNbMNhK5U2DNkhFuGTKkhHt8H7wTLwOmDXvt+d02JwOBOM/Th05KDrz7VRsxVq5jQJOUoBW0ljQh+KSKtZ5iDn/7gUtjFwlUERe4/QHwI0KFbY++U5fSFEkTCImUeGyDnNM9rOuUWrKN+mu0o3ATM0+KpCQjyWhZvEtpVNZvvvks/Pv/PI+3XL0Otz20G4CYYdaA6/tRjDNDPS58n2+vnG3Ctky4XkSQiLHvGOEWp3ATr8Tck5k9dky/Oo6Ho0NlLBwsolx1G+1ga2K4NQhFTQw3T1Dq6OLjsAdn0R3SbzRN0H56BaXnI0wyYVtGSLYBaiXniN+D70xcgjcsPQlnm2QRZeXxpbFX4A+X/hw9S1Zj78nvwue+/yLWrxzAImMYuSNbcMaqPpw59gBQrwAATs/vBwDscRbi+doqPFdfhX3uQlyzxsGb8DP0jh3GdeaTuMDagv+ZOB/GlgmUR/dgYLyCt/dUcImxHfVnonqfmgNOzR0ENgPXlYJtb/SewKBZDpRozKN1+DGchTX4onEJxv0Cri5swRk7HoDnOtiZW48eo4ZN+V1YZI/jSL4PW+rL8Uh1PZellbY9/c76jxJeaoUbtPsNzZhvJWmC7/PE7XiFJxVFqBbLANBbslGtuymylJKkCZHvb4hYhRt1W0u5tlO5p6lI5clCcpbSCNPGpTRmi6qtPN8PXwqpsGXPCXz/3p1496s3hurYpuzhyJPO91Wlnt5V/B++8RQAYPWSPpx58gJpf0i4ac6frTHc6G+Rro/Yva8a56qQDwxqwj3enlYyGs8UJCrcyPekKYVXWuuJurhywmQYM3xsx/3mdhuyUrtLhkxzREkTumxIFzHtCLft27fjr//6r/Hkk0+it7cXb37zm/H7v//7yOfTkwNf+tKX8Ld/+7e45ppr8O///u+TaO3cg7M9cCe1V58NI9+TcHSGboJzKSUExtXnruj4teIe6nVQJXIAkmOn0cOZisr1+IUFVWPQ49O5lDKFW+Kh4bGqhZRtGRw5KILWMq7OEuFmJ8dYYwjVVQKpwMBIMvYdAEp5dUbKFYt68Ze/cjFs28RPHgkyX9K+Y6SYQwgp1big6jaAEW4GqvXob0Ow07IMwJFVCnz9+XNYoGcxS6nKp/SpbUfx1Laj+OXXnRYuAkoFS0ke6FxK2d/MpVQ8XveWuVzliRSqcNNlwQ2u44cuvmLMuzhlpcruI94Anj3rw3jlBWvgbT4MILinx+wFeL56GuYtXYtL3vx2+JVR3PLf9+NV5dtwwJ2Hfx+9FlVEv81HrSU4cdUf44ff+B7e0vsk5pujeG/ffcDTgAOgBODKhkjLWnkGchuvhNG3EI9876s4096H+tIz8NAeFxfnt2PQLMOBid3ecow6FnJwcXp+P9ZjDz42eBjjfiHI5hqILvGb/bu4eq3IH8e5+T14Q+kJ7HYW4yeVs7HDWRq2XdSODXsIYRrtdPDq4jPoMas47A7i4er6WPdJbWbbJhRubOiIi9vxch1x0Kmw+oo5HB+pJircKOEQKdzi4SkX3CkVbqospU2oN9pFUtGdUrh1MmmCaHSSosbzgJi8PXjohUPYsncIj20+3BLhhkmOx1UlLyPSln9itKrcrnJ/pONtpquAdEhDhjFCht2DdA6jL+DYyyiG+545gMe3HMbVRKGdJEBqxq1ypmGyFG6IabO4uWnWxHBr4fdlqpAp3NIhfEk+h5MmTCvCbXh4GO973/uwdu1afPazn8WhQ4fwyU9+EpVKBX/2Z3+WqowjR47gpptuwsKFCyfZ2rkH3/dRZ4Rb5k467aFyKZ0sWHFP9RpELqXN2cbFakNUT20MN7I9F6M4Y4gIt/QJFlSEW1y8JUAkBZtwKe2Qwg1ASFZSG3QupeJ5QKTwo9uSYrh5XtReRsMmGmA/Z5nSQj8gLt3wR1udNIE/Z6LCE25pkmFs3TsU2kVj1lG4pH4U7E/P8znyIlQPaN4yiwo3qrgKVXNE4dYQdML3/TB+m6ikjCXcNMo81+cJp+D6Qbm9RRtGvgQjX8I+aw3+ZOjtcGFCpGQ834frGXiqthbH+k7F+c7juNJ6GlbfApTOvAaHRhw8+9QLmCgtww2vfx8MIyj/K5Xr4Nbr+IPXXYjvbX4Sd5TPxHn5PTjUewqO+n04OhYo667dYOGKY/+NReYQ+lFBxc9h+4KrYE0cxWnVZ1DzLdxVOQPDhRUoVQ7jssJWLLLGcHp+P06yj+DvRt6IE16fMiB1f/0I3lB6AktcF+WfPAJzwSpcbezGVT1Phce+ovgivuNdB/nsAHqFW0yWUlHVJbiBM9CEMmnKYehtZHt2kpImUPLBjcYagzrjcEOZRra1lTRBaotURbWEpIUR7cZ2lDhcbLwOK9zo30o1ZoLdzJ5WY8vFhDNsG57vhwreoPx0V7Bt9fyuUmPRItMq3O575gCe3XEMv/aGM2ZENkIuc61O4cbFMPVhkja0yW+8OAc9tfUojo1UsWXPiegaCf00ncmTdpFEJjZDNvIqbHpe+pcS4cu+Ga9wU7fFdEAzisO5jCgMTEa4TQt84xvfwPj4OD73uc9h3rx5AADXdfGXf/mX+MAHPoClS5cmlvHpT38a1157Lfbv3z/J1s49eEd3wR85DNh52Cdt6rY5GRKhdimdDLTmUmpwn61cyyBB1Sn5Q+d0LktpCmKQkYdpzLIEkokiNn4b4skiCtmlNH0MN7aIFkkn1flhDDdN0gTuPEXfhWq/hBhuVOGWs00YhkC45Uzpuqxvo8DXzD59/UXCLU2/HhsJiJ1iwY5RK7G25LfTLKXUPS90KdU8iUkupaxuIGSYF7mpWpYJx/U44lJUuMUtBCWFm5AsgI6Vgd6ArFk0WAqPNwwDLtRjO1D3NeK12TncW78At544Hf/3TRdj3vJBjO06ju8+0I9Vvb14u8GTrLW6FdZn2O/Fz6unY2V/L0zSlqP2Qvy7+1YsLO9Bj1HFtvoynLtmPQ7Xy7j18CqM+iUMeb1Y0duL/ZWluKNyJlZZx3FD7yNYax/FB/vvwOb6CngvVuGuPh3mglXo88dwDD7O2fN1lEpDAABnF4Bdj+OqhokPV9fjjNzLWGYN473m7SjfuR/esb042z4FT7qrYcCA32hb1fiKW8yLZH1IuAnnJLmUsvNsy+AWWCxzLb1OpebgxGgVyxf2Km0MlVjcJCVf04ccuzLtGlrlUireIpO1IBdJwiR0SuEWJBDxYpXPsYhh3NQKtwTCrbGfxkprypxJJE/qdS+RUGQQE42oj+E/Ab4508Zw+9FDu3Ho+ASu2bQSp580P9U53YSocFPF9aMJI1TKU4YJYQ4SkzKJxyfblv7YmYCk+6EZspF/2aBv33iXUka4ZQq3ScMU/WbNdETJy7psSBcxrV7P3HPPPbjssstCsg0AXve618HzPNx///2J5z/22GP42c9+ho9+9KOTaOXcRahuW3MejFyhy9ZkSAJHOk3yLGe3QrgxZVqzCjfqOmqoXVN1SROSSDBaTqqkCY2He5XCLfFaHOGmv5ZtmVzdeJfS+EuICjexTirSj1O4adogTJqgIOxoDDcV0ev70YKeEUM0gUfOMqX2YONLVCmYCvsZQpfSMOtossLt+EjgjlQqWFydKLQupaGNapdSPeGmdik1zcillCrcGPnow0e1oVoSFW5x2XHlZA8Ir0E/TdPAO165Ab/7C+dgE0liEjfmPM8PH/Jty4RlmXBhgT3v64hSdh+JShvD4BWq8/oKqLgWXqyvxOO1dRj2e1B3PJSrLva6izDk9TauzdrIxF53Eb4ydhUqfg7LrGFcU3wRxmPfxMR//wXGvvgb+F3jq/jjwe+jVB/CsFfC3f5FyF90A2AFrrLP1lbhlvHL8YnhN+GAMw8DxgScbQ/BO/Eyfrn3bryz50GYRjQmlAq3GKmW6O7D+lmMyTaW4FLKxldPMYfVSyL3QEbY07b99x88j//7hYdx4Ng4OZ/EcFO4lKoD0bfuBprGpXSyYjylKZXWt1Mx3ID24riJNCH9WzXEEhVujbFXTVA/6u0h3zvcVaK6OG5cUSWcrSXc2NsadZlp+7jS+F0RQwFMV6iUpCI4hZswkOjposItTGLES7Bi7ZlMkrbb4NSEiv20uknDTZeZs5n5lt3f7cxf0wGtErpTAfklUXfsmO5QxV2ea5hWhNuOHTuwbt06btvAwAAWL16MHTt2xJ7rui4+/vGP44Mf/CCWLFkymWbOSfieC2fbQwAAe0PmTjoTwLuUTu6t3opM+JRV85C3TaxZ2lzsGLqgpYoSU0OyUduaieGWJi4dI4KULqUJ1+JcShPMoio33qU0QeHGSBRG1sQp3FgMt0Ky8FlFSobutSSGm+rHlWbXDAk3ok7M5yyNS6msUoirf5g0Qah7XIsdHw0UbiyOncp+tiDRkZeBwk1BuGneMmsVbkRhRxVuNiH22EJTJHdzMWSv2GZR7Dl+8WQZBvp78jjvlEWSqlQHn6j7ghiGvP3sGmIRrP/F+0hUjJ2zfqHUjnVHzlIqLjCOef341PAb8e3xi3FH+Qz4K88BrBxYhoqFVkA8/XDifNzrbUJh0xvQ8+Y/xl3OJtwyfjkAAxN+Ef9v9Drscxdij7EKd5TPgOcbuLy4De/pvR8GfO4FAEVs0oS0LqVJMdzIOP+tt5wVbl84GATNo217ZDgY50cbn/S6gb3MbToqX9Xrnicr3NK7lPJ/+/CnzKU0zUK/Uy6l4rmsH3zfx74jY02p56j6NdgQb2NS2ezlSK2J5AQqe4LvnV1pSoRbzLE1otDTEW4h3yYovhjSqoDYfD1TCDeVklQEnZ/E+YgeL85B4UuaJoikNC6uMwHHhiu47aHdmOBIyHgykSOom3C9jY3hlsKldMbHcPPi27W7mJqXRDMdmUvpNHMpHRkZwcDAgLR9cHAQw8PDsefecsstKJfL+OVf/uWO2mTPgBgNacFUBK3E26rvfhb+xBCMYj+KJ2+C0UIZGaYOtm1yCz/bNlKN5VbHSNryKd52zXq86aqTtQ/IWlDlnhW5lFI3Otu2lPYUC7a03UD0k2nbZkhWmFZyndh+lYKlkFfbQG0Py7HM2GMLeStUbJVIHZJiyPh+YCN7YMnneJsokZLLBTb09eSi8yHPgVZDuRScE5XHCMrI9dFAPq+wz4hIsHyjn2g98rYpjT/qLmzbUYw3247aTfwhr9TcRt1Z/YJrxY1ttvAoFYM2jluc5Gy+z7Tj2Ajs1D2GMTvDwxvVsCwjikdkRPVj16FZLAtCv/YU9T/ttmB32B4NO2FE21VjMk756YPcS5YZEmn//j/Pw/N9/OL1G8MyRFUjIJNMpmngwOGJ8O8zTl4gkVeO50ukpej6BADHvT7cVz0NAHDtK6/EvBLglUfx91+6H6/D3ehbvByPHV+HBcVGGy1bhzvdCzDh18Iyhv1efLb8JiyZX8Ke8hh2O4vx3r57cX5+Bw6X+uC5ZyGHk6VrO66nvb+lcWE02kYYzxNVJ3aOoONj5ZI+/NWvXoyHXjiEq85dgf+5fxdczw/jAobkghHd3yqS2DCiflL2u2Fw8xgrNM1vgbjgVJVvmpP0DJaGXyLtz+bRToDNqfc+vR9f+OELePsr1+ONV8hjJt40A77vc79RlqO+V+PsZv1cjxmfceDmR6OzfSUSP4jpAxp/0NDU2SdsZfibYdL9fNxMFTw/SlTTaptNNeSYnfK8TgkN0xDaj5w+oYk3SkkGI2EciC9v2m3DdtY17eB/H92Dnz22D8WCjVddtBoAr8ZW/X6KXhip24nOg9Lw1JcTJWzyZ8RY1YFLotXCmJnMMSL+fifNuXMd4nPzdMFUzCPTinBrFceOHcO//Mu/4FOf+lRT2UyTYJoG5s/vTT5whmFgoJR8kIBDdz0AAOg/+2osWDTYaZMydBjz5/dyk1ohbzc1lpsdIz2l/JTdK3RhWMjbIQHR1xe5OS9Y0BsRE+TcJYv7JQWXYRrwG2XOn9+L/r5AEVLIJbcZO1blZ9fbE98mpWJEbA0MlGKP7Snmwuxrixb2hsfWE/IImpaJ+fN7wzaYN6+Huw4liQYHg310EZXL55R29TZsX7QgssVuEJWMjC/kc1i4QFYv5vM2Sj2FxncL8+f3olSI2qJUzKGnh5/HCw3FmdWoD7tWb28hvL74Q1l3fcyf3xs+rA0OFDF/fi96e5N/IwZIuaahfmsv9hmzOV+wUSL2Fxv3RqGovm7d9bhyio3jCnkbPY2A9/mCjWIp2B6RkwZyjXYRx9qEo3/L2kfqBgCl8Bo5zs5iUT3+YxMyWGZoJyWv2dh9YuvRRh0srux8ox454d60ybWKeQtLFvfLLk+I3LwYlizo0WYrBID+gRIWzO8BsBCHzJfw90NvwG+/5lz4258GDMTei56P8H5/un4Svj1ew7v6HsRrS88AQ8/A+J8f4bz8uXi+tgr1xiOW6/mYN68H5R1PwcwXUVx9elheyT6Ec3J78GJ9BeqwUSoF/VARSCHfMFD1gHufehmvv/zkMBkCQ89QoFbL2cE9Mn9+LzadsZxrm96+IooFOxzPpVI0FlTuULmcpb2/AKBQsDE4yGcrt3NWqt8CMSlNb28RpnCNUk9hUn5X0ii6xATIrdqRz/NjutS4/0YapPDwhJO67Ch2JuC5/PxnT9Sk4/sHSpg/qP8tZ3Ojj1afdemLkHT9nhaHRvj71zAMHByq4r5nXsZ7Xns69zs+QrJn9vbqxkzjxRx5FioJc3LfQCk22RGnZjLNjo9Nx/Wwa/8I1q8a7JgSRPwtGJzXI9WREma9/UXMnx/d07lc1M6iyz87jZJD+YRnzb4jkRt7sah+vmgFraxr2oHXGE+GFY2Dnp7oGbS/vyjVbagczcVJde89Vo6+0/tciNcaVw7rH9fzZ/Ralo7hQqG5tQzFZIwR8Xcx6Vl+rsIi67Tp3D6TOY9MK8JtYGAAo6Oj0vbh4WEMDupJnn/+53/GqaeeigsvvBAjIyMAAMdx4DgORkZG0NPTA9tuvqqe52NkZCL5wBkCyzIxMFDCyEi5KYmxVxnD+JZHAQD+yZfixInxhDMydBsnTozzMmzPT9VvrY4R28SUjQtKCDl1N1RK1MjCcnhoInwIpIur8bEyKhP8D6RpRAvMEyfGUa0ECxfP8xLrVKsGD+BlRQZBE/FtUiX2ToxXY4/NERVJtVwLjx0dqehOCa9x4sR4GJNpfKyCEyeiBzaqMhkbrUg2HB8al7ZZlolffO2pWL24F6etGgj3G41+mWi4nTiOq5w/y+U6RoaDh0nfb4xL+oYcQLksLh4j16cTJ8ZRYe0+EbWF6D411KhPteFuWGm0m1y2DDqeDcNQBuYQ+6zaGAPlch3DpF9GRso4cWIco2PqvhqfqHPljE8EC03HcVGvB2N1bKyKghCDzvU8nGi0owH+/q5M6MmmapW/Xr1xf4w36jM2HtjpOurxH5dpsV53MdywyTblbLN+gyzzhPmIrdeGhsvK4wHgirOXB2NZULiNjtfCheBH3nkeDhwbh+f72LL7hNbOoaEJ5MC721TYuHWjeqti33ieF7YZADxUOwVr6sO4IvcC6kYOuYlhvL/vHtR9E3dWzsQD1Y1Y4Jfx8nf+EbWXHgAMA73XfxD5Uy6D79YxcP9n8av9e7DHWYjPj16LsUY/HBfavlZ18LHP3YdjIxVs2XUcH3rb2dz+YdJ2tG3pfXH46Cj6e/Kh/SOj5fBY6lLH5iaHjAFPoeItl2s4fpy3UxxfOtQF0mt0tIKa4Bo8qpiTOgFV9mER1AW3Vk/+LdBhTCDCjh0bR8kyMDEebJ8g83mt7sYS2m6YPTbQZY+ORXPQKLmO1cg+feLEBJd0RAT73Ron82gzoERNreZ0tK+OHmPzb5SM5f987l4AQL3m4F0NtWxw7Fj4nc23kq2NdqhWIjvHhb45enQsVh08REj8E0Pq67SDOx7fhy/fthlXnL0MH3jzWcknpMDQEP8bfOL4uJT5nBJpx4+Ph3MjgPC3Fgh+UynYyw/6jFWpxN//I+S3sdVxR9HqM2u7qDTunQlShzHyGz80XEavEFuVztETCXUfGYmOpfe5OEeOT+ifHVm/OJrf8pkCanu5nO73hWIyx4j4OzY0PIGSJlPyXEat3oh9WW7/np8MtDpGBgZKqVVx04pwW7dunRSrbXR0FEeOHJFiu1Hs3LkTjz76KC666CJp30UXXYQvfOELuPrqq1uyqd007tMRrus1Va/algcBz4G5cA0wb/WsbJPZBsfxOI7ANJoby2nHyC+9eiMeeuEQXnfxmikdF6ZhhA/7G1YMYuu+ISxuxCoCAvs9L/jRowtJ35PdPwPX24b03vFCksAwjNR1qimyvOVsM/Z8Liiu58ceS2PPWcSuuOyHQFB3x/FC4sAXrkPdjum+K85ehu0vj+D0NfOVdq1Y1IdXXxzMBWx/GMOt8QBiAPAU9rmeFy5mDQR1oa4WOcuQ+C3qruo4XlSur2+38bIT1N1lMZMa90WKLi3mrShwPBkfFLo+c1yPW4DU6i4cx0Otpl7kT1Qdrhz6nbWK43phbDyaSIHFEcpZprZfRfhCmzXi/cNxg+3jZXWZaeC6kcuVbZuSOxONo0fLZttF11AA+K23nIUntx7BDa9Yr7RnZDxaNJ9+0jycdfIC/OSRPbF21ht9AlDSQL5HfCXhJt93P6pfgu+NbsKFpy3GLy59CcefuhvzrQm8pvQsXlN6FgBQe4ldxsf4z/4N1R1Pwi8Po2c0sHWNfQy/M/C/2FterxwvjuuFWXSfeOmI1Bas3VVzPSNgyhUHpbwdzon1uqecS8IspYjaQjWiXNdHXQi47ybMZfQ4rn5kngq3NfmskhbiIkkF+rvhea3bIZ5XbtzvbA5kc+i2fcP4xFcfx+svPQk3XLNeWRZ7QcJub5fMvzTTKOtvOs6VtrGkCQnH6UDvD8/r7PMye3FTzNsoVx3uN2Hv4THuWmXiQl6rq/sqysIc7RdJ5GrNiY3zShOXTFScjo/NB549AAC4/9mDeOe1p6BPULG2AjEuZq3uSrFcaT1qwlighL0Yw02VECjp/qf3VbNrkTh0sqw0YO1C5yhaN0dxT3G/8wn20n6j9zmbp9k9Tp/BRNCkCbW6O2MD1tO5rZ1+nowxIj6r1jXzz1wHG7dJa51uYzLnkWlFuF199dX4t3/7Ny6W2+233w7TNHHFFVdoz/vjP/7jUNnG8IlPfALFYhEf+chHcOqpp06q3bMd9ZfuAwDkNl7ZZUsyNAMuacIk+aW/8vxVeOX5qyal7DiYpgHPDYKU/9Zbz4Lr+dj+chTnkbpjxAUsB4T4EACWNNwplsxLlhazB1dl0oRcfJvTqyY9CBWIWxINiJ+USFXKPCkFzCf2kD9+9f87A77vN+XWwsgV1t6GYTT+icG1owd01n7UtTVny8qokGRiWUqZzTRjrXDOROPNPPuht0OFWHJdiqS9TRPKmE+6BBS+53PkBfuuz1KqTppgGnzSAba4DbOU+hHRK6pi4haN4hhgcYwYAXy8QeosGFBnoo5rPxpXziJZVhlYP8tJE9TZfk3DwIWnLcGFp+kTIY00VCp52wyTa4j3tGyn/F1MzBF8VxBuJDFEaKdpwoEFWDlY578Nf/HzhTg3twdv7XkUA2YZ434B8046DYXzXgdn6/2ob74HzvYgCZEPA98evxjXF5/DUmsEvdu+DP/Cv5DGC/1TNd/oMhEDwT3l1tyI5HH5eQFIzlKqotx8XxHEO2USADE+ojppQrqymkWauNYeRya1bod4LusDGl8JAL511zYAwI8f2q0n3MKJT3EdlpAE0fh3EyrKxkGrmVOpQnqykiaUCoxw0/dHlSzIdXaEvx3c/c0fk/SsQDNKi4laOoG1ywawdV/wHPOzx/biLVfphQZpIb40ULWPKn4jA/1TjI0pPl8E5SfYo8m+OdOgGk+67+E2pG8n+ttDD2Xtxwi3uHJ4ctOHOUOVV1xbTLMxI/2OTTcDpwlYH85U0rcTmFaE24033oibb74ZH/rQh/CBD3wAhw4dwt/93d/hxhtvxNKlS8Pj3ve+92H//v346U9/CgA4/fTTpbIGBgbQ09ODSy7JMmq2A/f4PnhHdgKGBXvDpd02J0MT4LOUzq5JjpEgjNSxSfIEsaZJ2cfEplm3YgCf/OBlWNCvJhworJBkkq+Rt/WuQYBAFiV0DyXvKJmSNkupq1mM0/PFdmg2hgxTobG2YOVZpsEtZHzfj358G1XhAujbltSJjDAOM2kqsl2K5rLFgUjupakXjQ+ke0DQZynlHxDZolckaRgc1wuC6luM8Inqxq7heX64OKHkY62hLhIJtrhkGmJ9KKkHBNnXAGDhQBEqxLWe50dko00IsPBaIeEmEnGMuObJxzR9xUjHYpo+ayhj+Qd4fnykWTyKC/No7mEko4Gn6yfh6eE1YC120/uvhl2wYS8/Fdap12DvI3dg3oL52Oyuwv0PTOCl+nL83sDt6C8fQPXhb8JZ92buGknZz8RxTtFTtFGpuRir1LEUvPJBPJ+rX8z8AACegiRLu94Q6+P7PGnkN1FWs0iTSY4jzdtgBkRFdT1UVzXmBUVfJIGNN34hHnzS7NBJRCEbB9M5SymbizmiTKgXtV/Xt8w+n9/IHZPkSlQlL0dUatx2QW2//9kDHSHcxPZQDQlezaknEMYlwi34pGM3KfvmZI6ZqQSrsq/4LQHUWXWbqXtSuabwElIFfk73EpNsTVfQeky3LKCiNdPMvGkDVbzHuYZpdfcNDg7iy1/+MizLwoc+9CH8wz/8A2644QZ87GMf447zPA+u2/kfuwwymLrNPuk8mKWBLluTIQ2YG4JBlsazjXCzFGol9l1cpCf9AKoW50vmlVJlT7U0yhwAUpwUEbztCQo3omDK5yjhFm+fK7yBllRZJl1QtzdGTIF8ZCoLVm64CPSjt+5sm01i1OWEDLsAr+qin3E2V2ouXM+TyMY01SzlqYpQT95wf5MHYFd4s0w/dbYysIdrUeEW9SEjH6nCTci8axhalZs4Blh5zD7mtrhwUEO4xbqrRovWHMlSKteNP0+ncGsGXJ9pxjUbRx638BH3Jat2RIKdXc40xAdKQ3nO3Xty+Ovn1+PPHlmCkcIKAMARbwBfGQtU5PUX7kRu3xPcNVTurRRxCrfBRqKQkfFaQ6HHE9eezyslwnuYFqLo9kDhJi7o0604xMN8P1rAWwL53GmkKZYeMjkKN55o0xHynE3C/aNalBtGtD/JbHbPVxUhEdKAIxBaKkEPRm6VGjHV4vqDxuTT9VX026En1KXMqALKZJ4uVzuvcKO2laudWeNIClSFIidO4RZ3r4TzR1MKt3RlT3dEL//oNnk/BW37pHuTTge8KpN/lotXuHXmpUG3Mb0Vbvzf040QnC5QvSSfa5hWCjcAWL9+Pb70pS/FHnPzzTcnlpPmmAzx8D0HztYgO2nmTjr98Ue/uAnfuXs73vPqhgv1bFa4MUUJpxJLT6hQtJMNLM6lNM6tT4SZcCgj72zL4FRDSbYHyihfeiuqOj/JDS8JIuEWEm2N7ZZlwHN8TuHGrknJTVW72SavcPMVP96qtihX3XAhq1NXqcCppTTtIhZDXUodxQImbjFXqTohUc4WL4bBK1VYm9kh+eiHyg6VmjKfs6SsckDkQsrAynM9D77vpyDctNWA50d1tyxDajuXuBvzNqgJtzQkBAPtMzrfsXEHRH2pIioil9LkRVFdINwMMh/pCFq6+Hl0y2EAQfw+WseXnBXYt/BSrDr2EOY99RVcV9yEeyqn4Zz8HtTcdSjkLG3A/5CQVVx/sLcAYBTD4zWlckskg8P60ftL6VLqS22UWuGmUNL4ZIw77uQtXpott521qkS4uSLRJpMWOrAjVH0RLWgioj6JpGXqu5ZdSidxIczGeU+ocNPfl3Seo31brbu456n9OHfDQvLbEZ0nmtx9hRv93pkGFRVnYrEiESPOBWlUaGleUqj2z2SFWxKBq6xaAiHHl69up/AFURqFG40pN4UJJToNnyMfp9eYkV1Ku2TINAd9kTxXMe0ItwzTB+7e5+CXR2CUBmCtOTv5hAxdxalr5uP/vvfC8G+6rp6sGG7dghmqp6JtkcKtubIWDRa5YMit2CEuwAE5rpYIPv5YOoVbTiBWkjgyqowCVHHH0peVhLAtBHLDIp91MJdLds1gX06I4SYroPi3uZSUYlCZP1GpK1xKk+vCu5Sqj9GRl54vuqPxihYVypzCLSqfujmKb7YDl1J1DDdA71aqcyl1XB9j5XqomtO5VMcRlp4fPdjblimNt1BtqOlfceHfjLKIKtyoibZloJEgC7ZpoCqUKy1gUjzcOw6/nZ1rmvrxRRc/YxPRfCPWeduS63Hy0h7UX7gTb+p5AtcVn0OvWUO5/ii+WboeT9YXqsuPUbgN9AZk7shYTek+pnMLpfOSql6UJKPb0iBOAZJGvdEOmi23HXWIeC5zmxZdSlNdgvVLqHCLdtE51UixGAciErhWd9FszE56zcCWznZWRXQp5a7LX4tzKSW305MvHcHX79iKnQdHNAQJX04zMdwqkxDDjYsb2KH2FH92xHtdJNjE36k0ZriK+VQHunsmkxNKAteP779m1H2JMdyYClgzcXgeT7XOZMKNjsnpPmYyhZsarAvbETjMdMyuVXiGjqK+JUjBbm+4DIaZcbMzDtSVapYq3Ch5oFK9pcEH33wmzlq3AP/nXZuatoMF4ldltSkkEW70e4LJrCyV62AcqPsYIC/GO+lSypQ17OFIdPGlqotQdaZJmiA2CIvxJgYq5uqjML9GMh/SDJlJ4Mgbzb2jS0BBFXxAWpfSaPGmiuHGuZRa1KVUHcMN0BO+kktpozzXi7JgDvbmJXKXITZpAkkYYVumRPRHY0Nsu8Z9JC4GmyHcNDHcqCJUReSwZUm0L3nxKD5U07mHJQoRQUl5SvBLChOYKF75Xhzd+Fa4voFeswbPN1BCFe+zf4S39zyEHBw5NlNMDLeB3oA8HZ6oSe5jdz/5Mu5rZEcUERcjEZDjFVI7kiAe5vnRGLcTFpPtollyaDKTJqgyPerAjohiuMnkUeBSmo5wCzM4o9UFeXqipVnUao3YjCyBDSUX41xKObfMYF4tVxzpt0P8Dsjx9kRMZQy3JsS9sUgixMU6y0kTUoxLTx6HaeyZyeQEG4O6uG2qqjWnBKTf9S+IdMWI9/PMdikl3zvuvN4eWlV4zzWIcZvnIjIWJYMSXmUUzp6nAAC5UzN30pkIuj6abYEqo3hcCsKtybKWzO/BR95xXkt2hA89in0iOSaCLmCT+oe5lBYEEiRNDLd4hRtpv0lyKRVJNc/3QxcBdkkxhptoSXRu8He4uEywqe54IQGUlDSBZcMDUgbgFxVuuhhuGrc9ChqvJ1SqQFS4gasHr3BTEG4pFW6MNHZdP0qYoHEnBZKTJrAFnG2ZYdkMrC3EPmB/iy5dzRAdfGZZQrhZ8hinREXYrlbU1gxpiRmRXDYNI0yWkc+ZqNU9rv8p4SYujNiD6YkVl+Orj5Vxqn0AD1Y34Ib5z+McbMaVxZfgwUC5+kr0FnPheZHCTe73MIaboHAbGqvi9of3pKyj3PO+p3ApTVUaiTnXSGThE/JOFU+vk2i22HbsEDOF1jSEm5eGYQndctjf0i7BFT2+OKroqtY9LcmeYE7je2f7KkyaUFS4lEpJE9RB/9lXz9e4AAqjNW6OBniSbTIUbs0QV6nLTCAEZIWbSNAlX6MphRslT2YwO8Es1xNjct2accHWxS0LXfMSVKyiWjNJvTmdMZ1juIkGTTeX1+mC6IXQ7FqLNoM5zDVmiIOz7SHAc2EuWgtrwepum5OhBXBuVbONcFPEa9MlTZhMxLnqJincKNImTWha4UaSBgAKhZsiBl6roK6JtGwaww0At7BWx3CzJCKR7R8v13HP0/sx1siWluRSWqcKtzCGm9r+s05eEH7nkyaojxe306QQqiDUcS6ldPEWPpiYROHm+6GKkinXeIWbKoabemyKij3WLo7n49hIFQCwQJOhFEhKmkAVbobsUhrGcOPPY4fJ6grtpSTisFRQJ7qgc5/KbZStnMJkFIhcJdM+OosJOeh9xvrG8TzUHU8iC8SFEM38t9NZgtsr52LY78WPcA1uK7weAHBl4SWM79/Jnye4Y1Iwwm14vMapcZNUOobme3RNeYGRtIhmpLaYHdaHH9bdJolBJgOqGJBxmAyFW+RS6iuPU4EdoboHIwIzUhGkzVJK7WoGnCKr6bPjEedSKpGYGoVbFNSfuKSR82TyKb4WHOFWdTu+uJ6MGG5yllJx/olXQjUdw62ZY2cwN0ETzjDwyul052v3a0hM1Ys3FcTnjaSxPZ3RykuwqUISoZ0hgBhGZi4iU7hlUKK+JchOmiVLmLmgD+XWLNPxqtRKrSZNaAdxqrCkGG68O2z8dSLCrbkYbjT2l3hNQFDZtdluUQy3hsLN5K9JHxCpugWIXEaBhsJNsJPFeBsr1/Gl2zZrbJYrUHc9yX1VbIPff/u52LByALc+uDvcRt0TdQST1qXUE7O+BdePTZpQkxeMphElHfA8H7VG7KciGQPMxUk11lQknMpuRoS6rhcq3BbFEm7aXVz8OpVLKa0bVyZxnaWIc4Mp5i1MkEyBJU2iC0q0hq54CiUCJao830+Mq0ghurjT+hVyJsbKQV/9yX88JBHxOoWbS2LhOa4Hz/exzVqPJ6snYVNhNwp3fwb7t5yPf92+Fje8dlNCDDdGuFX5cZiwOlDNrxQ+fHnBEdNnP3pwF753zw78wY2bogdw0wBcnohXqQ07CUpOplF+uJ7fUowzdi4QZA8fK9dx8NgEt13MVhqHSMXW+BvAQy8cxI8e2I23XHVyYx9RuMX0r5idsqZJxhFvEF9eJ8HsYS8/YhVujjpLKTtFp8CSXUrj61AhbeQjUOFRZW27EBVQrY45XZmqvyU3/haSJrgtEiLTjTxpBpFikm6Lb4cmpl5l2ANarpXwUmJWKdymM+EmUKszWbU5mdBlqJ9LmF2r8AwdgXt8H7xjuwHTRm7Dpd02J0MHQN2qZgMMQVFCv+seUCcjjl1cmYlZSjmyK962lYt7YQBYuaiXLyLhPOpSajbiS1FwMdzabJ9I4cbH6RJdSunCWpc0QYRtq23jCQFI36miSNdXxbyFnmIOvUWbbEvOUhrrUkoJtzQx3AhxFLnbRgox1/NDt6kCUd9V4mK4kW20baQYbuQaSRlKg7L044RzKbVNRZZSPr4fAxsHskup/q28LdT5otOWkPKi7ZRoVRERomIguG5zD84i2c8p3BoE29HhCo4MVbDvyHi4r5C3pPiPofKp8cn60fN8+J6P/564CAfdQZhOGf1778fv2N/GD7//s+g+Vync+houpeP11lVNim73fZn8iOMsdh0che8Dew6NkuDfEXvkiYvJSYrXw7q2mTmv1XUUa59TVg0CALa9PAxA4VLaRPkGYdwe33wELx8dx/O7TgBgCrdkwlIk+HTZb3UQFaBjZQe3/PQl7D442lQ5OrCXCZFLabRPrFaVupTS4xp/OJoFe/MupbwbKQ0F0AmIc04n1u5JMabEOVdURqUZl3yimSR71OTnTIOYMR1IJtSaydCqdykNPq2Ee1zs15mcNCFN5vBuQVa4TTMDpwlUic7mGjLCLYMEZ8ejAAB79dkwin1dtiZDq+AyUM6y1wqsOiqXSF1NJ4N0jCPcKDGiAueulWDamqX9+MffvgLve+1pfBlpFG4xC3FV0olWEQa+17mUkqD0nLoFfN8ECje+bFuj0ORINrK91CDMHEUMN53Kr6dACTe1eyJ/nqhwY/UTs5TyShYVVAo3mjSBU7gR29giWZmllGyjLrtyhtCGS6nr4cRoQLjpMpQyu3SgSRMs09DGcJPUgZrFQxxhYFsGzlm/EPP7C/iT916INUv7o/KoSylVuKmSJvjy/RG4lOrrKUKcj+jfTGmoyoTse36YTIEp30KFW6PuOZIwxPV8DPs9+OTwm7Dj9F/FPmc+eswa3lh6QkoOQjHQExBu1bqLcWJHLYFw091f0VhvLksp68+agggPYjsG2+xJVrhFb9vTz3mtKhdYv5yyah4A4ODxCYxO1EIyuSmXUkEl4CNSMIdktmkkxncC5AV4sy6lYsmHjk/gZ4/vw20P726qHB0kl1J6z0ox3DQKN8gvO+LiaNE5eqxcx9/d8gTuJwlFqoILdqfjuMnkdfvjP8mlVCQZ5YzFyTY0o0DSKcJmGqKkCer96hhu6u/K8jUHiC8qdG0oqcVnMuE2nRVuCYR2hgCtvOSabcgItwwSnF2PAwDsky/ssiUZ2gLnUjq7JrnIpTTatqC/gFLBworFvcpzdKRNW3bExHDTufQxJLlriRjsK8iqqhQKt7iFOJfks80hEsYbc3mXUisk3JjCTSYBc2IMN4E2FdVM4jWDCkRfWTyvat0NF4a6GG5s0c2UFIW8lUr5J7YnKzcgRhRJE2IW1GUuhlt03SjzK1G4KV1K5fYpkDazFYkDxHq4bnQNmjRCRNww8fwo613ONiWSmylNxD5gfzfjUmqbJn7vhnPw6d+8HOtWDPDlkTqyugcKt2Cb6qGd2uopiKQ4iIpb1samaYTE+8h4TTqv7noh0cGO871gsc/uoxxRuIWZFmHgQP4kfH70Ori+gfW5wyiOHwzrKaKYt8IxcrwRpw9ojmThEtSEhI6sOIjjjVh/1p0o15xJSFB2rpgkpdOIXDPTOw63muWPzXUDvTksX9gDANi+f6Qll1IGg5D7rC70RUcal1LRxaxpl1JN0TSBQTuoSTHc5JcY4rGAWhnEk3AEEuEWbdi8+wQ27xnC3U+9HG4TYx52OlOp2F2dIJzlGIv8/qQspWmmwWZiuOkUYTMN4djiEvDE142re0JL8YpOudzkpAmCwm0GN7ZKOeh6Hg4en+iOQQSZS2k60BfJcxVZDLcMHLzhg/CO7wMMC/ZJ53XbnAxtgM5rs41wi5ImRPUqFWx8+jcv18ZOs6dY4dZUltIWf4WSzvIU5BZvQ+cUbmLGVrGPQtWKzwf4DvaJMdz4snMaYpNX4ER/BC6hVW5BFNZPInuCDSzjYymfLk6eLgEFVRUCEQFJEwaIz2SpFG51WeFWiYnhRhVuAdnpcvVlYG3vErVV3L2SNmmCZZpS7EidW0GojmxC4WZZgYu0yhx6X0ZEa+RSzWcylAlpzwuSVqSFLoabZRphfw0rCDffj/qw0JgvHttyGHc8sQ9L55cAUIUb77o1Xqlj3OzFM/U12JTfjaVHHwZwhnJOMgwDg715HBmqhG7DAFB34gkDXVISNpyaVbhFhJsbKdwYeQRfUr1NlpohcmkP6tisiqcZ0Nh6G1YO4sCxCWx/eTjczsZ8OoVb8EnHPLOdEXeGQeeiGLuEBXm1SYWbbmHZqQVnVSDc6LpWvAa1nbu3FepiXWwsgFd7MUVxnRCIEuFW7bDCLUGN1gqSXN6Ss5Q2Z0OSzbNF4Ra5lNJt0PzR2BS/m0NSllLbjL/H5Rhus0vh9t2f78DtD+/BdeevwrtfvbFbpmUKt5TQxe+dS8gUbhk41HcG6jZr5ekwCmqlUIaZAS5pQowSayZCzArI0FPMceQNxWS0QaxLaVNZSlu7fpJCI1Hh1sEYbjr1XaRwixbR4Y8vi+9GYrQpXUo1BJDBM24hig2FG3X5sSyeDInKCD6Xzi/BALBkfg9fL03nSFlKyRtnR7noCz4pOcbIFOqqRN3duBhujqxwY1DFcKNtRtVbuhhujutxgfp1SEqawB7sbdvUZinVkZVJiz+KOBtVWUoDIqJhJzk2iokTlef5flOLXXYqG4+cwi2nJ9yAKGuneNyhE2UAvMKNLlBHJ+qwTBP3V4LFxvLjj+Oi/HbtfcwSJxwnhFuiSyn9Tv6I7mWFKieOcGuMjbrjSXNAoHBrLCYn3aU0+NQRtiq061JqmSbWrxwEAGzbNxzWTZwf4sCO4BRuwnWCZCvJNrercNMV3aoSUASbE4uKLKVS0gTFC4vAxgapmdqlNNrAzqm7lHDjCbZOK9xkl/r2y5QUbsI1krKUNt2dCcc341Y5ncFazddUSNV1zcRw49ymFWOWZndWQXYpnbmNrUqE8uLuEwCAO57Yh3ue3t8Nsxr2tEdQzxWEnhsZ4ZYhQwB391MAAHvt+d01JEPbiAuUPtMRLmibmLx1Kql2EK9w66xLaZpyGFRqK3UMN/mcViGTKPx2i7iJiW+7qLtvzjbTu5SS7/QMFsONLohUmW2pDUvm9+Avf+Vi/Pbbzub26/pG3B7GMffVMdzYwoaSY0z9xBF0hAwI24zEcFPFBlS5L9PxTttX7CeqcHNIhlEd4ihemjAiZxmSSylV4VAw8+SA3fLD6znrFwIAXn3Raq0dXNKERl1o0hBVwGsxS2kzD86RmpO/PqdwG0sg3DQxHynhRhdR4+U6bMvAVmcZHqicAgM+3tN3P84YvQ++Ly/3BnuDuHzHiEtpEuFGu1qlhqXkOUNcs9EYbo7gMgsQtSFJsDIZoCrStHNvuy6lpmGELqUnRquRS2kTMdwYmxGOYy6GW1QnOv/rILoSNh3DTadw6xThJirc6DVSKtyo+1l0LqT9DPQ41h41hcKNJdgpdzqGWxPkdeoyhW4Vi5SzlPInNEsgJMdwo791M5ecSE6aINctab/uWNV5phn9LqgguZTOZIWbYszQOLP3PtNFwq3xGYUU6Zop0xqRd0OXDekiMpfSDCH8yhjcw9sAAPaac7tsTYZOYrYSbs1M3lOdNCEpSynnUtpG/xgGpLfKtm2gVvcTFW401lW7P4Ri+ZHKp7E/dCnlM6cG9tIYbs24lFI3wKgRGMlRVRFuUhnR91VL5CQxutB/cS6ldOHGFjRR1kkLQBC4vpCzMIo6t8ihgdFD5ZdP4qupCDeF+zJVdNKxLxKrVOHmpHIp1e5quJR64fUlhRt76BJ6gfVjmhhuv/22s3Ho+ARWLNIrsGnfUIVb+FDsMXv5c9it5Hs+vCZuiChLKf/Jx3CrKs+dEBRuInIhUc2TW6PleqN9DXxr4lKsXL4QJ514CKcP3YfKXS6Kr/x1GMQvNlS4jUYKNzFDqlQv3XaisJLc4GJWHCH57HhS1t1gXgiOo4kUJgNU4ZZ26m3XpdQyDUJue4ospSkUbqFKgG2IlDDhvWUYUcbkOMKtXYWbZnsnFG7BXBSU06Mi3GJjuJHjfL5tAAhqIf18wwg3qnBjvyfz+goYrzidV7hNikupQIgnZGZtV+GWdDzdPZPVQGyu4oYW6NiSz2kmfp3eZTv4jOZI9fly9tmZ3NZyu9Lm6aZ6jyq33CZf1M0lqJJTzTVkCrcMIZx9zwG+D3P+Kph9C7ttToY2QRfWs45wYwvbFCGvLz1zKQDgjVes7bgdOjfVfM5MVE5Q29shu1TXyRGFCFMyqIZA1I7tp+vWEVAsRpNNkyawhxSTtxdoKF4EU3SKK3pN+kDJ3JDYgoiqmyR1VUK99S6lGsLN18Rwa/QDJceKLJsqeWCkcc4ssnCOYrjxC1C6kKfIEdKMy1LarsItpr08D1wZYgy3yO2NP0/nUqoiDGzLxMrFfbF2qNzpTdPglFmAvPikyQCaU7gJn8SNmhGkoxMByXrq6nn44JvPDEnNiUo84ZbPUUIqsmmiUo+UYDDw4uLr8dWxK+DBhLPtQVTu+H9w9r8YHs8SiYxxWUoTCANO1Ubqy2UW5U+JazbW/5WaG34vNurnkza3Cck4GWDXaUbh1irhRhXGIblNlMdx2YtFRGoKI/ybmeWG83y6pAlSDLcmkx1MpsKNEmhpFG70eBWpQX8bOHdyoVw6/zjE/ZmVWwkJt4C8Lnc4hptEjnWgLSXVnNDN4jgYK9fx1NajYf07TSDEufTOJKgUbqpYa/xJCfvpoYo4o0ERDQI/IUupqFycLgo33/fx8pGxpuYJV0GST5txxFTZJDRCBhnUc2OuIiPcMoRw9j4DALDXnNNlSzJ0GrMthpsqS6kOv/aGM/B3H7wMl56xbNLsEJGUoVREO+6cKhMoYcJULGqXUkO7r3k71KolSj4ADVVMuAg1G/ZG5+ZUWUq1Mdyi7/QBk5EcLOYOVXjpXEF1MDRtIyrfqOqHLvBE1zE6NhgJ4noedh8cxbfv3hYu4kzTiDK/xsRwy2mUlDbnUqomToCobVxO4dZaDDefuJTaKpfS0O1NVEMGn+JCutW38nQ8U1di2kf0E4gC6AMsXlq6a1GymiZLYH8zgpQVt3RBCRefvjQcB6yOiQo3j1e4Oa4vJHrw8WhtPZ5Z9mYABpwdj6J866dQferWoPzG9cqViCQQXUpFpSTXS4oXOKpYd2mSJoxVItIvdKUlhGK0mNQW1RaoKoFVK2kG7KjCzfWleSEVwkUL2aRwKU2jEBQVbkkJNCRTdMqaDgQeY+SfZRrK+U28BCUL6Zwhtg3dJn4Xz40INzf8m7XnvL7AnU2ncPN9H3c8vg/b9w8r9+sgxXDrwPhPijElEjM/enA3/uW7z+DhFw41jm/vevL+6PvMdinlP4Pv8SRQnDtz3LFQnEdfxqkgzivi/d4tPPDcQfzpfz6C2x7enfoc35PblWueLo6jkEia5EQ/Mx3Uc2OuInMpzQAA8D0X7t5nAQDW6oxwmw2Y1THcQkVJcr1Mw8CieaVJsUPXrmkSJnAupR1WuFHChLnEmArfyHCx2YG3TpJLqcHbQmNRNZulVEcAUbvpm/qiEMON2ibHD+uQwo2QRkrCjbmUahRuP3xgF5546QhHJqsUboF6Mnrw1MUK5F1K9Qo3do26y5NlOsQq3HyfI+1kl1I2FvnzIoWbGD9Ie6lYcEkTrKg9w6QJirfkBgs27zYZw41UMYrhFhFv4lxQyAV9btsmQLxMdf0Y3Tf84sr1PK5fWd8dHjwLpQs3or75HjjbHkTt0e/BHFyOQRe4ML8DB91B7Mf8QAknEG6FnMXFrDIUdWP1CmyS2ylWVdWwcZyo7Bjx6PnRIspOiE/ULsQspUDQH3FxzNwWByNNDsGIRMf1wnvBR/p6MnULeyERZIlt2Efc9Nk4V4TyCyEqXpLi+bmehwPHJrByUW8js6vuuPb7jMVvK+Qs5XzDxXTyfK4uqgzErmLBDigUbjSGW6NMxw1I5TIh1wYTCLcnXjqCr/30JQDAFz92rfIYFWQ1WicUbiLhxu8X51yGE6PVxvHN2ZDoUjpdlEltIlnhpj9H/B5Xvu57kqJKSoYxTRRuhxvJgFhSoDRQuYnzxG1HTGsLzJNjOtgyHZFlKc0ItwwNuPueg18ZhVHsh7VsQ7fNydABcG5Vs41wayzIuj13y5k5gwcBVZwtEZ1LmiBvozHRKtVgUZBTkChR8omWLy+VFdrV+PvaC1YhZ5s4a90CPPTCIS7uUxjDjRAHQQw3viydioseRhcWLH5epa4g3DTxw3S46LQlGJ2oIWeb2HNorFGGPvmCGNxeylJK6sLUPa7rhco2PtsgIdycKMg8ixcilkeR02QplWK4Ndq+Styy4pMm6OH76VxKZZWhwe1vF/SyzAaTxLZiixZ6OS7YPHF7ToKBiOBQxXAT5wLW5+L9qCPp2b0s2uS4PnpIdl9OSbXidFjLT0MFCNxLf/pZnA/g/EaIwopv47A7CNMAHsNa/LxyOjyYDfKrhiXmCBZZozD8RVw9Q5uIUktspzQupYxwK+StsE9o39N4j5MBViyN4WZb8YRbRxRuZuS+LZKnqdA4JSTUQFRcYUISEsOtKZfSeIXbF374Ah558TB+8fpTcP2Fq7XZETtBErFYaYW8pfx9o9cQ3aI9BQHCx8iE8jugjuHGvjOb8jkzVCaLWUsZ9h+bUG5PwuTEcIu/hk75xH5vmu7OJCKJO3TmshMq4ieJUOPrnq588bwoHEf8PS4mRRGVjN1ClOQlPQGoIsy5tk5KjTuJEGOTzeQxPZlgw1HnMTIXkBFuGQAA9ZfuBwDYGy6FYWbDYjaATmuzjnDroDKrHYjtesqqeRjoyeHcDYs0Z0SgZ7bz1kcdwy3aNtpY3PYWc9JxYQy3DowPWeEW/H3ehkU4b8MiPLfzGAAWw41/SKEEoW2bEqmjjeHGKdyiBx1G0FVTKNySmv66C1bhugtW4bPffSYk3JTuueSNM32YDGO4hVkZI2IlzFLq+rBM/gGUxnBzXC9cAOZD1UdQXx1RwyncaCwuMYZb4+9ajRJucQo3xTZEiwKqcBPL8TSEGzOpU4sClcLNNKIYGp7ioV10OU374EzjgEmJQhQKN9bn4pgu5DXxIMm9IY4rSqTW67zruGEYKF71PlTtAuo7HoFXr2JPfT6WmMPoMetYYwf346qeY7g4vx3P1lfjYns3BuaPwjKCum8ZOwHgnLCeDKxN3WYVbg37x0ncOlYsJZ2ieI/aotqCKoZbzjIQp7loPUtp5B7JK9yi8tK6e7GjwvvHj2KSsfmPJluJz1LK70vKUvrIi4cBALc9vCcg3CZR4cbUZTlLHQuVXqMmxJ6jqj7xZQcg3NeiS6mr7pO644VqtmLeDkl8XV1b/Tlt5l5qtUzZpVTd70z9ysiMvG0mZzUGHyNPbY/6+0wDs11F8AbbVeeQF3EJlde5n/ohgR8f51J2KZ0eCjdmV70JF1dPcf9OF6Wk5OI7kwf1JCIkJrtsRzeRMSsZ4FfH4ex+AgCQ23hll63J0ClwLkCzLIZbK1lKJwOMFKFxmH7rrWenPJmW07oNqod72t+j4zUAQG9JJtxEF7h2ILtYqlVMnh8tikyy2AUCEoLGVWLQu5RG3+nihxFuUQw3k5yjJgaTQI9TLQLZpuZcSqMYbo4nk1CsDak7U8G2uD7Xx3BTk4yywq1BMnHbmkuaYFlGuEBlC3fbMqUx4ISEG39+GKuuQ3FmuBhuFlPDGtJbaPpsbIC4nHpybDIdDAPhvSzeT6ZpoFgQXUobhJvQb9oYbuQ4SgK4ns8pCJlCkiOXc0UUr/5lFK78JTz24kH8vx9ugQEPy60hLDDHMM+cwOtLT2GFPYQV9lDjJKDum8gZHk6deBLOgS2wl5/Kv8Ah2TZlBY2yGo194r0QKZjoomoqFW7s+mJ/iOhE0gQ2j1ElKJCepIrsbvyNaCw7hMym2Y11kFxKU2YptRP6piNukCSWX9LsLCrzlAo3jUupaCpHggoKN6aky9smiXupI9xa+z0Vua922tLzfTy34ziGxmrCdv44XR1YfWnogjSEW9KLCq8J0mk6Q6lwI/uVCrcmyEYubhnkNkuKcynOKdMlhhsjeJtRuPFqtgA8IdlFhRtEhVvXTJnWEF+yz0VkhFsG1Hc8CrhOkJ104Zpum5OhU6Cqlm4zUx1G5ArZ/XpRwq2Z35IkAictVOeaRhBsuu54ODZSAQD0FuXpvpMupaLCTSJVGp80sD67/qLBEs48eQGWze9hZ3Pn6hRXnMKNEm6Nhe1YOSAhqEpIrGvapk+KiUjdEbmFW+M7W+DSWF00hptpyAq3KMNltGjKCRlwdbG/dJlJ5RhupvC3EXtfqfZYpgnHDRZoTJ1iWYYcBJz1u1BKSBB0IOA6LS+wLZorDNJHgEC4URdeP33SBCBqL0YPREo3A8Ucf98xYi0nkJpJMdwAniQRF1ATJNmGZKFpIZcP4k75MLHfXYD97gIAwBO1k3Ft8XmstE7gYN9puPvQPIz5Rby952FcVtyGyl2fR8+b/4QbcznOpTReQUMhLu4DhZtMXkx20gRms2FEhE6cGzU9p1lQl1I6b1CCK70qTCCsyTh1w1idZPEXU67YF6JSTIewnSZR4UZ/H5LU1yJRyBNuCtKDp0WE69L7ixJuLk+cKtygKVr9PZddSlsqBgDw4u4T+KdvP514DR3xUSPZWQGgkDMxlibsVhKRNMsUbtpYa8pz4scmhU45FyqqElSs0zWGmxs+D6XvfC5Eh0Lh1k1vWWZG6OY/kwf1JIK+5JqryAi3DHAa7qS5jZfP6ZthtoFXJMyufqWZB7uNODIjfRmtX1/VBKYJ9PfkcHykikPHg3gyKoVbSBR0oB3FhZFO8UYzG7J6m6aBj77zPHIuX7Y+hhsl3KIHSnY8U/0wYis4iS8jLWlLr6XqL1aO7wtZSl1e1VOgWUpDl1JPGjumEbkBs4cVFr+NmixmlmSwNao+sW1FMjOJeFAq3EihdRJrTnRTCzMpxmR4pejvkcdsGtC2tEOFG1EGNcyii28uhpvCVVIHTj0ovAiwTSPKwtlA6FKaVuGmSIwQfPe4MR+qOTXjWTdOJvwCbi2fDwA4e8lCDPuBq+kPyhfizN5jGBg7hon//ku8rtaHSu5UbK6vDMeMo3IpjSN5hH00RhfdN9lJE2jGNDb2LNPgXKNFtO5SShVuhHAj94aYvEIHcdFCFW40PmKUHERflrggr6bMUhqp9DQKtw4sOD1CUibNzqLqSrU4p1Ap3Fi/u4IbKf1ObQoVnhoSo9WfU5EgjSNMkzAiKNvCMiWXUvU16kIMN90LARGJJs8ShZtKJZ2kumqGbNSVxX6zopcS6oKma5ZSZlczLq4q8tFPaOupArtypnCLh5gobS5idvmZZWga3shhuIe2AoYBe8Nl3TYnQwfBxdyZZbNcpFrpsiHgyYZmFHf00MlQuPU1CLaDjHBTKdyE2FPtQBfDTbTT91NkLJJIoRQupYoYbgw0cL0uYH8SzIR+pq5xLucuxlwogm05pUupLz2AGqaBHqHPmFKPXr+noH5vtnJRr9LeJIVbXPw2QL2Y5GKJOVHMKjE+kK7fxeG3cKCICzYuxh++a1OsLTrQ8qIspZESTaVwo0kqghhuCOsRB0rUhS6lVOGmTZpgcmXoSGUa84/CcXkl5UQjOYruXk6zYM6R+IllP4+fL3gHjJ558CeGsMzZh1/vuwvXFp/D6e5mGPDgup7kBhe34JAIN5KFkiPcuuBSappG7DwYl/EzDrzCTd3HSQkLRITEsR8tzCPCjbzciIvhJizA66kVbqxv1Ps7rnBLmJ5FhRvniqcwhY/hFnxELtKEcKMKN9fjiFM2J+hjuHVK4dZ6W+pdfvm/tQq3OnMpDcrJa+YhEcnKLXpsqiKnJVj76hSVyrGncA3VISn7aRTDTX2+nDRhuijcWPbfJgg3VQw3sr+rhJvwTDOTSeTJgu9HIz9LmpBhzoIlS7BWngmzd36XrcnQSczmLKVXnL0cw+M1nHdKcnKCyQYXH6yJdjY035uF6tneMAz09+QBACMTMUkTmMKsA8NDVrSp7fR8P1wU6RYmoq5BT7hFx9GHsjjCTSwpbd2TCFKq4KPKozBwd7hwoYRb8BPsup7sgmsYQbwg4rLMSBN6bElDuC1d0IM/vPE89Pfm8Z27t0t2MogEW1K8RyXhRsoMkybYJhxH/fApliHeN6uX9OFDb0sZC1EBzqW0UZ9g8c6/heaTJpAYbkSFSdtfBTpWQwK7sclSKNzCGG6knXONflZBR8QBvAqnoojhRqHLZkvBAvszMmYiN4jet/8N3AMvYcvdP8Ka2ja8uecJoAyMF8/DE97FYRuydorLGCcSQIUcVbhFdbESVFTtQpU0wTSM2L5u1d2ZkkeMQBKrlZZwU7nlhAo3N8pSmpTBEIgW4KZhwPN9KdunDknzQ0djuJF7VgeROEx0KVUoY3K2AccVYrgRQqBW98L52zJSEG4t/qCK5rZFuGlskxRuGuUTIxxDwk2jkJXLT9iP+P6ZKVAprfj97SrcqKpN3p6YpVTo107FR20XbFy2r3CLJzenDI1rZwo3PcQXm3MVGeE2h+H7PupbHwAA5DZe0WVrMnQadFqbbYEqz1i7AGesXdBtMwCICrf057GFBF30tQLVD5hpyO546qQJk6dw0yUnoFlKdQSlWCUd6UBPp885YnysIiWlWlS4ccRKTAy3IEZdtD1MmsAUbrascHNcHzD4JzU2LnqLdkiaMtKE2qwj3ADg9MY9winchPqK7ua5RIWbvF9FiNqWqX2oTkpc0e4zGedSatL7LNj2jTu2ordoY/3KQc6mMMab54fKAcsyACfmYqRcpcJNm6U0sjHXSBaiQhzhRtU95Zo+hhuQTuFmWQZytgXHDcoyABiFXthrN+GeAWDZ3p/hJPsoTskdwmtKz2DEXQzUVobnup6f4FLKjweVS6kB6tqbaHJLYMUaiNwvTcOI7et2kyYwV98g3iFfsUpNjkOmGg9hgG72N43hRl5ipFFbsPmop2hjrFxPH8NNSDwiohOEG61L0lQgkl70T6VLqeJ7oBZyufHJuZSKCjeFIo5CdSu7nsfFkVRBUri1Mf51fS9u1imfmOKRHa9zeZfKTwjiNl1cAduFKlumLu6aen9CO5FuUZFL4X2oe0Ewi2K4eYq2mC7jKHxOSJgX5zLouJ9lS9GmkLmUzmG4B1+CP3oEyBVhrz2/2+Zk6DDoc91sy1I6nUCJpqaUhGSh1w5Up5umgf5SntsW51KavKxJhhyDTE1s+X70AKVrLl5NFqOE05IUapJDdc20zU8Veyq7DUIS0EVnlKW0kTTBpkkTGoSb50kPxKzOPUSZyEgTev04wi2yjdZD7ie6pV2FG4NtmTh/42JlGUkupe3GFOTj7UVjnF13ourgs997NlI6CccGSROYyiahPRCR28yNm7pq52yTa7PQpdTmFW66OlsxbnXVOq/CoXUQkVbhVqBKFkpomzn8sHwBPjf6arxcWAfb8PAu+6dY9/DfYFN+Z9hOvu/DGz+hLD82aQJVgjWum7R4bxWqGG5mQrKQuIyfcRATxKhctqsi4aYjrWIUbmwBa5L5Mt6lNBgvbMyOV+qx9WBg5LqO0OmESylVlybNBbrELEE58vGqwPXsXtQp3OqOx/VjpHBLfqHg+T7qjoc//vxD+My3nm6uLm25lOq2q5VPooJNTJqQNoZbosLNj++fmQJmO0fgJpG9lCRKLF9N3oW/Syldu9lI1MXqm2q0G8MtbPdpM47SKQ7nMnhPgrnLuGWr8DkMZ2vgTmqffBEMu9BlazJ0Hi0SQRmaQssx3Nhnm12jIstMw5AVbiqX0nCx2Z4NgCKGm6R4Cz5pFk8dmSG6Q+vaSDesm4nhllbdpyJx+HKCTzFLqet6XNZLTuFWYC6lPhczCKCEW0SosUURVQbqYrjxtunHqMGUPQ0kJk1QjTcN4bZqSR8++cHLcOU5y4VrCmVqxkqrGOjNYemCHmxYNciNcbHcMGg6cSsEWNIENM5LVvy97er1+M23nBUSjOwcq6FooUk7dC6lunvQsvREkBi/CohxKU2jcDMN7jja1/Tb4/Nfjyeqa3HC64Xp1vDLfffit0o/xMX5bbjBvhPjX/swKg99kyvb82X6jCrcGNkgKg0nA4wn4WO4xbdRq2oj6h5JPykqdV5Wp3VTa3wym31yLCN/ApfSxrVjmo8teJctCDJDD43VUE/hVholTVDv74zCLSKPk+YCkfTiiAqFLVwMscZnSKBxSRPod00MN41Kh3ax5/k4MVrBkaEKXto7FFuXZjL+JiGtSymrg6hgY2MhSpqQ1qV0bincvCZYNJ0aToWk2HDJLqWNF3wkMdN0QKRway+GW1KCiqlC2B9CuIoMEegUnbmUZphz8J0a6tsfBRBkJ80w+8Ap3DLCbdLQcgw3YZHfKlSnGyrCrSRP9yxbZCd+BFVZNvm/owcSqjBRgVNcmXp3O93bMjEDZIkQHhLZk1LdR21Vu/ESdZSgcKMPjHlN0gTxQY1dgiPcbKZwa45wS8qwalkmHDdYYLWSNEEVm8q2DLgAlswrSYkDklxK2x2Plmnir3/tYhiGgbueeDm8plgujeXF6gEED/N0H4tzpYIBYKA3j4tOWyLZz8or5q0wY66acLO0dbZNE6Ymtphqm44gLKRYMFumyQdHJ0VR89xCP748fjVKOQMfPWMPFuy5G2vMI3h335HwmPozt8GavwLm/BWwlqxXkhP5nIV6gzRk+02T74fJQDj/mPw8/K7rTsG+I2O49YHdCve+5o2hJGOkcJP7QXTnTFqMh/ePHx0buWGmU7ix9h7sy6NUsFCuujgyVMEKkmxFBTY/6EruiMKNS5oQPxdILqUJCjcoyAuViyivcHND1bRFXlDoXUojm11XdvvVQYrh1kZbNutSGtz3kcqxLirc0iZNSNo/XWJvtYlIaUW3xRNqOjWcCrp4b6LyOilLaSFnoVpzp00MNydMmpDeHp5wY5/TYxyFc0jmUqoF51I6h2Vec7jqcxvOnqeAehlG30JYy0/ttjkZJgEZ4TY1aF/h1l7f6GO4iS6lcQq3DhBuGhfS6O/gkwak1xKUwtjV/Ujrmi5W4Qa1XUmIi4MWlBMRitzCzeMVb7xLaUSWiQ/orE9ov0Ux3KLj0riUJpGFNItxosJNRbgpyCxaTpILaadjuAERURuSaUZyzECaNIG+uY57SFQT3syG4AtVj7DvOUnhprbNSnB1lI9XG2tbZiK1HCR5IC8QyD56P7PxUveAQ2tegz8fugE/cy/CUbcP434R1qqzAACVn/8nJr7/cdRful9JHqiSJgRjKdg2eUkTojpRwu3C05bgLVetU/Z3K0QSrXOocFMQ2lIMN8W1aFtELrdy8HYuaUKcS2mjvW3LxOLBEgDgyFBZXQ9ybTshoUUnY7ixNlONW5FoVF1f5ZKsIi9Y3Ep6LhfDzfE41R27x9JkKXU9L8pomdA2cpbS2MNjoYvt1bxLafB36hhuSUQSd+zMJSdUMdx0JJl6fxMKN2578GmF97j6fOZCymKIThuFW5supdMthpsvPMtOE8/daYXMpTRARrjNUThbHwQA5DZcCsPIhsFsBCUWshhukwfOXa+FGG5tu5RqFEdU4WaZhqQyAgjh1oEfQcmlVKNa8oniK41yLU7loA00H5M0QTylFZdSFXETkjUCweZ5Pvd2WZU0Ie56VMEWZikl93apkLwQCmP1GeoHHjo/tOJSqirXiiHcdGSs7vh2QMe42G1hnJuwfaK31GE2OKIYSmsVTZoARP2cz0XEmm1HpeVsvYrTsgxpjMbFY4u7p3IpVG6UEKZF0VLZGAnUOz5G/RIeMjbh48NvxV9PvBOl6z8Ea/lpMHrmAQAqD3wVzuhR6VqBSymvFqKB5SfLpZRXLwbb4tyugdZi89B5IOx3BZtXrYkupfHqmEjh5kvHUiVnbJbSxpxkWwYWz4sn3Cj5lORS6idcNw2owg2A8sZjc6oc90wuh98vb2NzFU0gwGUpJS6lFudSqovhRuwkCViS2qYbMdxChZvkUtpqltL0Kr6ZTE6IRHfwXSaG+HPSq7KSyk1SVLHxW5hmLqUtZSlVqFYpmd7NccQubRnx/TGXQftnLruUZqvwOQivMgZn7zMAAHvDZV22JsOkIVO4TQlsbqGW/jxGXLTvUqoif4wwGDYQJExQHce49k78BkoupcKvS6Rwi36AdWQX3WpZ+jg++qQJTcRwS1n3JMWoSR6A+RhuPhdniKrU4jJQskuoYrjRtk2XNCF+rNH6tORSKpBZhsGXKb7TkRRuHY7hpirbMAwpOH214c4YKdyCLy/sOoFntx8Lz2MEq6q/lASmEK+LjT+asZRzKbVM7TgMlHr8trhxQxVqIpLcwlzPF5QspA/p+CduhWGwftMEYMD1TRj5Enre+DH0/uI/wFy8DqiV4d36V3hj6XGcmdsLA9EinxXLJU0I76VYc1sGjd0X3RvRflWftuRSyincgn5RKtzqYpZSRWFkW0gMQ24j00iO7wREC17bMgnhVlEeSwm3sO+bII6ahRj3TjVvsTlVzlIaT2qoCJ8cIZAZKCHgiEkTElxKeTt5UjSubaJx2bB1KlxKNTHcalIMt84nTZjJ5IRS4cbtV50jn6+DPgZf8Gkl3ONibL5pkzQhJNzS2zNdFW6c6niSf7NmMmj/zWG+LYvhNhdR3/4o4LkwF6yCtWBVt83JMEmgC4iMcJs8tOxSOokKN8PgXUp7FO6kwBQr3AghFSnc1GVxapoYhVtLLqXCOWkl7rxLqcoW9gDML9xoEgUDUXy5nGUGCSGgjnvDyutVZCmlNqdKmqBQ8VDYzSRNUBG8psGp/sQykhRuSfvbASvJNIDDgoInItyYIi3YfvvDe4gtkX052wxdreh+EaKrNlv0FMg4bMqlVNgnxiikWNRwD1ShkDMxphYxAQhIBqpk4esW/UFtZ2QMe/FASQLDtFC69jcwcfs/wR8+iOtLzwN4HtvqS/BE7WQsGgZexgoA4OYEdqXJyvgWxnAjtaLjV+VS2gqJ5HKEGyNhVQq3FC6lkBctvi+3EVW4+TEiEjZHWaaBBf1B0iydwo0m52CtFNc1rucjZcgvJaIXMvpxHmV/Fgg3RYB1HtxKHUA0/9GyKMlIFW6mYYQqRR3hRi9LY7ixc3RtExGNJhzXa0/hpnMpFbYzlZ6oYKvXPfhEQVlIkeUYSOMqqf4+0xC6CbeocEuquxgPbu/hMQz25pvIUtpQuOUYmTw9FG7MLscJxlea33rqNjuVMdy2vTyMat3FmWsXKPfTy9LnW4ahsSrufeYArj5nOQb75m5iQp88/85ll9KMcJuDqDXcSTN122xHNLFlhNvkoVWX0ohwa69vlDHcTAM9RTsM9q5KmEDPbSbZg9YOUaUkqZaiN4Chu542phYdu/rYU6ldSmOSJqQlGzk3V6WqMPikMeoYGElD1Tu2ZSLIEGoq3StUWUoLjZUaJfTofq3tMUoRgCcBWonhRkmpoLx4Ai3JrXeyFG4Hj09w+xjRERKSKhUoUe+p2kZlKqtvGMOtQbRRFQklzXK2qZ0HxCyldMGvwsIB/YN9kkpFVLhRi6h51HY2diPFBV+mObgMvW//Gww9/wAevevn2FTYhQ25w9iQOwy88DAG8sswnF8POEG2TIPcI73OCYx/908BMwf7pPOQP+8NMEwTnu+jWnNTqTtVYCZyWUoT7u92Y7ixIlUKt6qkcFMt1qPv1D7xUMOIFKVNK9yGk11KWZlxxIrr+oD6HU8qhDHcyAshV3gt4WhcSn3fx60P7MKieUUlGcETJMFnlDSBxG3jkiZ4XOysJJdS2jauzyfNiSNuKZniuPr4XGmQVuHG2rogsIA++GQ++ZjwB3HlK44gx85cxi1KmqAmfpRUbxOqLLr/+EgVf/HFR7Bu5QAZhw3Xbs14CpWLjWcfqij72k9eQqXu4Fdef/qUEyDs2cVHMEatFNd3FSQ639adH0e+7+OfvvU0qnUX//J7Vyl/a2gfqX7//vnbz2D3oVE8v+MYPvaeC7TX2vbyMMbKdZy3YVHnKjCNkOTRMleQEW5zDM7IUTj7NwMI4rdlmM0gPwZZDLdJQ1ysqjiELqVt/gjpXfwM9PXkMDJeUyZMoOdOSpZSzbU8P00MN77cZhVuZmNRxB7UOpE0gYtnpYzhFmxzHHmVxBQilhWRJYy0YIsr3fWogo0p9+gCnZKJOiQp3CxO4RbfIFwsOwSzjOhSKivcRHuEPoi5Rrug8evENU7Ujnri2TCiBbbSlVNJeLPP4AvrI6pws1Mr3EyJ1FeRNgAwry8fZlNUIY1LKbewoH1N+5fYExJuMa6GhmmhvvpCfGOijp9WzsZrS0+jaNRxVs9RzKsdxHv6DgLD9+PagXl4xjgNA8MeBo1xXFF+FN7oXgBA7cgO+LUJ2CvPwC2PjOKBnXX87QcuQ//xF/H/Z++94+TIznLhp0KnCT1JOWdptUGrzTl41xscsL3OGHDgggEDtom+9/IBBgO+BgzGhssFG2MvBmOMbRxwWIfNOWp3tSvtSlpJq6zR5I4Vvj+qTtV7Tp1TVd0z0zMr1aOfft3TXXVSnaqu89TzvC9cF8aqbdBSpkCjMdxkdmuppXQaMdwMcg2TnV9pFG4UgcLN/0ehkyQbsUkTghhuOhfDTaY6oapORgLFDUdnYrg53GvO1NG0HJwYreJrd+9FTymHjSv6IvvJLIBmQKC5mKg0/O3CfZpU4ZbCUkr7b9sOd4ziiFv2lalrqGN646i2JIrEpVzhBnjZc1nbRUJOhSTygyedUhU5L5FkbZRbStOrsijZOjJRhwuPeBNjuEUe7jVt/L9vPosnXvBiZrIHKKGV08GPHn8ZAPD6K9diUb9aET0b4BJKWS6MfMzGPmTKQEfy2UzCcV1U/Mzijab84Y7sIQht6/5jEwCA3S+Pxdb1p7c/BgD445+/BMsX9kyr3fMRYjb4MxUZ4XaGYfLZewEAxtLN0HuG5rg1GWYTMjtLhplHXKyqWAQKt+nVL43N5n/Um0C4BcHdZ2B6iHOsu8TXGd6QtKhwiyGA4uJnmaYO21/IzoilNME6zL6XLaiYQsTQdSxf2I0tq/qxaWW/105/caUqr1sSw61GgqynIWxD67D8e6qYUmW5ZKBFmP4ilwa6B6KkQqKlNMGOPB30dnvzsLcrjzdetRbfuHdf8B0j3OIUbroG9PcWMFFtYqC3gJNjfJyrOEspe3ovi+GWI2PE7MUyiFlKdV2tQoyzkwJITJoQsZSS7yhRrRMrNJ3bQFxMIW+7YacXX5q6CgDwv19/FkYf+S56ju/AMnPU+48HgZ0P4g/7Ad0CYJjIb3sNGo9/E80d30Nzx/dws1vEs84tGH/yDpjPfdVrX3kxStf9D+iL1gGaFpsMKsiSTBVuCbE4pxPDjZYtO7+iMdziFW5h0gSZwi2cL3acCs0JidKhviI0eATLeKWJvm5+FdwgTwQCokFZcntqQGnbmDo1pg7WR9PwrkWVuh20WW7NJe/ZvuRBxgf/5t7IPk3L5shT1i5VXCzRQsrFjYsl3MK+JG2bhLRJE8IspVFCrWnZJIZbWjI7qV2nh8JNam0k38vOYZX9lOLEaBU79gxzNm42Dxwyl1RJE5588WRAtgHRpAl081qdT9bSCdBzxnIcFJBM5PIZW+OJzpmCLFGDCI5wSxE3Mwm7D46eloRbmIDqzF6HZoTbGYbJZ+4GkNlJzwTQJ2QZ4TZ7mG4Mt+knTSDvESqOAKDXJ706YiklDSkVTKwQbhzCuEPJCjeKuLkr+ypQIxk66mCEG7WUylU7SeBVd7Lv1YUFCjddg2no+J2fviD4TkWeBAo3SQy3VgIO07alUbjlzPhB4ZROhoamxSylpDxhgKI2XvFvkXCLbUJL2Lp6EL9227lYt6yMcnceV5yzBH/x5SdxfLQaKItkgfNp2z74lm0Yn2rguw/tj3wva6qYpTSM4RbOw4jCLc5SSoZTJ4o7EQv6i9LPGZLiMNm2kDSBXlu495qvzHQDwo0GjXYcF3/9H09h6VA33nnjRgBy8iDf2489Q9fgey+uwbnL8yiffBqXdB3E0m4Lhcpxb5ttr0XhojcBABqPfxMw8uiya/itvm+j8Jy/KDXzcMePofKtjwO6ARgGcpuvQf7sG6CXF0XqZWsiXZMfe9n1sB0SiRFH9LxLpXCTVhV+SPi2yAJP18hiPKXCzTR09PcWMDJRx/BYLUK4WS1aSmc6aYLs2moTEgLwCOwqQgLYcdLY+rxXdi6OTTak7aEKN0/xGk2ywNdBFusOH2Igbh6x42UG8bnaH0fV8YlYSv0PZOrdhh9nC2glaUJ6hVuaafLI88dRq1u4etuyVPV3Cqyf6hhu8fur+v71e/biwWePcZ8Fc53E1FPFcIuE02AKN59wo3OqKVHjzzYcmgk4Zf28pZS9ph/rdiBmmpcj/DwuaULa9dfRUzEBVl/BoEmKzmRkhNsZBHv4ZTSO7wd0A7m1F811czLMMugP65nunZ9NtE24Qb3IbwXsR0zTvDJd1w0WjCxxQrLCbQYIN9KRzSv7laolL8ZZdB8K2py4mxWpws2/EaULCJXCrZV+J8V4ijuODYtXbFCoLJzSGG4pFz2qspRJE6gCp4WkCd7C05YkTYhXsEUVbuo6pgtd17B908Lg7wX9pWDxGBJu8nay7wZ6CxjoLSi+l80FX+Hmb88yBtNjGY3hJm9/ROGmaco5s6AvnnBLWjRbjsPZTjmFm1ClF3vQJgq3cIO9h8fxzL5TeGbfKbz9VRugE3s3RSFnBONXcYt4ur4ZL3adjzdftB5f+9a9uGBRA2++4A3ethfdhvx5t8K1Gjh4++9hUPPsOrmtN6BwyVtQu+tzsPY9Ctg2YAPNp7+P5tM/gLnuYhQueQtHvIUWl9AKnaRgnU7SBCNyzvAQCTcZUSZTuHlB7fntdC08F1PFcPO3ZdmTZfEkqaU0XPAqi+ZiobUDmhEUkD8YCS2lPGEUKnmisTTZ5+J7dj7J+g548dyo6i60lMq3p4fPdlwueUWaLKVsjjQtB4/vPoFNK/u5rONpkNZSyuaainBjXcynTZrQwgbJ9lMX//cbzwAAzlk3hIHe+RN4PrRWy5VQyUkT5H2v1KKqsyBBgxOOWFpFVahwixLlYgKgToCzlKZ8cChLhNJJhZuqfHq82c+HbNu4rOIUx0YqyRu9AuEG1/M5bsgcIyPcziA0dt8PAMit3gatePrJVjPwoD8YmcJt9sDFcGthnNkiYvpJE9irZ49y7HDBeMlZi3Dg2ATOWy+3j4cqu2k1AQA/xzav6pfURRQwCRLzKKkjh2x/tj27ydE1jbvh4RVurRyv+AV5JEkEEKiAGs2o0kVsr6o+zlKa8sYtWpb3qlZREfKnhaQJbKHKYgbKyvP2EQk3scz472cazB4VyVIqtWeTfrVoP2avl529GCOTdVx93tJgm9RZSg1JDDfFnEmylCYmTbBdLs4ctZGKylBmhRZjuLE2MoxO1jFYLsoJt7wRHGuLkCyaBhy1+7Hb6OPismn5ErR8Cf+v+QZ01U7g1ldtw4UXbAUAFG/8AJyT+wEzB3fiJBrP3AH75Wdg7X0Y1v7HUbjsnTBXnAOtVA4WaxqxQidlIW5HbSSzlEoVbmkspeQ9bZ+4wKNq0zjeyyZJE7z9QhJPBLt+0baxpb+GKMkybYWbEKdKdtqxxTqbV6JS2HHcROKSvWX7qgiIRtPhHhKFdj6vreJ1g4/hJijcYuaRqF565Pnj2LFnGNdvX46fvXmzcj8ZVPNVHBI2frLrvkUUboUZSprAxd5KmCeUAPXCKMwfwk1G/EgS4HJIY6eVjQn7jA8TI0+a0BRI40JObSltyoLHzjKoKtRKSczLVJGUrJ11hZuqAvIxvSaISEu4iUmdThcEIRyU6c/ODGSE2xkC13XQePFBAEB+Y2YnPRNAfyTOdCnvbIJXuKXfL26R3wpChRtTa7hBOy7cvAgXbo5aqhh0su9MYsuqAUld3iuXNEFxH0JbE69wi34mBrgv5g2eLJC0KQ3otjJyRDyOhuERI5ZtBzGQZH1RxahjmxYLZrCoTWvriZSVoGSkbYiLmQfwN010sU671nIMt4TvZxr5IGaTd8PPalMp3IL30uMeLf+s1QN4aOcxbFndD8BTmr7t+g3cNpzCzVBbSk1dixBubSvcEm78+3sK/Daa9C2XSIIt8CgZSRfKp8ZjCLdcSLixhRglb1WWyEm7gKPWYlTN8DqjaRqMhWu8PwaWw1y1DfbwQdQf/DfYh3aift/tXqxETcP6ruU4O7cRGgalDz6kSROmo3DjYrhFy47GcJMUJlW4KWK4pVK48eROuE90W7owZ+MQ2HIl6sXpx3ATFG6ShZotkBDiotaFvC8yK1pc1l/Am+PU5kqPoW270AUbPh/DjScVYhVuAnk4OuFF9xyfkltd46DiMsQ5wf6WK9zsMEtpyqQJScS0zNKrAlVAzSeXhuuGdI9MMQnI1Xtp+i6P/eZ9RsdDlRVaVGkWckz5KVG4NedY4daWpTRKdE43SYsMaWK4cS4iTX3NjSPc6PE4PiJPWvNKR5al1MMZLvA7c+BOjcCZOAktX0Juzfa5bk6GDmC6T5kzpIMhLIbTgm053d9WqlILyLeU7UiyGraLlYuiClpO4ZYUw4183GrSBNYX9sS+WDCEfcj7lhSJ8cSq+Jmhh4HwA9udREWgjuEWkmQsQ5ZImBRTqg5Cy6T8e7rgTFp88go3piKMVyWKhykaw01dx2xAaSlNULjJ52v0sws2LcSnfv0qnLNWnZiIV7gZMVlKRUupmoROJtzk8+WSsxbhws0L8fZXbeBsy1wtAmnN5rJsblPF1vC4l2RC9ntUyBnQwS9UqOpMudAhGffiYAytROk1v43CZW+HVuwFzALguuieehm/2PsTXFq7J6grKTRAOySSLDmM7HxPZSlVxHATlTKUsIxbiIrKsKBMf599R8bx9bv3otG0pZbSuMQ3Mx/DTdZ+h9tWtqi1JfODV7jxpKMKTcvhSEB6fZPZSukxsR2Xm8eqeURJHEaoMzJ7OnMvUo9QFmu+TOHGx3CbmaQJKoJKBqrWmk8B12mr6XDyltL4/VpRuNmBmjMcD1XSBDEuG8taLYs5Nxcx3GgfUltKJXOmkzHc0lhW42K4xbkGxPN0otJUbpv0ezdfwcbvDOfbMoXbmQKtawCly9+OvlUbUDfzwBxcaDN0Fhnh1hm0G8ONYbpPsziFm95aO2YyhtuGFX249bJVWLe0nKgUEhUMkXZRgmHaCjf+Zy7JOqZCUlB1WeZNtpCrN9UKt6QYbgDQ05VDpW5F+pKWcAuJVfmNH11wmgkqKFk2UpoZkX4u2weQ2G8TFG8zjTzJSkjrl1WbpGxUxSFKOq/pGHlJE+TbiZZSL4aU/BgNlpNiuMn327Z+AS4/Z4m/TXLSBBDSTxbDjWbYO+UTbjLyo5A3gjrY97oeEsPKjKf+52kWjJqmIX/ercifd6tX5tQI9vz4a1hy5B6cU3sM+wrL8SL6OTJadn7PpsItmjQhXh0TKL5cN0JKepZSLbHNQQw3dg6DXzD+8RceBeAlwKFkVpg0wft7pshJ2f7BvJfVkWApVbVDZkVLsnw1ScZTXdO466W0DoFgo01THRN6zGkMN1UdSUhrKWWLYdkYNJtOMFq5lAq3JPaDJ53ii7I4onf+3M+qlGz83JLNi2SSKM5SSvcxFIk1RBKr4mcilSU7acy1pTQlgcTHU/M/k8zjmVSGpUmawB0PRrhJ7gfi7qnEeXBkeAplIWkNALx8YhIf++KjuOWSVXjj1evimj7vQBPOnMnICLczBJquo7j9tega6EZ9ZGqum5OhA8j4ts6APu1uLSaY9zpddRmrXdfDRVNqwk3jX6fVDk3DW6/boP5ejy5S0rRTVFyZhh7cqEljuBl8DDeRlOIUbi3ElEiK5RWxlBLrkYyUCLdTKNzIx2++dj2ePzCCtct6uW1EAi6p7UpSJyHGFF8W2Y8p3Py4W2EZfJ+iirYoOamqYzYQKNx8YojGQRSRGNurzQutmDRBafcVFG7UzgkAXQXTzwrcrVRLMqgsyZRAKBBSjovhRrbnFG6SGG7UqnRirIZHnz8uXVzRpAn0mhBYShNUIO088de7B/Dy8puxa98JXFt8HrfWv4NzygPoP2aidv+5yK2/FFuwD72mi4PWEOrwgtXPVAw3GVkqlpxUV5zCjbOUxhJuTN0VqlQBlogh3O/EaJXLfhuUyQg3yZSbrsVLVEDLzgwW/4kpZmSEkUxBww2JECtOBZqlVGYpFSEq3Oj5m2bxLiZxcNpIQqGyY4uEQGjJjV4bqFI17T1C0uUwTeIABnp+z6f7WXo4VDHc5HZm+n06QlS1LbtvELcXH0JsWtnH1U2LmvukCe0QblHi0Pt7Zu8b0lhKOdVxcM2NbhercBMKPzxcwWZJSJb9RyfQaDp48dBYXLPnJWj4gTMZGeGWIcNpinZu0jK0DlWw8CTEqWpaQVAOwoVW2jLZYispM+VMgC7eAzWLop1cAH5ho2LewGTVj70Vp3Az5IQbZ41rYezpttIYbsIQshhuQKj4aVfhdvGWRbh4SzQWX2qFG1M+KgacEjWJllLyPkcW63G2uYjCTWxfpxVuAuHGWpSkXJS1q11ugbOUGjFJE3SNm1teDLfwg1LBwMd/6bJUY6ZSuNF9KSnHkdMC6ceyW1oSMrlOlBN3PnEIdz5xSNEeI5gLVNUUWEpVcaj8bcUA4Ul4bv8Ieko5OC7wrcoFOKt3Aouah7DWPAk0gOYzR9F85g7cBgBlYNwp4nOT1+Ela1F7KiOZwi2B0Pb2i37GKdxYEW50/uk6jeGmroMRVWbwmxHuM05sTeXuPLeIZ0XGJb6ZrsItlaXUJ7rEuGd8O2QDSepJqXBrWA5noWWKXsd1pX0VkyYYOk/AycAluTL4uFszqnATLaX+dqYZHWSqVE37MDFJidZKDLcmITPnk2NDZYtNSoqQRuEmO9ayzwILo/AdI7EuP3sx3v6qjcRKKlG4NTurcHOF86UdS2nA97vRbfQWHqAmIY2llFO4CQ+JaJvjY7jxf4/4cRtFsPk/n86DtAjDRcxxQ+YYWQy3DBlOU0z3pjdDOrSdNCF4nd6vUBj0myh1UjbkvPVD2L5xAa7fvnxabUgD+mPLbrTStFPcZvmCblJmdP81SzwVGLvJKYmW0piy07YjKdYXwKx/3meNOIWbguxMQ6CkjuHmzzFVlk1O4dampZR+Pljms8lFFWzC30KVHUuaEInhFt02iWhtV81jcjHcdGWfDUOLENBckgtdh6Gr96dQxXCj5alUcBGFGyPcmFKKs5QmE2GMZGTN5hVu3meqRSvbthWF20Slgb/88pP4m68+Bcd10YSJOwbegS93/Sw+P3kNHlv4BhhLN0MrlXEYizDmlFDWa/i13h9gtXHCy3rpunCb8gWRDDJLaRKhDajmFFFTsMUdZAq3cB6ns5RGY7gdHZ7itqOEW2hvU1/Dp7sojCRNiCH1WHZbaQw3qd1TrRYSwc47MYYbEJ4zMqs0H9eLVwymsZQyEpSNu9UO4aY4NSJEBRs/IzzvxSzOwMw9BOEFYQkKNzrv5pWlNHyvjNsmVarRbZPnQdxnZkCq89+xOVMqmCh354UEK7wFXcyOPNuI2l9nVuE2k+AVbirCLfxcjOFGycw4wi16/OTHxA76HdPoDuPUeA3/3+cewl1Pyh+oMcQ9nDmTkCncMmQ4TZHxbZ2BmEEwNQJybHr1B3ZBogxJ+8PW31PAr735vOk1ICXo2DA7kGq8eNui98dvv3M7jp6qYGKqgV0HRyP7/OF7L8YDzx7F665YAyDOUqpJ3yeBs9fJFG5xltKmmnAzU4yBCptW9idvBLJwTaVwi69Y545NaCmlny/sL3H7iH0R/45mKY1twrTBFpS1wFIankMikhRuM2EpNU2dmxuaxsfIEuNEUtImjWKKQZWllJbPWUpFlo28Z/WGdml50gRlW3JMHcnUbOymHEShJSNMwveWlX7sp2oWHNfFRKUZqEJ0XceYOYidDQ0Le1ei68Y3AQD+7fMP4+ixEby3525szR/CO7sfwFPOeajf/Xk0d9+D0mt/B+aysxLrlFtK0yjcvP2e2TuMZQu6MVgucut3SkiKY6QjXdIERpTSTMNsn8PDlWC7St3i5lukvphz4uUTk1jQV0xtfRf3j0+awCs+ZLYt2YJeRnqoVMZdRROT1WbEUspem0gm9WzbgUPOO6nqDjxBZgYKNz4xRCtIQxLQ7Sgp0F3ModGsc+dx2mtyK5bSxBhudpTonQ9QKdmS7bLJfZdZgWV9pwTPsZEKhspFLtyGSKSz2mkba43OEm6i/To14SaZM+KIzHSMP17hJt+GuyYLv1k0LqeK0KfbM6hsvuKDjvmAXQdHcejEFB5+7jiuPV/90J41+Qzn2zKFW4YMpyvm0xPB0xntJk1gBM501TxhXOnQSjRdEm82QLkMduOlGi8+46X3/qzVA7h++3LlgnXV4l68/VUb0V30Yi6pkibwNrn22p+khPLaHZIozGInI3RUcbfi5tIfvvdivOmadXjt5WviGy20LS5OWNCeBIUb7Sgj53SNP2YLBMItKWZblHCbbYWbR8I2mslZSmlTRSUe0P6DjZygcKNj0lUI56yoHtQ0jSMIkuJPUeQVGUjpgoBuQ39CuDhyCO3STRJPkW2RxqoU1BMo3EISPi5LKV0ItZJlL7DkEJUHHVsuaYKmoYEc/mXqSkw4RSw1R3HFwX9Cc9fdgOui+cwPU9UpVbilINxc18WLh8bwya88hX/41k7/M7594bb8vprOL/4aTRsPPHsU45UG3zYh9h7rv+sCR06GCrdq3eJUF6w+Noaya5rtuDhwbAK//7mH8dlvP5fYXxFiBlTZiNlCBk/ZdUuu8o8upFXXYHYeShVu/muapAlpFG5U7RWo5/xtZXHikpA2Rpgsy2tX0et3nShV097bJFtKk8eCgY/hNn/uZ3lbLJlPim1knyUlhKGQjROdf//z/z2Iv/rKUwDC6zE7nvT8FAn6TltKxXMltaWUi5knV3rN9PRoNWlCGHfU+5uS1XHnhPhVU6EODyz08+c0iNj6VRBjcp6pyBRuGTKcpphPTwRPZ1BLYCsKt5WLelAqGNi0on9a9dNYcAH5NoOxLGYKdJGYlKVURQYA6sWRCEa0dZdEwq1NgjRByegt3sMbKGkMN0nbVQRiXNNWLe7FqsW96g0E6BJSQdWGpPGl7WKLXDFL6cK+onKfNH/PdmxdpvSqNfgspUlWYXkMtzYVbtTGKWQp3biiH67rYkGfR1zyKlr+nIh7ei6CqcrCoOxRQqhACDcVoaVpYRmMjNF80tV13VREGDsGbEzZNYHOJdnYUoUQjeE2Xmng8995DtdsW4btmxZG9mMLTcehhI6cbGXvp9wivlq9DO/uugvlxonge+vAk3Brk9CKPbF9lCrc0lhKHRf7j44BAA6dmATAjwWdkzLFWTB+jotv3LsP33voAJYv7MYf//ylYR8UCjfXdXHkVKhwq9YsadD/wFKqULgd9cs4OVZN7K8IkaiUEfBifLO0SRM4ssR/VV2DS4RwowpMbx+dq5+C3nvZjssRBjJCRdxHnCPTiR8oIqpw817p+LF+N9pQuCW1NI2tkqHJKdzS1d8JyBRXkfeSkVDtx22TMoabeC/x3P4RAKENNzivyd2UZysN96mnsP7PJKKEW7r6OfKLKdwUSs2ZQhpLKRtMDbwlH+DVg3Hnr3i8VXFJbeG6Ox/AfouTxj4u/MCZhIxwy5DhNEVGuHUG1ILXygOcob4iPvXrV6cmkFSgZAG1l8430IWZHZNlFADHuIkKnrSKnlddsByO6+Kabcv4ohOUairIFuSybdiCytA0ie0uup8yftAMHkPWXFUMt1YspfRb0whJE3ojKFpKk5IiJMV4m2kwdVVE4SY5FLyyUUa4tdeGuBhuhq7hA7eFVu/YGG6tWEr9fhuG7h0vSSxFuvBuWPIYTpoWjeEWxGNz01pKeau3LZYD+W8Y/Ywu2L521148tWcYT+0Zxj995FXK/WhMLUpOiaQmw3POWvzZWB/evvIQtm5eBWvfI3CGD6K592Hkt0br4frkhNcChjQKN8cFDvpE21TNQq1hccv3cHEnUbhpoRLTcYHHd3lE4aETfHZ6S0iawLrsusCRYV7hliPHKgy+7v0tO2dsx0W1bgXvW4VIVEoVbmyxF2MplcdXo6SHel8gVHo5rhtm4/U7HCqMonVQsiWtwo1+LJ7TKhtqHFTDrlS40UQseRnhpuGWS1fhnqcOY92yPjy9d1hafiIhwKm84jellvH5pXCLzqHoe9l+5L2CmpRe8ySFqX6mRYUb/clyhLlY77SltE3CTTbG4jDNvMKNJIpJOpe0qMKNxjGNW4uJ54tKdRg8MJpH50H48CVhO//72b6vm++Yh8ajDBkyzAQywq0zSAqmH4fpkm0AH/A9WDzOw981OjShmkW1LU8wUKTNqLpooAs/feMmDJZFtZUmfZ8EnqhTqdJ4IoS1PS5pgmoBPpM3J6HVWF5mu0kTzls3hKVDXbhg00KMTobB5Ms9eb7+BMto9O/YJkwbYlDw1Aq3GUyaQIktMUupWI9oWzfatJQWfCttzuBjxnGZlkl/OaWaRt9qwXnIttG0sN1s0dDXk8eQkEBj7dJelLvz2LZhgb8fr3DTiTVernCTE24TgmVShGjzY3WzbqmuC6ah4bjTh0/v34p/OrAO5oYrAAD1B/8djZ0/jq1TpuRNpXBzXbx8PCS9hsdqHFHBsvHJFu2URLQdFwVFYhVGcBqCwq1at3BqPDyXK3UbzWbUUsrq1iX9cRwX1brN1dMKIlZcyRQP7ZY8wSDbhkKmcFP9DpeItZuRExFLaYKKzrYd7iglZSnVtOh1qJ17OVksMK9tgjJIohBcOtQFAJEYbm+7fgM+9etXY0hQMPPlJ7RLQVDJMF9juPHWUPnnCSHcYkic+IcMAH+tFSEqV3lLqahw63QMN55gm16WUn7fpAQcrYJTuCXMPV0jD4n8dtSaVrh/zDwXi1apw4OYlfPnNAiSuaRWuM3DdUknkRFuGTKcpphPT0JOZxgxC+VOgN2ca+RHfz4q3GSWUhVZQD8Vn/YnKbAS20Het0KQcgo3xS8n/ZzGcGMLVjnhporhlrppiUiKF2i0onAjX69Z2os/+YXLcP7GBRivNIPPIwSbmIVUKFOscrZjfbAYbuyGn1UnSyrBW0qjZbW7EKRzIWfqERUb3wbyXheSJrQwUZi9ulQwuPpUmTPpU3quDUThxhQV9PrDrEpXnL0EH3zLNq7MwXIRf/WrV+Jtr9oQKRfgHxzIhpaON12cJBHx9PeQV+VFH1Jwx4KU+8jzx+FuuBrG0s2AVUf93i/CeumJ4Ptq3cIdjx7EqfEa11YVuamCZTk4ROKoDY/X+OVkoACM7qtpIdHvuK40k7Hjhplew0zD3ncT1Sa3bbVu8dY+UeGmIMNChVsb6iyBqJRdDxjRxRTFsuuoakEvZjpU/V6WCuHY1Rpef4KkCXGWUkHRlmbxzqkuhfa0pRJUxnBzpX8buobPfOhqfOrXr0JPyYuDKovhRhWoMqRVu6TZlhJu88lKl07hljAvUliLGcTjT0l1EcxSmjOi1zVn3sVwa91SOicx3BSFc1lKiY0fAOqNNhVuSUkT5hHjFqjGk2K4MettpnDLkCHD6Yh5dF0+rcHFcJuDHxQagyiw4MzTH7bI4lpFuGnqbVqx0CWV3cowpVG48aRcqAKqM4WbLIabcgw6p3AzOUIgQeEGvo+p6k+wkEYtpamKbRv5HN9H1ie5wi18P5MKN03TMFQuImfq6O3KR4L2U3AKKVHh1oJKdulQN9716k14zy1bUj0ooJZSjZe4hZZSK7SHs/FjC7mcqUeUR4YuJoHg6+QspYkKt/B9klWT7hckaNAgfUhBh0Ms19ILKL3ud5E759UAgNo9n8fU1/4Atfu/hP/48Qv4tx++gD/7l8e4OqkKLM0Dg6OnKtxidHi8zscL8j+XjQ9VSLkKhZvNjRuvcBMXxZW6xS0CIzHcFEkTqj5BlVbFwu1PSCAVmCWW9UWucJMvXl3hDSWQKfKmEYwPUwOx/rLjKLOtujRmm2DjUyrcyKJUbMpMxHCjNmRpvbqGrmIOvV35IL6iKktp3AxOTJpAk1YkqJIo0dvOGMwWlKo2yD+XbqtUuMXvB7B4mfL92ZjR+KphOe7cKtzaJNwcjnBjr3LieKaQKktpcP2gv1neKyUzW4rhZsmPyXxUuIVtSiDc/MOcJU3IkCHDaYn5dINyOmOuFW580gQ1cTAfYOg6d5OVLktpe0kTVGjfUkr2S0GSGTqxlLLFmqS+drKUtoog0LfKUirEE4tDEvHYXYzeVkQtpfHfd0rhJrZHVq1IooqYzn3+775rO2oNG6WCyS0gxOMktoHOmVYUbgBww4UrgnKSylAq3BC2gdrD2fxnBI2KcKOQHXtRLUDBK9zCxUnSdYELZB8oGzXpNZOexyPEXgl4i0RNy6FwyVthHdgBd/wY3Oo4nJP7YThNAKs8ggy8eoghjiAtFUxU6xYOHJ/kPh8eIwo3wrjJlAWapgXXJ8d1UcxFCTd6DTYFJYxIINXqFrd4DBe8fn8kJ40zYzHc+MQaFGKGPFkcNvVC2QU0LYwtBI/EFtvquC5ypgbLDoOgi9fSJIWb5fAkR1IMN12P9rc9hRv/N/vtFesPVJikzpyUcEv3u5l4PaRjkahwS1YZzQVUSrYkBVsaO20axbSYpIiiGSjcoueO4/LteqVYSmXjJu4509MjTdIE1hb62xckTSBjG2spFf5WW0odrvz5gDCRQ/x2dJzOZGQKtwwZTlPMJ+nx6QxDoYzoFEKygFhK5+kPW84UiJcUllJREbJl1QAAYFCIDZUW7SrcOJuZUuEWvqcx3IKkCRIVTjtZSltFXIwyQCAEEiaPGDxfxFA5Gt9H3C4pZttsKzRzosItOG+i9aZRNraLBX0lrFjY49ejJvbEa0wrx0uFNGVwCjfhvJERZ+wjtpDLGTLCLYHQ1aNqAQqa5dGSKLVU4FRGzFKqyW349P1lZy/m+soUfZqZR+nGX4G57hKY6y8DANys34ctuUNhPdIYbvRY8mPY78c+PHBswqvD/3p4vBaqKfx/gDqYemDJdcJszUBIUFIChx0PTSCQGBHnApggdvFo0gQJGea4qAUx3Nq3lMbFcPva3XvxJ198NCAPk2JPUoTDFi4EZfOy0XSCz9k1PIjhxjL9JsSJcxzexqciz9j9mtRS2s4YCnODtTeicGPqE87iLk8qwxB3xUlSrcmSVqhgccrK2E07CllMMQCJMdqSFHBAOnKVEjwigvMhUK7SOgWF2yskaUKaLKUzTURxdarOWf+VKg5ZM+jYxlpKhe+SLKXziXhm16VEhVuCdf9MQaZwy5DhNMV8ujCfzohbQHUCNDNpEM9tnv6weYsXmvlQvh0dRpGQKnfn8TcfvBoFiXIjDdqxRIptUu0Xtf7xSoFWYrjNJOnExlBF7lHbXJLCja626HzftLIfuw+O4uZLVkV2iaqY4r+f7dOoEFG4heeQiDTZaWcacVlbdV3nFW5tKj5bVbjRA68JtlbvM6JwI5ZSUU0Y3S86N+KSJnAKN6rUoqSY7UTOKy67KbOU6nIymr7fsKIf77n1LHzo0/dG4pkZC1ajdOOvwHUcVCsjKBzZhV/u/REaroGp/7of3X3X+PWE5XHZaXN6GIxf09BbyuEIgOMjVQDAmiVl7Dsy7iVNCMaLLO4kazOPsPH77LocuTxVs9DfYwQLXUruhCSdN06FnAHXtWE7LsanwoQUaeKfOW5oKW1HnSUSlaqzbs/hcfR2efHGVJlGZWDTKsyeJz8HmrYTXBvFxDeMiJMnTaAEmxOJ6SZDsCiVqJfauZcT62EPiU6MVvHcS6dw1ppBod5w2zCpjCKbeMxlMFntkn5bSxI7cD6A74OcQJQRj2kUbmmII42c4yIYMSyzlDouX3692VkWs21LqWS8ZzuGG08My7cJlFsgqmz/s3paS6lQeFLShHl0GoSZUxOu8cHDmTNc4pYp3DJkOE2RWUo7A7rgnQuiKxABaPLF43xCarVLgo2vp5RLJoYUEK1xaZGGeOGzlOrBIpAtqmWLOhXZMZNPA7etX4DzNyzAdecvl35Pj0NiDDcF8fiht56H//2zF+KysxdL9kkgWWIIptmAGMONVd9ODLfZQISQ1PnvuKyybbZJT3HMqWVT586b6LlLFW6MqDMlCrekeH30wYFU4cbFcKPWyLAemVWKliVVuNH+caSyb431iRfZgkjTdZRu/U08X9oOxwXymg3n2Is4a/c/4YL8PqWaME/GprcrFwnEz7JFego3CfmYEMPNcV1OQTFVY3HV2PEJ29Jnj+Di/B4MTrwAAzY0TQuydEoVJpKxYuCTJrRPFrGxirsesGNpmunPg2AsA8JNk16HLStUuDWEGG6hpTQ6HzhFm82rimzFijm0lEaTErST6VWcL4zofvLFk/jzLz+J3QdHuXbyCje+z5FzNOH6HEca0W+SFuqU3J5Pjg1XQcYkJYRQbUuR5nyhKlYR7Nym111KBtE2NJp2Ry2KUcItXd2yGG7itW9WFW4qctR/pffebLc6ZylV1yN+p0pkMT8VbqxN8dvRDMxnMjKFW4YMpynmUxr10xlzoYChCGK4IXzqOU8FbhIbmnw7+nGSBa1V8Mcr/X4006aYdVNWXk/JBOtJqI6I7qhWuKVvWxIGegv49becp/yeLrwTs5RCPt+LeRPrl/dJ9xG7nRSzbbZPo5xS4RbdNilL6WwgklRCIKCpSqxdEjBN7Mk4BUQkk6oeJkNgVtScqXvt1cP4WHEZWAGeBJMmTSCLNEuhBqg3bHQXc9xnvK0vzKx6ztohPH9gFBtX9nNtCNvnvWeKEdUiUTPzeHbBzfjnHZvRo9Xw+xceg7PnAby160H8yD4r2I6e7576z7Nr9nblI/Nr0UAJADAyUcd3Htzvtwex48PGG/DuAejCsVLz6mJjyAg+Z/QoXjfxZRR7asBRwOragO/iWhTyBiaFrKVi0gQZGebFcGOW0vYVbiHhpt42tC+nVzyLgdc1yNW/DcsOFW5N/hrOtpcRJBzBJiRNUNrTyKJ0RrKUigo3ocwnXziJdcvKwd/xhFtr1xgXahGciqySwXolJE2gSSASFGypYrilUbhBUx6TJksiQh8EawBcb7w55Ra8e5N23QKtIhrDrZ2kCXKlV3LgfhdPvHACqxb2oK8nORwJvW6pMwt7r95DDv8zfz7wllJ1P8V5oFK4idfd+QA7ZZvYt/NVCNApZIRbhgynKebTk5DTGfzit/P1s9ppsOX5aikVySV18oHwfbsxqpSgSpYWyk5DrNJFy1BfibNiAQqFm8Lm2cmbE6pwSoqFJMbySoPkmG3837Pd90IkS6m6Xq3N+TIdiO0QyTGTqtPaVbhRNaaiDHrzL2YWFc9lagVl5ARbuOdMHbZC5dly0gTyu0YVMHTxVpPEJuIspUzhpgNXnbcUV567JNI/sX2sv3GLxHxOR9XNo+rmUbvg1agdPohy9WW87sQ/YOo/vwt9aA2Kg5dx2zP0deeg6RoW6WOwoWPY6cVAb7gw/MnjLDYcieGmSppA7KGUqOAVbi6uyz+NyX/5GtxGFUW3jmG7G0PGFC4rvIg91nogX8ZJFOGSi6a44JVdLWiWUsf1Ypi1ck6HiogUCjeWNKEVhZu/BAwVKnKFW9MKrcmi9TK9pdTl1ZUpLKVif23Hxc6XTuF7Dx/AuqVlXH/BCvR152P7GE2awJc5OlXn5g9/PeDJ5aTrtQiWlEL+nbBdDCwrWWU0F+ATJai2kXyW8D2QLlZdqMrVIuPCHkKYHOHmMW6OkMAD8AjrjhFubVtKeZJQnpAivoxn9p7EX/37U7hw80J84E3ntlynDOE8CM/ZIIZbM10Mt+Bah5AAdV1Xeg3wtk9seqSNo5MN7rdkphC2KZnsBDKFW0a4ZchwmiJTuHUGVBE0Nwo39hr+6M/XJ0nRRbqCcAO9+Z/Zvuia/H0SeKVTcrsX9BVR9Re4DDJyTZ2lNH3bpgs6h80E1jgpa2fSPkCypXS2+57PyRVu8iD0nT+/Zeox2gY6j9qN4RaXNGHtUi922EVbFoZt4IhWWQw3LVAD1UkMN/ZaCwi3hPmlh/Mh0VJKCEEavF5uKaWEGx+bKm4+sq9YX5oxi0T6mztRt/HCituw7LkvYZU5DGf4IJzhg1im3Y/39KzACbsMV1+AglnEsN2DdbkmNo89gJX9L6HmmviT0TfCNHRcunUxHtp5jG9PjMKNKaQG9QkUXReOE6qYKrUmnPHjKD5wO363fBDLzFG4Fb+9eh8+OXIT3r98J1ZVnsXP5r4PWMDr+7tQcfI4avfhPyuXwHGLfN0KhRtLmgB4pJTeAiHGbJeBwi3FPu3EcAsWzJp8Xl6zbRnuePQg91k6Syl5n1LhRgOLy65/P3z0ZTyz9xSe2XsKLx2dwIfeuk3eOaE8BrF/oxN13lIqUfKy8yQpJICIOPLDFYgMGbnA0JynMdxkMcXiPpd9Nt0spYB3rXSES11TaikN6xTrbTRsoCuxyhlB25ZSoc2yMUoib1m26QnhIagKqZImsIcOGlEdOxKFW+z54L3m80awj2W7kQcIgZosISmJiG/e9xL+6959+NBbt+G89UMt7ZuEtAq3LGmCh3lHuO3Zswcf+9jH8MQTT6C7uxtveMMb8KEPfQj5fPzTnN/6rd/Cjh07cPz4ceRyOWzatAm//Mu/jKuuuqpDLc+QYX7h3bdswd994xm88eq1c92U0xrzJmkCkbXPU76Nsy4CcbHQwvczTbjxSpZWFG7kvTLuWvh+QV8RR4Yr3PetxHCb7ThmXBuopVShuJMh7XyPKtjiy5ntvht+nCSRM6CKirAt4fu5SpoQsZTOhMIthnD78Nu24akXT+LCzYRwI99rkn0KOQOlPH9LychkGqssrm/s71AtIFG4cUkTiJKILM5l2ffofkFQfpVSVUKyBgo3heVHrGOi0sSU2Y+/HH8tbj2vjDdu1dB8/m7YB57C9vx+vyHAzYwPGw7LKWoWri7uQqmxDu/bOoFXLTLx8TubcH1KX3dtnJfbj3Jdw5A+gT69giN2P/r0Knpqx1A6vBf/X9834ELDS6Nb8Jx2Fsbcbtijx1B56gvIT41gmQk4robS5e+AsWgd/v3+MUyeHMdT5WswNPkCurQGLC2Hfr2Cfr2CZeYo1ponsA+rYB9dCKDsj090HJqWLQQNd5BrIWR0NIZb8j6iTTwOgUrP/1sHfw385TeegwV9RaxZ0oufPHGI2zdImhBrKaVzzYlYTGUIsoVq8t+XWiN8eHNqvBb5PlqeQLgJ1/WxqQavcOOuB3wsQbE5SYcjNoab8JUbU57FxXBLqLSDUNlik5RvHBErU8C5bipiMbzPY7qoEKHCjdznsAcYiI6/7OHEbKFthZuwn5xwS1d3Wh0CrSMphhuAyG9Wq0kTirmQcGtadiT2aRDDrUUhxeGTUwCAI8NTM064MatsUpPiwg+cSZhXhNvY2Bje/e53Y82aNfj0pz+NY8eO4eMf/zhqtRp+//d/P3bfZrOJ97znPVizZg3q9Tq++tWv4hd/8RfxxS9+ERdddFGHepAhw/zBRVsW4W8/fE0Q+DjD7IDeqM7FExxqL5j3CrdIAHX5dnzygdnrSyvDlCaWF70vW9BXSgwYD6gJrjmzlCYmTWidYE5UuCVYTmcamqYhT25wWXtk6iWe7JrddjHE2S51jZ8z7RJunMJNmIM9pRyuPHcp9xl3zLRovcW8EfmtYfPfJGRIYoxAovBhi4vPfXsnDp6YxC+/4Rxl0gSqlqglJk1gyh1FG2hX/WOeS2EptTjCrRG0tZkrI7dmE8zVF+Dg04/hzh8/iIX6ONZ0V9HTHEZZqwC6iRcKW7FzOI83dT+K64o7kX/kadQALAHwwfIC/MvkVZjUyth29Ou4ufd54ORduKVfaMQu1nAAcLG+thP/u383vlM5H5te2AO3OYJmzxJ88cgWWL2L8Vvn3ey13XgGwDgmtR780dhtWFAuYM2KIZzYtQM5zcKbex/HoDGOATyPynf+D4pnvdcfq+ggTgnK3lbjb0WylKa4ILSUNIG9Bo4w3lLaXTSxdqlHKEbORVHhJlHpiEkT+PiBKrVMuCiVXVdpPEWZZTquDbTdDKcm6tw5Qa9tYoxSMbnQTCncgr8V5VFyez4p3FQkG9/E1hVuabsYd58XJE0w5Ao3cRxl18rZgniuxD28oBBFpLQP7MFZcgw3r5C0MdDoearchztnuY+4cY21lPo7mIYe9KVhORHRYbtZStNmEm0HYdKEpLH3XufruqRTmFcr8S9/+cuYmprCZz7zGfT39wMAbNvGRz/6Ubz//e/H4sXR7GcMn/rUp7i/r7nmGtxwww34r//6r4xwy3DGIiPbZh8Gd2Mzdwo3L1W8fyM2T6Xb4mI7DVkwu0kT0o8Tp3RStJvGbOvryUdsTrL+Ki2lHYwHyI6LTuaQCvTrtMMXVbjFE2ydeBJaMPWAcBMtVKq2dEzhpqnPEzFpQruENPegIEW/eL5Ni1hZi3lTSbjFKdxk5GugFoC32LnvmaMAgP/5Dw/i527eHGxrkXg31NqXWuGmVKrKFG5qUlZWx0SlGfxNiSN30WbcWRsHAJy/bAGefPEkNDh47y1bsGPfCB47fAxXF5/HAmPS23fRejinXsZanMSvl7+PY3YflkweheXqcHUDmmNjwiliwKig7powDR2G08DD9XV4XDsHb+x6FEusw7it+1GgCWi9C3D8gl/Gjq/vwQqjO2gvG3PbdlFz86hrBRSKReyylgEAFiw9H1MvPIJLu/ZjI17G6p2fx21dG/CSew0AII8mDM1F1c3DnjqFKwq7sc/yFJL26DFgyQrluKnGsRUy2dD1IA5SEkRLqS4QyPRBiXh9NjRGuPEqMFn5gGePpbEIEy2limswzV6YinATpqk4lvWGjdGJevB3XEzH1mO4xXzXwrZWinGbC8iyZgK83U+uYJO/D/dJ18fgIatwj+C6bhB3kz7cpDEfpZbSDkG0X1spjqmMJKTjb+gaLDsamy5adzpySNZWVdw0qpAXw1I0GukIt8CWqntJdOpNO0iyRdFu0gS232wkHWHW/6QMwvQ6eyZjXq3G7777blx++eUB2QYAt956K/7gD/4A9913H2677bbUZRmGgd7eXjSbzeSNM2TIkKFN0JtTVfbK2QS1kV64eSFOjdewUZEtcq4RSZqgtHSF72feUppcvwxpiDp6o6RrWkThJiMPVYRiRy2lOlMipagzBfEoIkqytPb9bMCL48bfH8ieuKchWmcakfEgU0TXxKQJ04vh5tlr0xBu5DqnRcnzUsFAqcDb+hjhTM8DkSCU2Ytp/8X1xX1PHwm/g7eQMA2NU7glx3ALyQ0ZYrOU+rbjSq2JetPhglGLhJssMyvtP0ua4EJHubcIXdfgQsdXpi7DjaVnMHDRa7Du0mvgTJ7CC1/8IywzR9GnV+FoBj4/cQ1Ka8/HY7tPwIGOktZA3TXx0zesx9bBJr70HwfRXczhW91vxaIj9+D1pSdg6yb6bv4gGiNdfluETIakD5qmcQTq6pUL8YVn12NPbiP+aMPjwMEduLb4PM6vHMHlvSVsynmk6JONVVh/fAy93WPBvu63vgPrlg/DXJkcrByIxvxJcz0wdG/epFlYsvLp3KLnUex8TRHDjbOU2imTJrBx11UKN0q4WZHv49pA20txeNizm2mIf7DQ6m9RHKkhfhdHINDrsd0i0TCb4Ik1BfmWoGBLssvHgWamp7CdsGU5yUMOTwnGlxWXiXqmEbGUplC4yQ47LUfXNcCOEomqfdqxlKrKDgWyYWZtmcItbu4GD2X8+8V600ZT8vvVavvF8meFcLPTtYmdI2e6pXQOlodq7N27F+vWreM+K5fLWLhwIfbu3Zu4v+u6sCwLIyMj+NznPof9+/fj7W9/+2w1N0OGDBnmUQw3Da+6YAX+7P2XY0F/qePtSINI0gQVgRHztH26SGMNTdwv5Y5Rwk2mcEte9M822KIyKWEC0J7iKynotiyO12yjSOKNxVlK50LhFmspFRRuSRZNFUTiIAl0K02LJmsoFUwUUyjcDHEMI+Qrf16KC/SqoMhgig67pSyl8mDwQZMoyeq/Fy2lv/rX9+A3//Y+jFdCVatoKRUVboBaSVXuzgft2WUtw99O3ITmUo+g0nsG8dnarXi6sQKP1NfhvjW/hGeaK2FDh+PfxlfdPBzo0Iwc9MEVADRYjgvbAX5cOwd/MvYGfL38bhiDK4Ox4uI8gRFI4QKwUgsJ6dVLegEATddA6ZYPY+9ZP49huwd9zlhAtgHA+fkD6HXGMOXkYbk6mq4OzXVQ/eHfovH8XWjufQTNPQ/DtXmy++UTkwGRJBKVaRZqaYljgCjcWN8FSylVJovXxOC8YTHcpFlKw/ceCZJG4eaXr8l/l6jCzbLdxPhXSUkTAAQxRiNxFSPXH36/aS2che7HZV1scjHc5hHhplCqqe2l/mek8y6iRE5aUkQVq5fOCVNCpsuSJnQ0hptoKU2RclNG3ooKNyBFDDc7nRor2D5NDDdGJCE+hlu8wi0ko9jvgVThFjwkaFHh5m8+G4Rb2rhyoYrvzCbc5pXCbXx8HOVyOfJ5X18fxsbGJHvw+OpXv4rf+73fAwB0dXXhr/7qr7B9+/ZptUmMOfRKBrtBbjerWYbTH9kcaR35fKjqyOX0jl8z2A2HrmsdqXs6cySX4/cRs0UG25F+5HLGjPdLg3fDq+vpjxfdzjTj9xssF2CaOgp5QfEjmR/KMcjpHXsi2F3KAfDicCWNB72RV7VRnCMi8SiOn3gTmTS+M4HuUnj7Y/jnjuym1DDC80rVpplu68aV/fx8E2LsFWbgmsPIlrTXDV3IjCoe0+5SDj3FHPdZsWDCNHVujrPzWXUdMQ0dOXpOCNOrIS4QNW/8qYqgadmRPtF5GsTNMeV958bbn4usTY7rcvscGa5gsOxl7qTzeLLWDPqdI/OZEr0F0s+B3mKE/MyTa1+xrx+fPfEqAMDri0MAJqQZ6wxDR96vwyHKj5NOGYNWF0xTD1UwRtguRiBRdRmdZyX/2Dqudwwrgxvx+fFb8IsLH8OxKeC/q+ejrFfx3p67oOk6/nr8JpxyuqHDxZ9veQTG8d2o3/35oDy9vAj5zVdC712AY+M2PvqDOgrFAn7z7ecHCziWCCEN0Z3PG769LHHT8JwO5gF/DrF5C8h/s0wznP8Oouc/PSre+Gvcd7I5Rwlw2feiEqlpOxGCm0K8lMke7Bw9FRJutM5IFmfh+ySSXjfS34vEbctdjzX5dnNxzyoSB4bByF7+86QxMEydf5hipX+AJf5e5Qydm3elghmGGGGKOD1qV7Zsp2P3rKx9hq9EtW03sW5pJmYuxIIOwI6dR4YRjpXq/IuDpph7OvkNDX4P/d8jLv6go+6nRs77fPAbE21jQG65yWNGQX8jZvo4ByQgEtrkHy7VtW0+oBPXkXlFuE0XN9xwA7Zs2YKRkRF873vfw4c+9CF85jOfwbXXXttWebquYWCgO3nDVxjK5fmpfskwf5DNkfSokMyG/X1dHb9mFP2FUD5vdLTuduZIdynMNh13fdVz4U9TX7k04/3SdA2u47Y0Zn3lqeB9T3chdr/Fg90YGOjGQB8f+ra3pxjZb6C/Ki1jcLAnVbtmAv39XXjnTZuxemk5cTx6e73YUpqW3EY2R/omG9zn/X3RY8oCBgNAj2ScZhr9vcXgfT5vevVJFvbFYi5oS59izs9UW//+Izfg0PFJXHL2Eu7z7u7Qtlgq5TDQH9bX093eWBUL3nUjZ+qp9u/uCtvQ21uE6ERasqgXgwP8g9EFQz3o6ymgqxQScb09/LnTVeIz0Hd15TFIv+8uct+LKsTuniIG+krQON9ttE9FUo/rrwC6FedxkRCH5V5vrjJSOpc3uWvfQH94zdfJzXq1bsMcNCL12KSdBkkmsXpFP1cv4J2XbL8lQ904dMK7BpX8vpiSzJw9PUUsGPT2sRwHGlE21Zo2Bga6UfDroXObzQfWB9PU8c6bz8KpiQZuumw1Bvr9a5nrYmCgG6VSHuNuF+4cegsePX4MADDs9OKjo7dhoCePYcdjvmwAuVt+A/0H78XkzvsATYM9cQr2+HHUHvk6AKAXwK+VF+CY3Y8Xv/4ArNp2ACbKPpFpkEXawoESfu41W/Gte/Zg94HR4PPBgW6PNEwRRaZcLmGgr+Qv1r1jTMmrBUM9GPBV4iXxmPi/8V1d3jHI5aK/ISYhrDRD545rTvGb03XcO7amaaCHnO8MohKpUCpgYEAMrR5CvJQVJOQcU4sawm9xVcjWbAjnE+u7Cn19XehVbGMIC+6+vq7g3IqAdILOVRk6ec/aM1bn/u7r7/YszdQuzn5TCHI5/hj093XxMYAn+XJVMP1rNiXcTFNHd49/vugahobC32ZWR29vCbZgbNMl83e2UCQP9qZqFlwk/3ZSlS1DT294rJkaNemegSVN0FKu63PkwUixlJfuMzzptU3XNfT0eOesYUbH0/GvmTL0nPBIb9PUkfPne0Ey1+lvSyvHix17cxaOM2uT68a3qVj0rgWFQvScmG+YzevIvCLcyuUyJiYmIp+PjY2hr68vcf/BwUEMDg4C8JImjI2N4c///M/bJtwcx8X4eKWtfecjDENHuVzC+HiVs19kyMCQzZHWMTVRC95PTtYwMtLZy2qD2XBsByMjUwlbTx/TmSO2HS4adA3K9k4Qm1alUp/xfrHbYttKP2ZT5Ga4VmvG7jfQk8fIyBTqdZ5oqkv2q1bkN9mdOJYUt16yMlW9U1Nee3VNU24rzpHJyRr3vXee8PvqmhaolKqzcMxF5MjiyLJsjIxMoSq5uW/UraAtlVk+Vl2mho3LeiPlNephu5oNC5WpcDwbjfi5qAI7F+OOI0W1Gs7lqck66sJYNWqNiD+sMlWD07Q4vw87B9gcqQnl1OsWxsbC+66Tw5Pc97U6TzycHJ6E7jiokTEam4jOLzoH2TVTdj4C3hgHfZ3y5qLjX+vGJ2o4diK8T61Vw7lar4f7jYzXsMgnbRr1sJ4pklhlQdlbpOUMHZMTNVgCqULPg76ukJRgY0brC/ap1jEx4ZH4rgtUybhMTDUwMjKFsXFvLFzHDcpvNi2uTNdxAdvGB950DgDgmK+Gsv192HXAEiRlNgyMVPh5MDppo++sm9B91k1e2c0aGrsfQPPwc3DrFdQP7cZanMRa8yQAYGXPURywhlD7yUsYXb0Gph2SrjqAbWsHcN+TPCk1MVEVxZBKjI5WoDtO8Ps1OVkLji/gzdsR1/vbEX7jpqa8ucWO1VSlITlfw+NSq1ncdaMi2R4AxsfZMXMj54QMx05MIK+li38GyK107HonXgMmJ/jrNVyX+z6pfSMjU7Dq8m3EIP0jI1No1OSEG70eT07JfxPm4p51dIx/SHbq1CRMQ+dib9Xq0WtLXYi9d2pkilPTjqUk3FzXG7cmOcYawmulaeh83f71d2yswiV2AoDJydn/rWWY8OdVPucRbrWGnXy/IZlr/D5+38arGBmRzyOqcLNS3vNNkXvQyano7wmrE/DO2Yq/Pbtf4LOcAsOnJqVKXVoGU6GeGq1E506d3ee7LR0vtl+lKr/uTAe1ehgCIK7sKf/6ZzWTj/dcod3rSLlcSq2Km1eE27p16yKx2iYmJnDixIlIbLc0OPvss3H33XdPq01p0xa/kmDbzmnZrwwzh2yOpAcXt8NxOz9u5D66k3W3M0do/CZd15T7cwFrZ2FMWTM0rZXU9HwQXdl+t12zDnc/dRhvvnY9LMuBLiwBNaSvb76ef8GTYk19/BjYHHGE2C2OHR0/z5ITxgSZ7f4XBbuvZTko5aO3RHSeq+K/zHZb6TVGg8ad863MKQoWsyvuPOTbEL53HFfIWuqd2wXRxum3TYyDxdUnWoZclzvXagKpJFpKa3UbluVw8YuqNSvSJ7o4tUg8n6S+s7nIbHT1poNKjbTJDftD2zBeaXJ/B3OI9LeUN/HXv3YVcoIFKSialE2TM7B5KM2Q6YCbHzRj61S1CctygjE0JMc+iG8H/jhRSxM33pJTQmxXo2nz9Wh5GJuvhbHZexj+1EPPYPShb8KCjgvyL2G5OYLl5gjw4os49eLdeJfWi6e7luC55nIc17ZwxyPsePrYYpblX5dcNo4OnyiD9F1cJLP5wD5tWtHfQdp/23a42FWW5NrHymF1p4nTNFVpxs5d8RjIFvuNJruWy481g/h9Uhws2ZgE+wp9i9uWO2djtgM6e88qkszNpgO4/PMG2W+YSN42mzZ3/jRSJjCQXfNt1w0eRpgGf16zQ9+0HG5MAe9879S4sf4x66R4TCerTTy/fwTbNiwILJpNyZjQ3wBmkU2aHzR5QJr+Wtzck+9j0XNWKF88hxoNW5qRnv5GMLVerR79/WLx7hy3td97dh2IO8/aBSOmku7Xgu9auN+eK8zmdWReEW7XXHMN/v7v/56L5fa9730Puq7jyiuvbLm8xx57DCtXrpzpZmbIkCFDgPmUNGG+g95wxLWXfjMbgVYZudNKyXqK4/y6K9bgdVesCf4W41zJ+sJluYV0/TqvEMy3FkJdpMlC6odi8d53YC53EYsVq+2dN27ERLWJa89fhn/81k4AfCB8bRbmYhrQgOeazmdObDepCM1Smgaa8Afdr1gwoGkaZ8vTNS1oN42DFalPTJghZGkUF4ji+cG+bylLKbEXycAnqfBe2bXLsh1uwccFyCdtqNatMPg/KY/PMKuh3M3b7Clo3K2lQ6EVR8woyrVd5/eji/iGT5SxRR6XNMEvlLVZldiEkQqs32lO1aQA/5VcP75SuQwA8JPaVlyU3wtAw2svXY7cgYdQHjuBK4sTuLL4Ah7AKFznEi6xAWtf2t8KMUuprvGJSOh1W4x9Jp43smNAP7Mdl5t7jiJQPFuwi/NfhGnosGwnMVOpGPtKNjbsuCQlTYgmvYmtOsKhf/3uvSgWDNx66epIbLm4jKZ03sRt12lEnxGwD2gcSQd3PXkI2zYsQL9vNxT3i4xF6iylkjY5bnAtVMWvdCRJE9LWORNgGX2LjHATzoW//Pcnsf/oBG69bBXeet0Gf5/480snfYuvm53z6frLK9Tk+7D4aF6WUo3bVmyP47iAJFwvzVLKjpuMeHVabH+wH2vPLBxnK2hT/Hb0OnsmY14Rbu94xztw++234wMf+ADe//7349ixY/jEJz6Bd7zjHVi8eHGw3bvf/W4cPnwYd9xxBwDgzjvvxDe+8Q1cd911WLp0KcbGxvDtb38b9957Lz75yU/OVXcyZMhwBoDKiediQc5+w14JP2ZpCTe6vJ8dwo29pi+bz1yYbr90WUpJEgJTl2aomk9grW1t7OIXcOJnnZjKXSSuEqt7sFzER951ARzXDQg3SqLM1TmmC3PP4Eib9oL8BgG10xJutA1CvSwRACUxTZMQGGSOi/YLsXpd07i6LEkWSAq2KKeL85qEcKOqHHZMVceTn4vee3YuU4UYwC+sbGHlwbbjspQa8vdee/h20OvF+RsX4Mpzl2D5gp6AbJEtvjRhfjQENU6jaQdjyhG5flVBllJhWtFMhwCf4TMJskyeFPQYjzg9uKN2HgDgp7ZfjRW3vBP/+KnPo2v8AK4s7sbleBKVr38Uq/Tt6NIKqLh+7CRDS511OsxSGtYbJB8Sxs80dBiwcW7+IC7M70P+uWE0Fy/HVS/8K3q7F+Fk42avLKsBa+8jsI/vwVWTR/CSvhWjTjdsx+GIFVW2QPaxpsWfkz0lE6OTDWkmXq6PQj2y3x5G0Ijngbht5BC3wLidHKviW/e/BAC4+eJVkTkbt1inZHsniaEkqPpAP37ihZN44oWTAHbhnz7iJTsRSZgI+ZWSTJFdtxw3vAbKyGjWPomguGNgc7+QC6+lFPuPelb9h3ceCwg3J3gA4G3juuShAPi+pak77Tyi26mzlIbvafu8/eX1q8rQdQ15PyZnU5L5JWh/q4SbE1//dOCkbBP7/hWwRJlVzCvCra+vD1/4whfwx3/8x/jABz6A7u5uvOUtb8GHP/xhbjvHcbhYQCtXrkSj0cBf/uVfYmRkBAMDA9i8eTNuv/12XHLJJZ3uRoYMGc4g8Aq3ztcfZKB6BfyY0UV43KKiHXKrFWhtjBldWKblOMQbX3GBDfAKilcC4cYGrZXjEiFVJMdel5AcswlO4SYhfRhscuc8V1ntuaxsmsbNGdmcSgNdUOoktoHzkPKKIGbPLZExpXM/n0tLtHvt0jQtUHuKCjcRbJFJSZ26hIzgSY/QSidvA3nvv+aowk0gAu584hCWLeiOLOZY2ynJGKeIFv8WH1D8/Gu3AgD+6959Qd0iGGHDkpCIaol60wn6T+cRs7+zcYwo3JiiK1CHpV9EJS32VDFzdF2Dni9il3kWXqgswx5rEd7W8zCKw/txIfZje7+G/dYC3FXfAh3XpJ7LAWlIFW5MjSlkT14/9iCu7b8XPbofX2vnQdR2AgUAlxQm0Tz6WdTu3gnrpcfh1jzCYCOAN5Yq+Oepa2E7vKpIteBn2+havMKtp5TD6GQDVUn8PgqxGnq+dhdNTNWsIAFJqwq3pGGmdVNi0HGjeXXjFDu8wi2+zk5CpdJTEQ8Hj09i5aJogqGI4m06CjfXDQm3iMItLL9dkm8mwK4t+TxTuMnrpvOPtdfQNY9sc11C4GiRBwHqupmlP2VbneRzFuT6ERJ/8rmgah8lo/LMRiv5zQsVeunaL5af9NCjHdAyHddVXreoiu9Mxrwi3ABg/fr1+Od//ufYbW6//fbIPn/3d383i63KkCFDBjk49UKbapPpoB211lyB2qnibto5wm0WhpQV34p6jrOZzaLCbb6DdaEV8kkcL6mldJZJVhFdRUq4qeujN950vjBCoxOg42HoGjdnpm8pbX3OaUK9jGgrkbh4dC7zCrd4kon9resabMeVPu2nYKQBJUblhFt6hRtvKfXem2QxRBVuh05O4Yvf34Ulg10o5HjPECPmONu4psHw+yYeO/F6pDq27FPZOpC13dD1iP0VEBRuRlThplIjiEqS0FKaQuGmsFEyqBbebG6yuh9rrMOEvh4fPvcETj3/KHrqx7E2dwJrcyfQvLsBTdsGwMWF+X2wXR377QW4KL8Xu5tLsd9eGJTLanNdFwZs5I4+jY2Vl3DQMHBR8WVU79wNvXcR3KlT2HLyLkAHRp0Snm2sxBVde6E5Fk4MnIeJ40ewLncCzefv8saiexDmmgvQfPaH2Jbfj8XVUdhONz/3lAq3cE5qMadkj5/pMUnhJpIE1NZcKviEm0LhlvR3ElQEo0g+ytpJQZWPrzSFG8VPHn8ZP3fLlhgrqoe05JfsnHMcN7gWirHCqN1xLhVurH8FEsNNBvqbZBOyxvHP3ND2TvsWX3erCjE+Zq9im+AiSGy7ijrUCrewf+w3U/bQVVTcpT0n06rQ2gG9rjuOy2XppQgfzsz/NcpsYt4RbhkyZMjwSsJcK9zCGG6dr7tV0MV2rMKNWkpnVeGWvmyeBEy3n3jjKyM36PxhloL5DI0QIqn3SVBMiOV1xFIao3CjkMWLAbxjm6S+milwhI2ucX9P11KalrCjm2kaT54zoq1ESEyOcCPzOhrDTV4PG+pmkh3R8r6ni3OZpZQeR7atag7LLKXsXG7aDupENcYSKFTqVuR8Z2RhxLJn+IRbAvmoPLYCOSYrwzQ0WHxMdgBefLsghpse7aetUCPQPx2qMpG3kEOSukKtcGOVh59V9W4ULr0ej9qX4Mf3PI1LC3twa+kpYM9DWKqvwOLcKfxcz71CSU/i7tpm/GflEgAatKPPo/bcc3iTsQ+b+g+g6+EGzgdwfp+3tbWb3/vrlYtwd20LHOi47LZ3oLt+EvtGluBf97yAd646jCsXjMBcfxnMtRdA003s3rUPa609eEf3Azhgr8W5B49icbeG55vLYNtD0r4GKpCEGG4h4RavcBPtzbzCLYeTYzWicOP3VdmJw7/TX6BFpVArhE9znsZwE7kTpttTtfCBZ4/hp1+9KRrXS9ghre1PqnBDqIxSxY51XUVssQ6BXQdYDDdGwIrzic7V4Dqja9AcAHCJzTS9wq1V4okjkxL20bTQzu66rnRMVeMcWslDS6mMcIvElEtLuDGF2ywcZzETq7oN3utshId5JSEj3DJkyJBhGjB0DX3dedQaNhc0vFN4JSncqNIltaV0Fn6kp6vSalfhJutLdymHcncexZzxilC4MbQy38ReyXopIzlmE9NRuCXZvmYaukDqmzGKsbRgipfU+wvHh0uakGcKN0q4ydVu0fhQwt9kjAE3kdRsSmK4JSncqJpIBs5S6m+T88fJsl1ONRYo7GwnsjBjdk6xzx6R5kSte8KJIQbsD7Zj/VBYSmV1MtSbdrDw5Syr/ltGfqkspUG9wUJRWg2HpMWeKk4fq5NWwerLGTrG3G78oHYelpmj2J5/CVdpT2Cg66TXRtc7V47ZZSw2xnFNcRdO2GWMOl0o3nM7mnBxvj9FnWIfRlBGuXoIL2MJNl98GdyJk3CqY3jW3YA7nwoTVuiDK5DrWgfjiUNwoeG5wjbceNN5XLsfzV+KFc19WJc7gXU4AVSBoQKwvbAfp0ZegDO6CHr/Um6f0N4a//vS0+Ul2Wg9hlt4rNm1L8jEqosPhuKJ4KRjzieJ4M+7qDpMPTcoEfvKULjJ21hv2qg17GSFW2rCTX4AgqQJEYVbWF+kDR1M08SSJOSJEtqyXeRM8fooXGvgzUFXc7nPNHKuJA1dq5bMNJbSQLkFXmknmweq9oX9C38nZapu7jxyAEnC09jyVQ81pgNbOLdVCFV8M96EVxQywi1DhgwZpgFN0/C/fvZCNC0nYinqVP3ea8erbhlG2iyllHCbRYVbK2W3QwKmtZT+6S9cCl3X8Ke3P566PXOFwPLXClmZRuGmyd/PFijhFlcfvVHVCUnVSfc4HS5D170YXfA4j3Ytpa3HcOP/5mK4FYygzELOQL1pR2IThu0XF/NCuwT1adOOJxYYaUBv/pMUbgyq05+PJ+i9cllKyYKI1W85bmRRw7ZTZR81RFIrRukha3i8wo2foJ7izeUUboYkS6mjWBzRttFFZdw1lFlnk7KUqiynbK7IFYfhZ3c3z8X2/EvYgr2AAUw4RXxy/DXo0Wo4YA/h6sIuvKX7Ybyp61Gw7NTGqm340V4NOyqL8O43vg4PP3Mc33v4AJYt6MbHLrg0KHvk4QMAXoy0ib3KyMST+gL8xfjrcEPxGSzI1VFZdA72HziG64o7MYiTmPqvj8FceR708iLkz3k1tGIPHMfBBvMoLq4/h/LJTejVGphwixA1hD0l77qVaCkV5gadg+zaZzuKY52QNEFL0DXSqun42BKFm2pmeDHJ0i3oO41IH4S4hjLYthMht9q1d6ou2Sw7c064brDj5UjIoAS394yCzYVijhJujuQ+KfybXbcNXYPjatxnnqXU2y4xhts0kiaoig5t9XycPNmYqq5x1G4ZZylNkzVVBrbbbBDWjoKUbDRtTNUsDPQW/DaEfTyTkRFuGTJkyDBNLOwvzVndgVrrFfD4iN5YzWWW0qCWDivcVAtoljHzFXAIg0PTkqU0Ri0j+6wzSRPCLKVxmTDpja5G+t5RhRs397xXw/BidE0/hltKwo2+1/hFEVW2lQoe4Ubnfp4j3OKZyjB7qvc3s4yqECrcyA1/ww7i3LiuC9txY8kpEVKCh4vhFi6ImGrDtp0I+SKL4Ub/FjO2cvXGtc9/la3hWBnitaZUMDFRaaLecIKYaaYkhpsqaULUUio0RoKerhzGJhvtK9wkD5PYUJpkTh3BQuQ2X43qrvvQcEz8Z+VinHJ6cApeoPp76puxOXcY5+ZfBgA0Vl6CwZt+CXd8+j5MWk1omh6MVzTRjTzjI9te1jfXBY7a/fjS1FXo78njot5F+GHtZdxf34hfX3APFtePwnrxAa8tO74HvXcIWydGcV65AtQB7HwEHxsARuwufLlyOZ5vLg/GgV23kiyl4tygc7BLUOJHkiZEjn1r1xg6IpagUktSeYX7zR0xlIRoQHz+VQbLTu57ekup/Hiw65JItrNrqetGr4NzkTShIBBuInhLqfeq6xp0lnGTS5oQKsvi62ZJE9JaSpPJXlfRDro9e+igtpT6pLeuBcmFms3omKTJmiotn/0+zUoMNzkJ+Df/uQO7DoziE798BQZ6C1xymjMZGeGWIUOGDK9gBAq3VNF05hZiLCoV6O/ybKgGwzhR7Src0u2jWmir65j/x5AtSMWFaRwiYbsk3ZSpimYTTJUFIDbjHw3oHqjCyA12JyA7bww/RlfnFG6UDBIspWQsSwUTo5MNbn5wRHvC4j60e3tvktRRlu14pBrZzoW3aCnkDfzDt3bi2X2ncNHmhZF9VaSxLjnXuSylREHHFpGW7UYWzGzhJNbDxiMawy18bxjqORan6ggUecJFihFuDYvEcKMxNSMx3Phy6XGii7+4352eUjrCTWZ30sk5JiNAc0LikOK1P4+P7z0XB45NSmrQ8PnJa7HCOIWTTi9+943XQNMp2RjO56SHJGKyEVnb6XGhqq5Jt4Rvdb0ZH9hegVubgvXC/XBGXoYzchgmgLpr4nBhHZbnxmBOHseAUcH7e36Eg/YQXmguwU+a5wcZgVtVuNF+UHUvICfYNI1X8PDbx1bN9T9KuMWrvGT7AfNN4Sa3xcYSbo4jSZIA4e+0hJv8c6aojWYppQo3fp9W1FLTRZAd2dS9JAiCipGBxpakCjeLKfXINaplhVvK7qYhuOgzBy6GG9neNHTYjq2sl55jLAxDU3JNSRsvTQQjqmclSyk3RuHnx05VYDsuTo5VMdBb4BSJZzIywi1DhgwZXsEIVDevgB8zLmZQTHtNQ8fbX7UBDcsJZOkziXYspXwcrfQkRc4Mg+snq3tSN2fOsHJxD265dBXWLyun3ieqlomOH/2oE2QWPYZxahF6o7qwv4TBcgGrF/diz6GxWW0fBZ8J2Vdc6RrqiCpw0oKVI8ZvUkFUuFGyhle4ee/5GG6tJE3gSRbZ4oPCsrzYaeJyota0Ucgb2H1wFJPVJg6fnIrsq47hxpOLgGgpDdtE2yfGm2tYcsLtNZetxq4Do1i9uFdZb5rjKlXtEUKWgqmavBhu0etRoHAjAclVbeMtper29fjK3aT4QbIspfwxQOS9zKYcd122YQSZSkULoKaF9YlkhUhcikS1jEykH9m2G2RXBICmayC/5VoAQP68W+CMHoJbGcej+yv4/D0jOGfjEly3fTk+85XH8KauR3FlcTdWm8NYbQ7jwsJ+nLQWA4gn3GTzohWFG+CNJVUScUi4PtPq6TnhOG6EeFARJeJ5P78IN/nfcfHQ7BQKt+nGcAsUbmLsWH9zx5Uo3FIoB8crDbxwcBTbNiyIqOdkaFoOfvDIAZy3fgFWLuohdbFrhgbT1NBoyu3mdD7aEnItuEZB48jEOLC621G4pbOUhu2gx9E0NNSbMdmJyZgwJbiYWVpsT0sKN3/b2bCUcjEWhYcMtE6q4juTkRFuGTJkyPAKRqACeAX8mJlGdJGkws2XrJq9hgQKtxZ2oSqLFsY6Z1DC7ZWvcNM1DW+7fkNr+yTEBGLlhu/balrbqNZjFq/kRrWQM/B/fuly6JqG3/jMfZ1oGgC5nZkRMp1SuImsByVrinle4QaIWUrjYrjJiR22GYuRpkGeBbBpO9Kn92zRwm7+ZdlOVacbr6jyXk0/sHfTcrkYbnTR0RCCXQex0oQ+X3v+clx7/vJIvVwW3FgFsJrsYUWIdbLj0mjYgaqEkqaaqB6JOWe5LKUx1yyWUVNGqFHICDlO1SmN4RZNHNLqgi5cMKsVbmLiCpHQlFtKyeLTdbkEBpxFXddhDK4EBoHK8ZfRxESQkKUJE1+pXIY7a2dhpTmM15aexJAxie7nb0dRuyH2IYFscc0nTchx38mISmaF877nv0v6maL9p8SZR+DFq7wYLIG8FpNAzCWiltIUCjc7qnCLxIJL2UcV5cWueRFLaWB3TG/ppfiz2x/DsZEq3nb9BtxyafJ92bP7TuE/79qLF14ew4feui34nM0nw9Bg6joacOSWUkkMN10n5BqXNCFdP2yB/ElCqqQJROMWKO3AjzG7rqjL8KCTGG6yREFpYsrJMJtZSulYuhwhCK5OlVL2TMMr4Hl6hgwZMmRQYelgF/c6nyGzMM0FRBVNGvBxhFog3GLIhrg6TidELUkSRUWHY7hRxFlKxWDHhq5D07SOPq2l48Hq3bKqH309eSxp87w3BOIgCZzlF5qQNIEo3HzyTZk0QQzorVK46Yzgima2o2haDmdLKvjbMXUZI3Nkixi1pTQ63ryllMRwo7HjJLF34uqJ2y7uWsG+kSeC4AlZBmYjpEkTpDHcnJDg5NpGLaV04a5oZs7UkffDASTZmdgYUuKWvx4g8t6UJOBJe10WFUkawkW+aJXnxojUEVpKUyjcyN/KWE6MRNA1juA67vThscY6fHL8Voy53chXT+Bd3fehFnPNkpEPnMJNtJRKVoJx1+OkUY5TuKWP4cafS7NBGLSLtpImpOh7ektpvMJNZSmlytRW6jw2UgUAPP7CiVTtq/pksKjCDLIj61qgwmPnvhj3TGyfruvBeUFVuGljuDkC+ZOEVDHT/I91jZKaNElAeB1OPO81pE6a0IrCjRFhs3H+2FxSk/DzQNkmvGYx3DJkyJAhwysWF21ZhL/4lStmxXo506BWh7lU5LVjw21XgdUa4XZ63pCo4nSptun0jVk84Sa/Ue3k9KXzho3N+3/qbNiOm8riI0PLCjcCTeP3o1nnZAq3fOw5ICzm/U1ZP5lCppAzUJfY6CzbDRIXAJ5drt6w0bR4hZvUuqSylHIED6+oEmO4yRUaGjdvxGykKtD2xFpKY1QdbC9RIVcKLKUOpzQJ9hMskjIbOFMZui5VZoTb0H6XCiZRgSXH4WP7sEW6al6GMdyi5GTaqRwSJKxMYLDs/X4OlPnfUdkY0c9lfeNjuDkQY7rJ24SgDzKCdtIt4avOq/G+3LdwXv4gTliPArhcXlaCTbBbINxk8zMupmbS7xQfw41XCkUtjfLxEBWp88lS2l7SBEkMN7Hc1JZS+ed1FsMtkowlLF9lh00DGjogDqyf4jiF1x09eCBjSR6I0HMu2EeicGsthpvD7ZsEmmRAVTRNHEPbQQkmaueVgWZ7zrMYblZ8lu1W1J6tZmdtBSoVoCOQfFnSBA+Zwi1DhgwZXuEYLBdfEWSNKSEO5gLMPtUK6ccp3FrYj1NiJOx3ut6QpFmwyVQsnYLsiTKDSp3TyfONKlDYe03T2ibbAKC/p8C9JrZBWIBT2w8l1+Qx3OKSJsjrYZ+zhVghJ++rRSylhk7j4PDZS2UKtzSWUtYONtZN20GdKNlk8yMvJHpJrXATyCsVAvunZGqGlkdB4cYspUqFG68UkbWZLnhphj4GWl4pbwTX+ySFGyXpxH6IdQTHg1NN6so2yxAhSDQNF21ehN9+53bcds06bls6z+kxMQWCksIRFuuyxWhkH4l1TsRxYwka298BALjeeAzWgR3ysiSLe0oM0wzNrE4RsQq3hGFWKdxUGV1lEC2l8ylLqTppQozCzXYjBNvMK9zkltLg3J5GnYCXgToN2LESiSH2YMTQNe4BBiAQbpKkCbIYbtDSx3ATyR+Gat3CsVMVSR/SKMqiSjuHKNx0XYs8yIjUw7qia8jl5Ao3MRFDK9xZaO+c2ROIZf+mfzMwslKM4Xaa3t6mRqZwy5AhQ4YMHQFPPs1dOwKFWwuZXdtVYOUkC0N1HamLfUUhzYKNJ3Tmz0AsGZJbNjtJjs6G+u+Ssxah3J3HuqUpk19QQhSa0jLKgmQvI+PGqzyTzgGfDI8o3ARVjq+m8mK4+Qs5QwuIvkagcHO4cmR1RT6XPBhgfbAsh4vVJis3b+qo1vm2pgF9AJCGTI21lCoVbjSGmzqJjfQc1QHH5mNB0c1YgHDAsxmzY502hhu1lPIx3KL9k1pK0xJu/kKZver+vmetHohsy8W54yy/akupuD6n/bdVShfWlhi7umloyG2+Bvfd9zCuLL6A6o//Hvmt18NccyGMRSFRKCMI6DzN5+SEDAV3DgjfJY0yrd0SAqtHkiYoEg2IytFOZtNMgkolFjfNZVlKxXLS2v5U0zxImqDIfuzKxj9hXOk1pphS4RYE6hcVbuTBSEi4qR+I0DK4GG6EwGFzs90Ybr//uYcxPF7DH773YqwiSWzoeZ2kcNNALKUkMYh3LidYSgOFW6gEbwqhCVQxA9NgtmK4qWzVQNTG6pJjeCYjU7hlyJAhQ4aOQLZImguwqltpgiyOVhpkltLosZYq3BQL7LnC77/nIlyzbSnee+sW6fedtETTumbqptXQdZy9ZpBTFcW2QdyfI9xCouTKc5fiL37lCtxw4Qrp9+mTJviWI6Zwy/O3q4ycaVpOQGiYuh6QCc2mw8UaExUztC4R0phhJOZQg1O4SQg3gdBoJ05e3D6BRUyy8JLFOAN4wo212eTOuRTnKFnwyhRu9FrX1ZKl1Fe40RhuMZZGsa4gaUKrMdyIJUwFLjmD5PgkWUqBaBwzGfhA8PIGGYaOYt7Ef1YuwUvWAqBRQePJ76DyzT+F9fIzsXWoFESA/DxQJa2Q/S2CS5rA9V2mDpOXIRJudK6PTzXwrftfwshEXdwtNb730AH8+PGX29o3YotNQYBYthvJ+hLNUpqufjb+H3nXBbju/GXB5+xBgCqGWztZSqdqzeB9URFHU0RoKeU/pypORgqGMTbtyHYAbykN7JnEsknVe3FwOAItfD88XgMAPPL8cW77NEkTWKWews3f1g2TpOg6Im2OFEH6UvCV0bWmPPZd0J42YrjNtKVUvO5xcSsFwi1Ngp0zARnhliFDhgwZOgJTEndnLsB++FshL+imLSncWsjMero+ABSHa77EcLvynCUAgHPWDUa+W7OkjPfcehb6FJbLN/vWs2vJgme2YMzB2IgQM3fSdojxI0WLe346SRNIDDcKFvi91ggtkoZBLKUWn720JYWbZLxzyhhu0YVMxFKaNoYbZ1lU356zrWSLqDCoP3+tZZbcRjNMMmFIkiaE5UjaR2xTssxzlJwq5o2gDWktpTT5Bkf4gB4P71V2XU1vKeXtZVoM46aK4RYQwilskpQ8So7hpinV36ahIZ/T4WgG/n7iRjjb3wJj2VmAY6H6vb9G9c5/hDNxQqq0onNWVFrLfpf4OIbClwnDTPvPKdyIFTn4TJk0QVBHkU7d/dRhfP3uvfjRY+0RZpVaE1/5yYv41zteaMtqp1K4JVpKI6ogsZx0pAi7tm5a2Y+fu2VLcM1jY6ay7buOrO3xdU5WQ8ItLdHD+iVaSkPyTOcs+gBvo5QF4KfkGiWn08dwIwSaZNtKjY/jyls4FWSZS9vhE38uVa2F2Y9VZRB3bPBQREyIIl4zWuHORPJrphBpk2R8w6QJ3uen6/1tWmSW0gwZMmTI0BFwSRPmNIYba0ML+7SpcDMzhVtkvKQWprgF3izhZ27ejHPWDeFcCeGWhIu2LMJf/eqVKHfnZ6FlPLiF/hzdtYq2Pk3T8KG3bkO9aScmbCnkDJS787BtJ0KciXOBkQ2sm4HCTdivu5jDCdRQrVth9jsjzIzZsGxuMS1TuKnmmSx+VaDIcFxOgWBJFux5M5nQkNZLNkujipOt4cT2Al5/2PjVm3bQZs4uKbAo8kzCfr2OSzJ8EpKQxnArmAGxk5ylNEyaQNsc9knWv2hcwFYVbmEMJvW2piKGW6Bwk2Yp5T8TSSdpm4j6R9UP08+QXMgZqDbyqK2/BuULbkHtR38H66XHYe2+D/aBHXAvex80uHDJsTlr9SDufuoIeko5CSEjO9YxCjdp60hfiN6Ij+HmpA7aLxLkdNxYkptaQ53sJg4sMYfjurBtF62GwlRZ/OI4DTF5Bt0v3CYt4Sb8HRDb/oMH8XgR0qfVGG4TlZBwSzqPgzIV9k12PTYMLRLfUaUC5WMbsnLCa49oM1WB/hbINqVKPlqHt73inPVfOeIPLiEEw3NZed4Tco5d/xqWA8t2gmvcfLSUiuXROIaseRFL6Wl6f5sWGeGWIUOGDBk6Arp4mct4DuwmrRWCi1c3pK+LU2IkLKJPV8JN7JXsxkuTqEdmG4WcgUu3Lm57f5X6baYxlxlcGTiFm/963vqhVPvquoY/eM/FcN1oVlWxOyw2VpClVEG49ZS8wO+1usUF486ZUSUXILccKS2lkvbRdlfI4kymcKMW2rh6Iu2hlsW4fWIWmawIQ1CAsfFrqGK4RUhxSbUI601SuJUKZrCoPjVRw38/uB9XnbtUSlCz9lDLWiLhRkhNVk/aUyOicIvZUSQuGQL1njRpAv93UuIAb59wUaok3Py25EwdtYaNpuVAM0wUX/1rcI7vQe2+2+Gc3A/jzk/hD/q68MWpq7HX8q5vSwa78GfvvwzlrnwkK7OsOp3+VosET6KlNHzfjCjcxG0VCrdI4PjwfWhVi22GEmmORxzaUbh5WUrjy0mrIFNl/WZjrSJUXVfddhUo4SZTCcugIiCDByO6Fpy/TUnSBJkaTZal1FNap+tHxCIquGOnRIWbQ+etvMxA4QaNG+NArZoqaYJfhq5x179aw0ZPSZfum9YeSsmvGbeURmyu7FWidMsspQAyS2mGDBkyZOgQuMXLXCrcNP61lX2A9mO4JfX5dJXc0xgn3t/RbZJiNp3J0LgspXNEuCn/SIeB3gIGy8WkkjHU522jCYtIw9A4EooRbhVR4cYWcpaTuJhOlTRBD0kOhqlquDgTY00BkhhuaZMmkPbEJU1gW8kW6CpLaZ4o3GiSibBueTncZ4FShleeMOTM8H2pYATlP/HCSXz1zj2484lD0v4w9UmJBGXnrgeItjMnIcLazVIad70xFHFHA/VeihhulJRVB08P26KKD8nqzAlkhaZpMBZvQNfr/xdyW66FaxYxYFTwS70/wnrzmNcmuFg80IVSwYwSMomW0tYUbnReNgWroJgkoZ0YbqFVrT0SoTFtwk2uEosrybZdSd/bI1JU5ypNSsBtT9rZssKt2gjey651MgTki9JSGs1S2uBiuEWPD02awBKPcDHcpm0p5RVutO1KhRs9Z7WwbJpZNa2lVNeYQtsblwohxcVxTCtwk5HUMwUVCSiLv8fakSVNyJAhQ4YMGToAqkpQZSfrBIKsdi0wO3wcodYJN/qEVlnHacw0JWUhjVvgnekwOAJoDhviYyaPjmglXuATbmLSBEPXOYKou+gr3MQYbtRSmrBAVFpKJXOVHgO6GJIq3ASyLLXCjewWr3DzXmTKi1CRxxNunKU0SJqgfhgQd466rsstnrv9eHoXbV4UbFvKh1lKGSaFRS0DIwpKqhhu9GGHxFLK6klLbFL7ExA/n02BuBQ/l2cpFQm3ZIKH2q5U3WB9FskKBi1XQPGa96L2+o/j+eZSFDQL7+/9ES7Nv4D88Z1wbSvSD9nf4metJk2gP+1i3yOqLsV4iOcVt5AXlDOtoqEI0J8WbSncpOo+/u/0hJv8eLCxFglbdv1xpUkT4uucJAo3mS1fBpWllMU7NAw9NkupKoZbJAGBxsdOi21TQtZRUeFmJRB0ALGUAoLCjZCEjHBLkTQBCB861GIJt3TzhLZ75gk3OSFOPxbnwZl+W5dZSjNkyJAhQ0dAF3hiQN2OIlC4pb8DoGvHVjJUMsItzaL7dH4C6I21q7zpEoPyZwgx7yylM9gGWtZQuRgsxMSkCV7cHx0NeH93l7zb12rdCi2Sus5ZSttVuPEET9hO09AjJIdI6lH1RvhZOpaUtieNwk228AoVbrxdlCkn6s0wlpQZo3CTWkqJpYsq3P70Fy/DkeEK+nry+I879wDwEiCIC3QZOQmEcfCKBbmlVNYYWWzM1DHchNe4+WwobLdmoHDzSAxad1zShKQspdSGJiKwlDKyQkGAOEYen524Hr9QvgubzUP46Z4HgAcfQPXAWTDXXACtWoWOLjjg7dsUcYrjRL6NdFGMzZUUx4xBjI0oU7i1ew/RbE5P4RYhQMAreWTwLKXx6rK0BGJU4RbWAUhiuM2QpVR1/opg4yGOE1Ou0SylVpKlVKJwozHSqLIsDpQgSpU0gSPc5GXSTM1BO5yQ1NQ1LTgWiZZSRrgVTIxNNTjbt5iYJe2UTZVptU2oVHe0TvbbSBPCnMmYB89KM2TIkCHDmQCTWI7mlm9jC7QW9uFIj/T7sYVZGvUFU4qcjmDdT2XjO8NvzESkju01i0iyBM9EuYsHSsH7IC6R5asiNI0jiLpLocKNLdZMQ0PepEkT4i8yKuJcFTCeWiYZRAJO17VIrMb0Crd0x1lceHLf+fsZnMJNRyFPFW6McFMnsZHaDAOlDG/r6u3KY9PKfq7N1FLKoCKIWHuopZRTddL+kesI24a9piWCPeKBjF3MbqrM2tQ23LTU5JD4va0gBtLFcOMVbqqYWo7jogkTX2rcgNzWV0EfXAmYBdiHn0P9/i/BfeJruLX0VLC9VM04jesx7b9l8URHRNWlKCMSI0piVWtf4cYncmgVUdKQf5XBtmdR4aYz8iokp/jt/fJTWkq/+9B+/N5nH8J4pYHJdiylgpVQ/FxqKW3KSWl2vhiSpAm6xivL4sAnQYh+LyZN4CylSlWq96pxSjsXbpCVMyTPky2lIeEGJFlKUyrcuHOm9Xkeh2jm1Og5yY6dS47XmYzT9+4+Q4YMGTLMK9Ab95l+4tZaO9hrCwo3TvXSusItDVFy27XrceRUBdduW5a6/FcKtIRFcRbDTQ1NQQB1tA2zVC0td9FAV/A+SJpAFW5E1cRiuAHhYskgSq6mn+ktDqpTklcUhp97i0Sb21ZUfRi6lsqyl1RvXIIVtpnsCsqq4rJrGnzShOAhQKzCTaZ68l4d1w0WUXysOJI0IW9yi2hATRAxJURJqXCjbSAqM1OH3bBJDDdp8RG4Lh/QIO56rkoskSdJPOpNm0vq0Y7CLVi86+r20KQJQEhGiwgyE2o5FK/6Oe/9iX2o/vDvoJl5OCOHcGPxaVTcPB6ob0xhKeW/a+X3L5o0IbSXRYhPgsD27KtKZZkr27XJNYmltC2Fm0gkCRZlipyp+/Ekncj5GiW/0tUvHq7Afq9ImkAVbpTgkRGgAPDwc8dx+OQU9h4aFxRuLcZwU/RP16jCzfuwqbBdU0spTdrC+hVcC1uJ4SYZaHH3pJhvQKjk49vBWygDwi3BSs72Z9fAWl09R9MSzXRM5iKGW8RSeoYzbpnCLUOGDBkydAR0Ead60t+Zhvgv7SrcWrGUtqBw6+vO43/9zIW48tyl6Rv2CkFIcsZ/D2Qx3ETwMdzmiHBrM4ZhmpIZFhGFW6Da8BfHhq5zJFIhZwSLtsmqT7gZeqhwazrS+FoUaSylSYkMxEWoR7gJMdxSjhetK86GGjcHgphzgjKLjYvrgigC1THcZFUEyjoSw02WYALwlBriNU+pcPPLKioUbrKkCUD02tqKpTStSkR17ukazYjLk7CR2FVpkibQWFUJSRNEO56qLI4MXbgWPe/8c3S/9U9gbrkWuga8sesx/Eb5v5FDNLZeLMmfMMxBlkrH5Y65Z7/12+PP76SkCSwJiiyuV7scQsNKJkB/8sQh/M1Xd3DkHIMq8YOsL6z9li2z0/LbpiVFImrUgHCLHnfve++VKtzY9UFG3jAy3XZcTFSnk6VUTsroVOHmH4smOYdk9mFdD2O4sXHilWXxbeIVbvHnoPheVTb9PFDaIRxjnTx8ScxOrLeicJO3J1o2v0+7ilAZxN9W1mfOUiomTTjD7+syhVuGDBkyZOg45jKGG7tJaymGW5txtAKFW0xMpjMBesKYa22O75kAun6aD5bSmcyaQLtDCTd2tjTJItIQMlMW8yYmq80gsLdpkBhu07GUKuaimAwBiCrcZJbS1Ao3mjQhRuEmxmjiytCidRq6hkI+2nbeUsp/J1e4+YtKR0HqJBBuyQo3+ZJETYBqXL3ps5S6wmJZvW0cKZn31Uuikk9c14rqHdd1I+NLVTvKpAn+BDEDEkc+nsECV1FQ8aqfw+cfq+Hm0lNYbIzj3LE7UX/0RcC2oHX1w1i0jptjLfJtcFzgX36wCw/tPMYpAemCX/fFoirygy3oczkdqMsDwLcdw42SgApS/vbv7wIA3PXkYdx40Uruu6g1VK1wy+cMTNUsT6WnUMYFf6cm3OR/Bwo3BSHncoSnhqakDbRdtuNgskItpenap4qxR62gAeHmsCylchKUXmciMdyQXuGmisnGlH6Ap5Tu7cpzbfW2VzFurAxq2xUTPcQTgtSWCpCkCQ014ZZ2nsj202N+V1qBSr1Ij0OWNIFHRrhlyJAhQ4aOY6Yl7q0gUFu1QF5oGrB+WRmVuhUEbE+DVmK4nc5gN8sq4Q4fN6sTLXrlYH4kTSDvZ7Tg8C1nKQ0UbsRSymWm1NBV8Ai3CX9R6MVwCy2lSXFrVKekppiL1NLKIFO4maLCrQ1LaVzShDQKN9EKaeg6TEPjFs2cekuMCyVTuJF4RDYhiGRllPJG5CGDGOsM8BZoYQy3kJyhyShU8QNZH/UWCTfHFRfAMQSmHzvKdaPXcEamNAQVlLjQFRNruG50fB26eFf0Q0yaIBtPr6yQ2JBB0w08aG3BZKWA9/bcjfWTj6Px+OPcNpfkL8EubPG2j8wNNVHNVFQ79gxjqmZx2R+ppdQI5pK8jYyIKfjKzDirWqtQBeiXYbIaVf+pFEeyktj1yHaSE0akTpogzFc272nmYG57QgaJ4y8jLVkzHEHh1rqlVCxXpnDzPhOTazDQ64wshluoug3rqTdtjE01sKg/fIDjkN8COu6ahuDATVY9wo1mYfbKjlengSPWQlJTI2pVpcKNkHOAXOEm7pt22ov72Y4L01Bs3CIiMRZjFG40PuWZjDP7kXuGDBkyZJgTzKmjNFBbtbbP//zZC/FHP39J6qyDQGtZSk9nsO6LiwXxeyCzlIqYH2SkgvWYJiZJjKBF/UVShVdHEMNN1yIB7FlWS7Yo9GK4hbHK2rWUcvEayR8yhZsIUYkHxKvVuHoVajFZHSqwLolJEwBwccaAeIWbPHOl9+q6bqLCrSizlPrHcv/RCXzk7x/AgzuPcovZIlG42dyiWJO+F9XDqS2lrgtKjyTtJhJ7DGw86w2ecAviMvl/i8og2eKbt87JG8T6GcRwIwTIyycm8cdfeATfum9fQF7EZl/VdTzZWI3nm174AmPpFuTOuQnGqm0AgIsaD2N7fp/XJoWiSgT7WXQBjqhhoJZSSlDIYFGFGxRJE9p8aNdoIYab1HIpIc5U/cj5DIdlOxFGTpVUIAmqGG4MImHL2x29z+IIT9bnWsPm1JsqS7gIaimWlctlKXXSZSmVKdyg8dckhj/8/CP4yN8/gP1HJ2LLpG0CwoysEQVjklIaYpw81s80Mdz8MgLCzZsvVS6GW3xSFhXEOZn0e9gKxDa5ArnmbcMrHc90wi1TuGXIkCFDho5jJuNJtAoteG3tBkDXtJbJhlaSJpzOSCI5+fhInWjRKweqOFkdbQMloWaw3OULe4L3OfL4ndUXKNx0nVNMMYUbEKpQTEPnFG5WgsKt1QQepiRLaWRfnU+aoCH9QoNXuMWrrpLKoA8FWHuYIiv4nEuaIF+kyz5zHJcjiBgKeQNXnLMEjuuiu6gm3J7acxLHR6t48Nlj2L5xYfA97TNdoNJSpDHcmHo27bXZ5YmGZMJNQ9OSKdyYfVluKTX8gP8i5EHbQyVPUtIEMcMjADz14knsOzKBfUcmYBr7ASTME10DoOEfJ16Fn9rWg9feclkwB2oP/BuaT38f7+m5ByuqpzDs3ghnagRarggtX0o4b1w0GnaEhAz7LSjcFKdoNIZblCRpVyTfVGTElEFGyEWIsohiMkTBnyO27UbuedpWuCWoUaMKt5AMCmO4sRh6avK31ohPEKOCLGMlQJVpkhhuQjZbsS00hltgKdU0rm8Mx05VAACP7jqO1Ut6vbppHEX/VbSWs9+RaJKC+H6KyRuoas1IINwoOQeECrfaDGcppXXNBJRZSqVKVO9v7QyXeGWEW4YMGTJk6DjmMktpYG/sAHcREm5n9t0GW/ylieGWKdx4cNkr54qN1BTvp4mB3gL+7P2XBeRZUAWzPPl/G4YGUyAeWZB9ppIzDC1QxNTTJE1QjKXGkb+tKtz0tpNc8LH61HXFK9wYKROdMzSeliEoqVRxoWRlO1Db1/7H67YG70VbLFtUj07UAQAnRquc3ZJuTxd03LWBTD5TUA+nvcQS3idSvgyGH3BMPJZUTUnBgup7Ft5oeVKFG7GBqvphBkkTopbSOmmDKpYXBTtuFgxUCgu5MShc+jY8tfsYttafxI2lZ2Ed34WpL3nx3Uqv/lVoKEvLZOfNOIn7JfYxXHzHK9yCGG7MUko2E61qDPc8dRjl4R3YZL0ArdQLc9X50PsWo/nC/bBP7IPeuxD5c2/mCNIk27nsPkVGnKnIjFxgKXWiRF2KumSIqFFFRZvKUuqEBFNAnkuqZNuIVum0llLX4cthYEPNEW7+caZ1ydSMnMKNnCtxMdzotYlLmiAE82dghFtqgitQp5Fro8Mr+VgTVErKUA3LFG7JltK0t84qwjMN2JxW/Q5Fybzo52HShEzhBmSEW4YMGTJkmAPMqcLN/93vRJryVrKUns5gY64aBt5SOvvteSVBzI44F1CRHjOBxSR2G4PYT1PXuBhquq4Fi5MJTuHmLdCbKZImKOciec9lDk1tKY2qy9KAHuf2FW7Retn2TG0DRG2ukUDrkjoC+5ZC4SYimjTB22d00iNkTo7Vgs/E7XnCLdoGgMTHNFpTuIkESdJeqvIDS6mYpdSh7ZMovaSqIu81zlLK+puTKNzExA2sLBXiSGFNN/BI7w144GQf3tD1GBYYkwAAtzKKyrc+jq6z3yctk7V7fEpOuNE4ZkEMMUX7WN8KBrDJPIyNTg3O1Ca4lVEsb+zDsyhzi/tGZQqNez6Hdfk9YFRF87k7+foBNJ+/C2v7LoOBtbBhoGk5uPPJQ9iyagBLBqPXIRlpH02aoOgEQlLWsl1JdtOZUbipkiQEfxNyk9URl6WUfSbOqfQx3OSEKJ+lVOPKVFpKCVkjxnDTNC34LZJd6lUEvqp9LBZohOBSkWX+qwbRbo+gzYGlVBkHzt9W5wm3OIVb2nkSieGW8vgBwF//xw4cGZ7Cx/7HpdyDGgZLJCX9v2XWXapsPJOREW4ZMmTIkKHjmMukCexnvxM3AAO9BQBAX09+1uuazwiylCoWgbza5sy+MRPBjc0cEbecwK0DTRDPTcPQuWQEhq6ReDdW8Bm1+SVmKVVZ4wI1Jv95MZ8ccVrXo0q8tODIvXZjuOlM4RYl12gMNzGxQ5JNjZZNkybEqqgEUo/Zx0YmPYVb03JwarzmbUsULIB6kcvFcFNkKTUVVk4GseSk6w0bq4illGXEjWQp5UkNEXKbIiUWSB/9TKgASZrAspRahHBqRom9uKnHZ/yNfq9rwI7majw7tgKv2azjDa8+H7V7vwj7wFNY9tztWKy/GgPGFC7K78P3q+fhhFMOxmdMQbhRhZVBSCAZLNtFl1bDm6b+DUPlEwCAqS8/CNgWXgsgXzoH1eYG1B4/guNTxzC17xlckh+G42rQt96AnKGhueseoFmHsWobzJXnwDqwA/bBHdg0ej9+rfcFfG7yOjyz7xR+8MhBnLd+CB9667ZIO+wYQoohLoZbnmSUTSLq0t4TJcXUi7OUOiLhGUe4CQo3VZZh1f7xMdx40liVNIES0ZEspRohuiTUrcFZ1Kll1d9H6HtoKRVipkl7ydvAgzEGPZepdTpB4eY3lf2mVerqOIOyY9Zo2hFiTKyyleymz+wbhusCx0erWEHCPqjKYseWNo21m9nL0/x+ns7ICLcMGTJkyNBxzAdLaSeIg3XLyvjNt5+PFQu7Z7+yeYxQ4SYfdJWNLwO/IDbmaGw6bfnN53gWQEyaoGuhwo3BNPTAgta0nMQn+sq5qIgJ9prLVqO3lMNlZy/BM/tO4dv3vxTZd1oKt5RqurjzI4zhRsryPyuQBY+ooIss4iW6ryCGkhsqGuKJQcFS6h+PUZ9wA4Ajw1PetkJ76CJTGVNPUA/393gPN4bKBRwbqSrbJRIkaWK4AeqkCSLZxZqusiDH2RQ9VUz4ec6ghJtvKfVjCVICpC5TuKWYJ6rtguyKMDBSWAq9ZwilGz+Aync+ARx7ER8sfw9FrQlDc7ExdwR/O34TatoCAMB4JZowgfUxsDTq0dhsAOA262g88S3ccPJxXFeewpA9hoqTw4TWi8X2KbCUsa8uPQPUnkH1wXDfEbsLX5y6Gh+88M0oduVRuPjNcO0m9KIXxyt/9o1o7n0E4z/6LNbmTuDXy9/DTyZXAAAqJLYh1+aUMdxUtzOMBLFtXt0nzVqaUoCUqHBTWUpdSniyZBTR8lmfxSy4aYPus37I4u557Q3nMjvPGwkx3AyJPVMWw40S7fT6I7OUin1ncyBiKU1SuGn8NYTFDqVqVWUMN0H9VfLDJFTjFG5Cux/ffQJ/+/Wn8TM3bcb125cr2y0jj2WYrDWD8RTj+AVlKSylMoUbs8cWC2c25XRm9z5DhgwZMswJ0gZ+nQ0kkT8zW5eGs9cOzno98x2Bwk0x5JmlVA1ucTwPFG6dQN7kn4YbRBXB/hYJN8PQiOoohaVUwWmFc5Xv9dqlZaxd6sWv2vnSKem+hpA0oSWFG2mPGbNfXJmsybzCzXu/ZKALz+AU91m4X/yiHQjHxXXc0CbUghLPshzYjsNZDo/6Ac5FxR23uFdcG8QYbteevwxLBrswPF7DP3/3eWW7XJdXuSUTbvIspXmFpVQMTC9CRgQHsc00IW5gTgd8fpKNpyyGm6hGAuLVsLRtcYSb971fnplH6eYPYvjrn0D3xEGvXtdAv17F7/R9Cw87W3GXvg7jU/0AgCXGKH6q9BgaMNGnVbDkORuP6JfjJXuIWPC8V+vw86g/8K9wxo4CVgMLAcAAGloBn5q4GY3uRfj46/uglxfhO1/9Nq627sWk3osF67agZ+UGjDo9+LNvjKOOfKiAyhWh5cLMxwCQW3cx/vvxKq4/+W9YZExg1eQO3I/lymtFnBqR/q1UuDHCjaj7vHPNjSqQUt4TJRFs4nlH47WJll55FlbvVVRuellm3cT7Jgeh2sl1XWiaxpFG9OFJM0iaEB/DTdMRUbjpiMZwo202iW2WdlNlKWVknSohgAj6Mb1+smuXRiyl6hhubH/vNbCUNtQx3MS5tu/IOFwXuOuJQxzhFonhlpIwnSCEOW0HX5Zc1ctnKXX8MrxjK/5en2k4s3ufIUOGDBnmBHMocOuowi2Dh2DMFdRNkuLiTMZ8yOBKD0knDk9BsMcYhs6poAxDR0mwqJh6mKW0YTmJFii12pJ9H7Ovyhqta4Jdb+YVbnGqMpnCjbWBZewDogo3cSiSLKVUeaJsp1BH03YwPtXkFqpHhivS9lBbl0pdKWaANg0dZ68dxEM7jynbBESzEybFJDSM6JgCyVlKVXH4ZEoTlxCYXmwqjxTMk7iFcTHcRNIPSJc0gdUZ+V4x5nqxF4e3/zIO/OB2uK6Gn9S24md67sWm3FFcaTyDK/ufwZGphXiiuAxXFnejTydKwwbw3u6f4DPjN2GxVsOq/EGUTzTQeDaH+kNfASyPWdR6hnCffR4mTp1EYd0lODrcRL8DmCvPBQA8rp+Hr4+swbplffjDmy/BwEA3Tu0fRh33Aki+tzjl9uGH1XPw5u5HcE7lYawzrwDsaPw2IJ3CzSOW5HXxltLwnLHsKHGS1lKadK6Kx52SUoHCzdCCz0SIltK8qQdz3LIcaUwvCqqscl2vfi7rsBY+PLFTxnDzLOf891ThxnaRnQfRJAh82QwsgYMqIUC0o0SVSgk3ci4nx3DjH1wwUqpatwOyMokAZETageOTODFaxcL+knQ7lcru+EgFC/pKQRsmyAORWj2lws2Jjh1TcTK1nvh7faYhI9wyZMiQIUPHMbeWUvaaETudgiouFgNVY2SHhYfuq6Zsx+USB3QSfNKE2Uc+L7OUypMmBNsYGrcYrCvsMAzKGG4J8QbpNiJEhVv7ltLpKdzo/kwtt4YQbnpiDDeJ6sl/dd2QNIpri5il1LIcjEzUuc+O+oSbSDByC3RFu9YuKeOhncewanEvKJTZZ7VQ3ebyjFssmDVNLFaZNMEvW1TtBd8nWEpZH2zH5ZSejMAzzSjhJk+aoOgQkgk3nbse89+7Zh5fr1wc/P23E6/G1twhXNf9IjZoB7FUO4GlXV7ctcNWPx6sb0TNNfGGwRfQ3ziJ3+v/hhcYqwfA7gdQ3+23acU5KF7xM9DKC/HMV3bg2eoIbulZCuCAJEspr5pSvZehYTl4oL4Rry49jbI+gQ+Wv49hqx/O6GpoPUOwXnocy41hHLKHYjPKBuMhELgUjJS1bCcSID9qTfU+uOGCFTg8PIXNK/vxjXv3Rcps1VIaKtyiSSvSWEoLeSMk3Oxkwk20kurQuM/otbwZZCmNt5TS2IbSGG6Bwo3EPvPLVhFW4jwJFG4Rq6+KLPPfaPw9C00SkGgpZTHcgiylRvB5o+mgkDeUhKHYbgB4YvcJ3HTJKq4dYrsonnzxJP7mqzvwmstW4y3XrQcQJiECWrGURsfUcVwvtIP/WaZwy5AhQ4YMGTqMOU2akCncOo7AxpslTWgZuqbhHTdsRK1hobuYm+vmdOT4RBRuusYnTdC0SEwYL4ZbuA2NgyNDkqW0HYWb2M5W1Jp6SqIunnDz1VgCOQkAS4ZCFc/wGB/jTCxSVgVVa7STpdQFgiQJDMxSKm6rylJK37/64pW46rylkYWcqkmessgjHeivT9IRUsVwy0tiuFEij8VaEyElcYTxZLZDOp8NQeHGWUpbVLglZT7mCTexXHFrDTubK3ACG1AZHcX5+YWjw+MAAJULSURBVP3YmDuKHGz8+9RlGHe9ebd6xXas2P3vWGGcgqvp2NtciKVDJfT39cAYXIn8hW+AZnpx+JjaiCnEuIW81L5G3idYM5uWgyZMfGXqMry2vBNlexRD+iimvvK/gFwBaNbwW2UNd9TOwXH7psj+EeWQKw/a77U/tJQyqBIWsD72dufw2zdtx8mxqoJw4/9OG8PNS5ogtEHSbrYNm1NeHzwSxkphS6TT25UQMTRLqUzhJrOU6kThFtqvozHcKPnN9k0T4J/2TbReJll9NVHh5veJJk1IspSGmaSN4MFApW6hkDcSLaU0Y+jjhHATYwLK2sAeeBzzr8MAn2VYZSlVxZWzhXOS/QZr4GOInonICLcMGTJkyNBxzGUMtwE/uDbLIJph9qGKi8XQacviKw03XLhiTuvnFnUdOD5RS6nGERi6rqFLJNx85YSueYoK1dP5oIyEuRhnNVTtq+uC9bUlhVv4XqWOSiqTtcuUkHc0iLi4cE5SzdBtPMJNvV1cO0+MekTfQG8BIxP1YBEoquHoIpezNArHRKaaUB8bDbDdiAUwMUupkJyBoSDJUkrLbUXhFohlggcTAGzRUqpx7aGWadHWCsQfGy6Tbgy5CkTHXHUB0HUdU24R99U347765sj3E8YgPjn+WhiwsW5pGS+cmsJ7rtqCa7Yti2zLAs8zUtOVkGtUnSULiq8Cs0o+3VyFk9iCybFh/I+B+7EGh4BmDSh0Q69P4ebS03iosgDAudz+UUtpjMItUCOG6jIxfh2DGEA/TfgFIJkQDWIvShVukrkYWErD7LhMYR2X/TfYn1M5+a+kGl3TInOYxnCTBd43uAQE3j6aRslEpnAL26eKyaa2lDpcneL2IkJ1mlzhRmO4KS2lDj8nNE1DKW+iUrdQrVsY6C1ICV5ZuwHghZfHMD7VQLk7n8pSysafXj8mKpRwS6dwY+PvCseuyjKUFswzPlTI3HgTMmTIkCHDGQn2o7tyUTTVeKfwzhs34n/+zAU4e02WzKBTCBaSinuuLIbbPEdn+baIbcnQ9UjShGI+GufN29d7rSQo3JSWUl2uaOK2iVFRUWKrpRhulCSLs5TGnB+hpVSeKVX1kCEaF0qiemKLWydccMXHcIsuMRjhtmF5n7CtoHAjhCD9Js2lgbOn0zro4pctllOUZwQKN74/sqQJdJGrjOEWp3AL1JXea46cB4zAY6o3S6Jwo/2Jnb9JllJOcSx+pygzYSwDBREMwPCIUhURwbZlfeVthl6/XTdKzADJ6nlRGTjhlvAl53Xo/plPoeuNv4/Su/4KX69cBAC4cOoe2COHuP0jSRMknzHkgiylUUtplEjhzyll+AXxeCQkTQitmDRmmO73JVq+I5BXhqEHNuakuJh0f/peVKyGMdy8z+kxYckW6P66HtKPaWO4KRVuis9bTZrAWHKP+CMKNxrDLcFS6rphXxjCOG6WtD2R2H/kmLjwbKKyOm2Jf1iWtIImTaiqkiYoxkhUmgbx2wpntroNyAi3DBkyZMjQQfzh+y7Gdecvwy+8/uw5a0OpYGLjiv7MuthBJCnc4ixMGeYePOkx+weokIvGcBPjTokKN0aMMFVJnKU0jrQaKhfRU8ph9WL1QwFVfDdDSJrQdgy3aSrc+DhyYVmXnLUosW7v7+g2XNKEFDHcpAq3Mc9SunxhN/d5JEupwlKahu1VxcILPifWuqSECbRthjBGTIV5YrSK//Olx/Hgs0d5S6ki8UWqGG4aP5eBMHabaYSqKQZGuPWUQst53NRLTJoQE8NNNWRJ5DJd8Ie2SsW2PonACDeZ6kllKU2yAFIVVL0Zkix6Vx+MRevgwsRdtbOwq7kUJixUvvHHaOz8MVyXEX18eakUbk5UXaZSuGkJv5WtxnCjKrAgaUKM8oodJkbC6JoWJuqQKClF0CLF2F4sFhtTK8sUVrL9DEUMN1HhRgk3tWItOn+47VMmG6BkGadwk1hK1THcvFd6zCKEm0ByRolC7+++njwAz1YKRK3VMiKa9ZkSqeOpFG7i8WKvgsItINwyQ2U2AhkyZMiQoWNYsbAHP3fLlrluRoYOIyluXmijyWK4zUfwmSJnvz5pDDdBtTVQLmDRQAnHR6rBZwCQ82MO1eIIt5jHzaWCiT//lSuCRaZ0/xji2FSQXUmgJJ5KHcXqUJahsf3lKrvbrlkH09CxfeNCYT+5Koarl1hKUyncYiylg71FdBXMQIXI+rtt/RCe2jOM67cvj3YK8URpsA0ZckPXYdk+cRDErZIWre6H3zZNOJRMSfnyiSkAQK1pY/umcFxVCU4mq02SgdDBt+/fj10HRrk69GAuRy2lOYGsAELiqKeUCxQqcUk/OMKtxRhuaa2OIuiCP0wcEK9wC2O4RcvhVW3yGGAyUDUPs5eKqiwXGm6fvAofWHAfljYPo37vF2HtfQTFa98nVaap+pEnCje2harvIvmSVuEmnqviNSe0lIZ1xmUpFS2lhhHGXEsXwy1KjgZ2Wr9pjMSWxXBj+xk6UbORGG5BwhYSOy0uhltUjQVuH4amJd8+QeDmJ29QKNwSLKUhaRd+1l30qBl2bUybNOHizYvww8dexs6XTqFatyLWaqml1IqOP1W4qbKUplEN2jbNUJrRTZnCLUOGDBkyZMgwq2A32olxszKybV6iwyHc5DHcBBLJ0HV8+K3bgs/6ur0n/IwIqcbEcEsiBwo5I7UlT2xnknpI3Sa+HBVUJBclqzmFGykrZxp487XrsW5ZWVk3IF/s08Uts/W1kqUUAIZ9hVtfTx7dpXARxuynv/SGc/Cht56Ht16/Qdq2NJcHemwpcUkXv7KFblI/xHEXbc9HhyvcglOlcPvUV3fg6/fsAwA899II/uvefVxmQ+/Vr8OMWkpNQW3kum6gcOvmFG4xc0hByMr2TYoZJitHNkdprCkxU6frujh4fDIgzti2rP+cfdR/y9nXWlC4NSXZXWVZTifcEr5RfDMKV7wLMPKwDz+Hqa/+f9g6cicW66PB9q4LRcoEVQw3ucJNJLFVRy+qcEPs32xzBxKFmyxLaWAp9eYUi43p9SOFpdRRHyt23EOLqot9R8aVGTWpzVa0Z2qkbzKFG7OrplW4sbkXUZQpyTJE2sH1lcRwU9mcRSs5AHQxwq3mK9wU1mMGRoKuXNyDRQMlWLaLnS+NRLeLU7gpY7gpLKWKxBK0Cs9S6h2PTOGWEW4ZMmTIkCFDhllGaoVbxrfNS/DHZfYPkiyGm8yquXiwC3/xK1fgl95wNs5e68VkZIv0OEvpdIldZQw3TVPGT0sukxBFMco4FcmlKYimNG2ILOIl+wQLdydl0gQJacgWnl1Fk8u4y9pYyBs4b/0CTtlF51ua48ZbcyXvXbJYTlEeUyxGspQKCrZ60+aysJox4/7t+18CABwbEbPFMjWdr2Yj1mojULjx8bQsop7qKaYj3JJiZsYr3JLL7OmKZlPmMnUStSQA3P/MUfzBPz2M/35gP7dtTpalVFBNATwBkBTDjVpKZftw5bpA/pxXo/utH4OxZBPQrGHLxIP4nb5vY1tuf7C90lLqX8csx4lkpBQJETcgX7y/leEXRIJNjz93A4LPcTkCC4hmKaV9YSSMkYJwc10Xzd33orn3kWD/HCy4ex9C7f5/hTt1imsLOzfKzhh2/egbGNAncdnWxUF59sQw7GMvwrFDYj9QuEliuLE6uaQJjEBTEFYiEcf6q8pqGukz+HawUWdzkWYvpWUePVXBcV/pS1VyDCxUwlStmao97JjkDB1bVg0AAPYeGYuQqWkVbnyW0rRJE9jnvNKUxYDLYrhlltIMGTJkyJAhwywjbQy3TOE2P6FBvQCfDSRZSumicrBcxCXlYvA3IyliY7hN83FznKXUkKiq0oDO/XiFm7zxtEl0m3SEm7otDNQKJy7cZYgjfIp5M7BOAWo1mNi2VAo3Tt1H5owWtj9QuCUXF5QRyVKajy4iD52cktYtgu3LFH8MbNyDpAmkDDZGIvlRJyQDVQ3Gxtfj5mj0e15VmEL+KJTTVTAxNtngvqekmKhwY1ZjRkQECjeWpRQe0aBrGlE/hWVTMsGNEWE5jisl5FRJFwIFUnkRrOt/A3d+85tYOf4ENhhH8J6eu/GPk9fDdc+KsZSGyQESY7ixORkwbvI+JNm/I0kTAoIPROEWJTLFNoWWUj2SVdSpjGJq14PI9w4gt/ws1B/8MqwX7gcAXFTcjvVdU9iefwnGAw00AeQPPos8rkFO02Adfh65vU/it8oPY6V5CqgAZ/V2o3Dx7+PBncewxBiF860/QqUxhdcYS7Chq4z+UUDTFvltZv0mDwFiFG7qLKX8uAYWVJEIVVlKicLNa48G13UDok/XKbnqbVOtW/hf//AgAOCzv3O9QuHmkdUVZdIEod02yyarY92yMu5+6jD2HR7H+mV93HaxhFuQMMLBVC383UxLuAUkuGD9zmK4hchGIEOGDBkyZMgwq2BrgKQMdy3wExk6iFZJj+kiLyZNMMLYaGLMnMi+QdKE9i2lSVBbSnVOndaSwi1l7DflOaSwkaYh/aKLePU2jhu1iLWKUt7g7I9xMetoW1LFcEtQuDkuVZYkl1fu9tpJ1WMAb/dkOHQiJNzi+rRuqWfpPTkmKNwE6z09DxjpIQawZ9Y/L3MvIdxiupYUw41PmsB/p76GE9JAssCWW0pd/zv5K1UROo4L3dDk8aIU8dxENCxFTCqJZRXgbXj/8J3nsPPgAmi4AT/dfT8uKezFO7vvx/7GFXDcfmm5bI7YEoUb6/vx0Sq+8N3nsfvgKIBQ/ZcUfoEhaiEVFW4I6hNjuIkcjEzNpet8DLfmrntQvecL0BwLDQAhraoBcLG19gTgP/9wuwahO00YY4fwB/1fQ05zUP12EzqAlaZXf83NYdCYgnbnX+ADvQaWG6eAhlfqIvsoFhWPArt3Y7znajyK1SExKYnh1uAIN4ViLSCH4hVuhu6Ru2kzjGpe9zlLKTuP2GeMWAY8Mku0GQOhpbRak8dwU1lFDUMLriv7jk5E1IiW5Lxg27BrySSJ3+a1Uf7QSmXTFclqFgMui+GWEW4ZMmTIkCFDhllG2sxrmcJt/iNNZsfpQqpwM+VKIxFskUvVDiKmbylVEG7azMRwaydpgsbt3xrpF81SKlG4MTUJWYS2TbgV5JZSGVqdbzS5gexYUOIhTdE3XbwKiwe6cMEmPtGESAoDwOGTlHBTk6as/pOCwi2I4ebvmiOkHiNJTMFSypRI+ZzBWXHTZpCVxnDjCLd040/nTKlgQtc0ZSZRMUumuPAXs5QC0UW9Okupuo1iNsxgH4mqjbYLAHa+NOK1Azr+fepyrDKHscQYw6Zn/g5G7XJoGIArRGriY7jxfWe1fOG7z+O5/SPBPknnVJL9O6JwI/ZdGen34qExHB+p4IpzlkqVevTamz/+HGrPfh6a6+CANYQhYxLdWh360Co0z30TjMljOPHET7Brqg87Gqvw3re+CUONI5j6zl+ix/LIJq3YCyzbii/uyGFXcym6tDp+e+D7yE2cwCb/kuD2LUP3q38Fd3zrBzDHD+HSwh5sn7wHq/oex4+dqzCMQSxuvgwNG4J+AEC9IUuawB/zUOEmt2ay/UxTh92wE2O4sWuI5jNuTFnHJU1gcQGrJCFBwwqzJVN1aJFZStMp3KildNmCbhRyBuoNmyP/aRsoREvpRIRwk/+GiuRdGMONP48q9cxSypARbhkyZMiQIUOGWUWoYFPZkfiFZob5BW6R1wFOVLTrGXpoa0pakMqIEBHTVVKKGSuDcgVLafsKt3RkCdcmpbIreTzSuAbpIj1NltI4FPIGZ39MbyltjTyUEY8uQrIjTfN7Sjlcee7SyOciKQyIllK+8NVLerH/6ASAcPEbIdzYddDvQ4FmKdV5hRvLqshIhkJO5xRhsTHcEhRu/Pf8d0lhAQCgWDCRy+k8ARKTNCEI3h7EpfMVbmSM2RpfrnAjsaNikiY0JfHbvP2JJZXsz4iIsSneHmvBwL9MXolfLd+BYv0U8Ox3cGH+KjzaWMdtF2YpjSZNYO2kQeoBOgfkfUhUtKliuLmIWMEdx8Vnv70TE6Nj2Oy8gO612yL1GbrmkTnGKSzb+QPAdTC+5CL85c6z0J0HPvVLF8LO9+J3P30fSoVeLB16J545ccqvU4OxeANGXv1RfPbLd6G3q4Df/oXXwXaARx+90+u/W8JjW34N1y2v4nPffBqnrCJ+8S2vQ3mwjB258/H81BqsOutsDO77AYaMKbzZ/QFu6i+ib6yKyepCrOw10XusD671Ye4hi6VSuPljECWu+HmVM3TUYSdnKQ3G2Xtl89zLogquzJHxerB/pW7JFW4FPkupyr7JwAg+w9Ch6xrWLOnFroOjePHQmHQ7Ckq4ua6LcX8umoYGy3ZTK9zYnxxZ7YT7FzNLaUa4ZciQIUOGDBlmFyyOTGLShI7kwMzQKnhb3+zXJ81S6lecRPLkzBQE0zQ7oVS4iVlKW1DSqYiiyHaKtquyc86Uwo2dmw5ZuCcV/Wu3nYujIxXseHEYu3zLXCFvQNc0dBWIwi3OUsq1K74+se1yhRtdbLc/D8TEHoAXEB3wzhdx3N976xY8t38E//7jFz0rXcPCZJVXlLCms7YW8obXQi2c12agmvIWycwmKSrc4shJSsLK5pNB9k1jNxbL6SoYAWHBIEuaIFpKbdvxFJSuxFLqKxNlGRFVCjURSktpgsJtx56TkX0O2gvw0dE34UObD2Lx8QdwffFZPNpYCzanNITnISUBRbIxJ1iTk+KdJmYpjSjc4NcXKtwYeVt069ja3I1X9T2G/INVNJ/oxgd7u6AB+Gb1Auy1FmPQPYXlzeexofcpGE4DxrKzcHD1G4Gdu1FtatC7+jE+WUelbqFSt7BooCuoOzhWZhGH7CEMaQVomg5D549Rz8AC5NYtwVNOBXXLhqN71wY2Z8ZXXIX7quux4qVv4rLCHvRpnlqup3ECW3IAKkdQf/Df0bAuDMoMFW5ywoq1LWfqaFpOcD4FDxPYsVPNp4ilVOPqo1lKWV0jEyHBXqvbqbKUquybDFYQw80rY92yMnYdHMUekXCTMIdsXxd8zLX+ngJOjtUC26s45yKqO4nq1HGcgDSUWczPNGQjkCFDhgwZMmSYVSQmTQhsGZ1qUYZWoMX8NRsQCSdTD7N/JpFYxVzyre20Y7ipCDddazlhgazMdhRu9OMkQkVENC6UTPXkvTpuekvpdt+Gyex4gBe/DUALCjc1+SODLiHZAHnShOnwrnHErk7iS9HtF/tkhO24kYQJtI3stVQw8c4bN0LXtaC+HCEnbccNMjPmTYMjb+KEjUmWUkpIR9SP4OepLSENSgUT7/+ps/HJrzyJ5Qu68fKJqYBUo3WydbsdKNxcTq3GKdwI2cb+ZpAlOpChqbCUuiBJGUi5zOL6zN5T0v0qbhGHl12PRcOPYwVG8KauR3FfbROOO31+7LPoQQiTJnj1FARFruqcuiz/AtbmTkBvLuC3p+cHAA0u6o9+Hdb+p6D3DGKBtgE6CuhqjmBT5Rmc130UG15u4Or+YfTooeLK1U1o9Smsy3kqzV81f4BRpwtDp3zVpg5Uiwux8NW/isqz3vnsuC4snyQNxowoGUU1IiWnmIoKAPp78t7YMPWfQODougZHz+HLU1dg3BhCo9FAc/XlOFvfh70vHcYtpR1o7vwxVnTn8RAW+e2IKiGBUJnGPs/7hBvgzaMgQ65/7JIspWz42SuLqabp4bFmZY6QRCJVaiklh5xZ7St+ltIIYahQ5rG5tnjQu8aI9uk4SyngZXhldXWXcjg5VoPrep+LinNRLcfGSBXDrZjFcMsItwwZMmTIkCHD7CJcSMq/z2K4zW/wpEdn6qSLec9S6ivcYsgZQJ49UsR0VXpxKjOzzSyllCCJ66M6hhtfr6Z5i8I49ZhsX+9v9TYuIdzS2FUBPtsmW3z1pI3hpsnfq0DHR2opdaN2snYgEmqmoQdkgybE8mPbU8WLaCelZbKxNnQNN160MlIPQ9NygkDxrVhKW0uaoJ4bhkEJt/DzUt7E2WsH8fe/eR0e3HkUn//v5zkijc1vO2IldThiLickTeCzkc4c4cb2o0kZaLtE2ydXptGF5torkH/xJ7iu+BwuK7yA/zP2elS1LmksxrQKN3pcbi4+hdd0PeXVt/v/ornkZ2GuvxT28T3YPvYjbOk5jjGnCw82NqF+9+fR3HWP16fh/diEJ/CXA4DORHoFADWAhZs7Yvfjkfo6XPamd2BR5UX8y3efxdbcy7igsB9DxhQcaDiUX4f7RhZi/bYb8KpCN6r1E9yY2irCjRGqEgu6d754c7e/t8CNjS0Qdd71TIMLDfdY52K81sRlRg8OD12K7z63D+sX5bFx4lFcM/U9FLrX487aWbCdAa6soE0saUIw/uEcs2wnmCPs80RLqXC8eEspTyCOjIfnfDWlpTRR4eafV2xsc4rfDqmllByrpu0ExFnJV9a68JS4EcJNZdMVzslqoHDLYrhlhFuGDBkyZMiQYVYRPgVWEBUJcWsyzC3mggeli3nDCNUiSaqxNITbrCVNMDSOLGtF4cbFYItLmpCgEg3r9gggI0VfozHcJEQBWTy2mqXUJItaFkCbWaeAeIVbUrui7QzfSy2lcFvKUpoGOVOHoWtgjkVdk1j7dC1UCToKwk2IZSkjNOlYNm0HdYWlNO7Y8CpAyfeUvBWLSRhfwFO4Ad64sLIYkaYhVHU1giQJvrXUt/YxUPKAzjsgGqBd9rkIVdKEoAyDVxCxOHlxJJ7ruqhvfR2+9dQkLiu8iOXmCD5Y/h7KWhWN7z2Onyrp2Jg7ikmngBGnG131fmwoTWHlgd2oVUq4qnYKi4s67q9vRMUtwnCbqD/+TTSP7MbPdU9ixOnGjaVnAQAn7R4swCRqP/kH4M5/BFwXGwHAE4jh6uIuNHcB0DQULnkb3GYNU0/dgZztWZ0Pmqvx2PgCrN+8Ht99poJxrYwa8mhaDi7W83BXXYRHGjU80liHH9ZOIac52LB5PabQhQeOHsUKvyJGBgFeZlBe4UZI0SBeWvR6QY9zf49HuNHYcoBgz/R3ZZ9pWnj+7ui7HmevX4LGk9/GpYU9uLSwBzsq29B49hTMRm/keAEgtuXw98KyXYxMeKq/wXIRR4YrMQq3cD6z9nBtliRNYGUDXkICmnGVgVpKqcWVQWyPLSjcTIXyViwH4AnophUeR8PQUcgbqDVs1Bo2+iJlyRNR2MI5Wc1iuAXIRiBDhgwZMmTIMKtIUriFltKMcZvvmK4dMy1MXUcD4dN7FtctnxCjrSiJrSWi3eya4f7yzz1LaXsKN9PQceW5S1Cr2+gt5ZTbab5yggZAt51onB3PstWewi0uc6Us22QSZAq37lK6GG6iZS4JvMKNtz8CTOEWLtpnAqW84RM1tl+uFiHLdBDLnBtaSvt78hj1rWasPQM9BRw4NokBX/nDleOr52zHhWU5gaW0IBJucQo3qsJMSJoQjRkm31e0lAZ1ifNGC0kOps6jSRMYYcMUgWyuO64Yay1sEyV5ZMQCQ1MRww2Qq3SCuF4xJJ7rAq5RwN31s/C8vRK/1ftN9OtejDHn8HO4oSTsUAdQAnACaJ4AtgDY0gVsyx/AX43fikUvfgONww8DAC4kh/+blQtwZ+0sfOjsY1h1/C7AbgK5IvbnN+Lh4yVsz7+EDbnj0BesRv6CNyC35gIAwP3aBfjGD5/BuesXYMzK49njIxjsX4dD9l6YhsZlfw3JHA2H7CEAwJp8L0whmUW1Ho5jI1bhJijVyByhx4zNF5GgYsfY8BVuXpl+CzUtOF8c6Chc8hb88w4TZ9WewPb8fpxnPYX6fU9hIYDburbgvyoXwoYRaZNhhGpgy3ZwylehLegr+sc3raWUn+c0jiObP6cI4Vath5ZSeqlghBuzi6vIrXAc+RhuqgzXMuKQU7hZTjDeuqahSAi3J184iV0HR/Dma9fDNPQwsYRvx5UnMnHRzGK4BchGIEOGDBkyZMgwq0hSuCUlVcgwt+AW5R06RnThoGkaVi7uwWsvX411S8ux+6WzlM6Owk2fBuEGAD//2q3p6tc1OCw7XUC48duwdqRpQyTzoWSbIEYRjcWVsns5M9ywyGK4pbSU0sakspRySsGo4st13cAPNlMEfzFvcgH5NZnCTeMVL6OT3uJ7zZIynnzxJNf2n3/dVhwdrmD1El6dw2CaOuyGDct2gsyM+ZyennAjbZONPW8pVRbDb8cp3GgsOaZwC6127BytC4SbZTuBJY+d/7oOOHaCwk3y/j9+8iJeOjqBD79tW6D+aSiylALRuGEMlu3CUe/mxQT034+ijM9NXIdz8wfxgrsSv7D5BJ7fexwP1tbDhI0BYwqrBgwcGWlg05ohrF8xiKd2H8PqscewyhzGr/Tegd7DxwBoMC9+C3befw825Y7ijuo5+FHtHADAkaXXYuvNt8FtVKF1D+CJH7yAew8ewr31LSgXgL/+xVdx7dN0ExNuCVWtBMf1xpuRwY7Dk2Iybskju/xEHb4iqkoVblZcDDfvlRFOSdciMYMrjeEWEG6E0KJxGQFgr7UID01ei4dzL+PW8i6sXVqGffg5XFt8HiuNYdw+dXXQR1p2ztDRsBxYVpRwUx17dtRZTEPWNUouBu1zXDQtm0uSUq1bAblLr0OFnBGQzJW6Fc0I6kTnJxAq3NSW0mhHLEsg3MhDHO/BSAPVuoW/+c8dALzr3BuuWhuch6ahc/uJWUobfpbiTOGWEW4ZMmTIkCFDhlmGHhBqKjtcenIgwxyg83xbJI6Zrml487XrE/crprKUtt0sb3/FPDV0nVMPmbM0n6l90TA0wIqeO2z8zBRx1kRyJs5SShfUqS2l5FgyNUs3sZTGxdZSqaha3Z7GzgqsXImlpUMhb3BEDVOhce0iFjPbcYPg6kP+wp62saeUw4YVopErBMsASmO45U2Ds8dpsUkT4rOZ8qpCcW6QchT2aapwC2NbhUQJU6kyAoyRBpYdjgufJMXlknUwBMHaJYH6v/vQAQDAc/tHcO46T60VN89UWS3FpAAiHJeonXQNuxrLsMtahlLBQNctP4PP/dVdqDZCMvbCVQvx2OETeNuSDdh64SrsGt6FJ48A7+x5ABtzxwAA+YveCOO8W/G33y+iW6tjyg3niKZp0PJd0PJdZHz8tuhRZSyfnZcnvsTEE7J+GroGP1ducO5XBUupSrkWEjGItJWWL74Xj4WuRS2bnsLN+3Dv4XF84l8fx4lRjyzb2VyBcX0L/uh1l+CFB+9C+cl/wbrcCfxe39cx+uIBuGf/Esm07IcBsBxYjhuo0Nh5mT5pgt92y8ZtXQ/j3IN3oV58NQCPKKYJEwBmKY2Oi6Zp6CqamKw2MVVrRjOCkva4rhvMfXa+qOJ/Si2lYgw3QmYy0rxG5u6dTx7iCLecqaNaJ8QqqaNO9stiuAUhEzNkyJAhQ4YMGWYHYVIE1ff+a8fonAytoNVMkTOBVuKfUaQh3KZtKVXFcNM1Kckz09C5Rap3Ky+eO0GSiRRtELsTF9eLEm6pLaU0hptvKaUZKOsxyiO+nSkIN5WlVFDDeAWmqjYRpbzBLXTlCjc+Dh5b3A4S26glUaHIwMbTskmW0hYUbqpMrtLvI+pHOaFJq5NbSlnfQnt4oHBzaNIEUeEWkkOqAPh80gR+HGm7GnGWUoXCTUwKIJbrIsx6S+MlsnESrcVillLXcfFgYwPuqJ6Dh+rrMbz9fyC//af88jWObAMkx4MmW5EcS/aJ69tyAbnt0HFcKblk6GH8TEbQ0Bhu4vjIyM9QTRYpHj1dIUkoWkqZAszQde7cAXgS7shwBc8fGOXKZfNtYmgr/nL8tdjdXAJDczF04lHU7/+3gDDTNQ0lw5+HloNT4x7htqAv9AI7jgP75H40X3wQzZcehzM5HKoBA8LNe93a3IFri89jsLIfS5/6LF5TehKO43IJEwAxaQI/JjSOWzRpQvjeIepKdkxVCjfZsbUsokgjxzFUuHlJExjGJhuoN2ySyZWfyzJems6fMxmZwi1DhgwZMmTIMKtgN6PqgO/xhFyGuYUmvHYC7d6kF9LEcJu2pVTxuW998uKnubNGuMlUIdOxlEYzUUoW7v5HnKW0DYVbUaJ2oIu6uLals5SG7+WWUnCL7elg65oB7HxpBDdetBL/dd8+rs0i+cFZSolaiyaPmKw0kQZscd20nYBEaiVpgskRavGEW2yWUjb3wBNxnMItsJSG5AIjW4MYbhZTuDmRIPAcSanJFW5i0gRKCFHVX2zSBL8IV9jEItkbKTyVqcvPJ4kVV4xPKNomPUWfhm9XvZhrH1lyjqfeUrQzNqaejHAjsc8CYlCyna0i3AwtolLkLaW8wq0pSZpAs42KoPEqRcKNJiAI4rWRRANxBDxrq+O4OOmU8bcTN2Fbbj/e13sXmjt/hG5nEDnk8Cr7bpxXeAbP6CswcWpdQAIPlT2ic715DJX/+N9wx45w5V9cWol9uU3Yemo3qnf8AL9gHkB33yT6LS9BxanudRic2oubS0+jaHdjdHwZt39VkTQBCNW/lbrFkWDiMaLXYqZkNk35mIhZSm2Hn9fUGqrrWvDgqtaw0duVw4R/bXp673Bo+/bPLdl5yFDIGVlsXmSEW4YMGTJkyJBhlpFEqIVZSrMbs/mI4LB08PCogj8ngT2Zj8N0p5mKzGALWS9DqN22Sq+V+nUFsRZkdU2VNEEoX7KLGIvL2651hZtMgUjtR3FtS7Nwo3ZfWTw9TxWitgi2gl9/83k4NlLFioXd+M4D+8O6tOjYiAo3m6h3zl47iIPHJrBl9UCqetmxpUkT8qbOJRRJq3CTzVGVcs37Ozqm4nGREW7UCpj3s5QyZSNTuDUtN5hfImHsOC5sXVD7SKxsjuOiUgsJIfods5RqQGQGMEWUTOEmIxJ0XQNs14/hFiWU2JiIlm5K/LL2ct+z38pIjaxcoR0JlmtWveu6UmKQwXFVMdz04Fg0pZZSBzkjvCZYMoWbJGkCQw8l3BixF4nhJre9x10O2PGkx/+p5mocWvYqLD/8YyzY9TX8bl8XFjoTgAaclz+I5v2fwE3FTbio+BLM73wfv9dXwZA+AXcMgJGHsXANXKsOZ/ggBqsH8Uu9B4FRwBoFVpDD/HB9HWrn/CzOrz6I8p7v41r3QdQeeR5D+vUYdry4jDUuaQLfEZZkoFJrBmNnGjpsx+ZUZFRNaARJE9JZSkV7NZ3nIuFGybqdL50iCjc/FiCby5IJxM71Mx0Z4ZYhQ4YMGTJkmFUkKdzCOCgdalCGlsD0Fp20/Kpi0SRhLpMmhIRbenVZe/VH6xRJj8FyEUeGKxjo5S1p8vLUqhnxM7ag1rT09uKcJIYbBVOVyKAp3qvAJU1QEEuhwi1FgTHI5wysXNQDQEjyoUtiuBHVm2cpDYml33jbNli2yxGTccgRix8bu0JeVLip909KikD3jVhjJeVoWqhWA/iYTQHhRuYNU6EydV4Yw41aSpnCzStHzFLqfSaxlLoupmqhUpASQIxkKBYMLtMmECWHgn0UMdyCY0kUbjKCN6JwEyylIhGSFO80ojhMspQSKzWrUxbX0XbU/QwIXhnhZtkoOuHx5gg39ipR1q1Y2IOXT0zi2vOXR9ofUbhJyDUN8ddxS3E8Dy25DqvzY7BeegwLjQlMoQv3aBfjnOYOrMAIXtv1pLfhOLDQ75a+8Sp0XfkuaHnPZupMDmP/1z+N/soBHO/dgrXnbcft9xzHwckc8n1DeHFKw1t1HVMbb8EdO07hpq5n0dscxc9234uvFm7DyyerqDZCS6nYjZKfUKZSswLy0TQ01Ju8JZ4q3NjYpSXcLFsyz0lcO3aO1hpWQIgDQK1pB/uy643q3AF4hemZjIxwy5AhQ4YMGTLMKhIVblr8IiPD3GIuCNF2Ew6kspRON4abYn9xkT1bCjeOSBKICYb3/9TZODFaxfIF3YnltWMpbaVvXNIEokDctLIfuw+O4qrzlqZqWzpLaXRsADlBMpOSTc6+Suyj4WdUZSfa5TQuk2sSghhuQtKEHFncxmYplVhtue9jLKV0yCjhViW2YHq8WVyzUOEWWkqZspFmS2SqN0ZgaoSEsYWmyGK42YLCjZbNCL5i3owQbkGg/kiWUnkMNy82m+3HRosquNhbkQAJY7jx9TJQLkymxItTuMmSuYRWTCgVVUBSDDefbPdthzUyds0mT9TRIlyBiKFz6SPv2o6DxyexaWV/2BdBDcn2M/SofdQj/CPNDcBUWZG4f9BQvP4X8PL3TNy3p45DQ5diomngh8PL8UtLn8SS6h48130JLr/ucnzy35/CsNODP73yVmjkuqX3DOGhZe/CDx/Zj5s2rcHmczbghXsfwHG7ikVOCUDVs5AbOu6un4XDpQ34Re1rWJs7gXfmfogv6OegVu9WKv+opZRl+sznDEzVLMFSGp4rgaJSoWiOEMkJCjd2jWlaDqdws203UA8yRa1oHabIZQo3ABnhliFDhgwZMmSYZWgJhFoWw21+o9ydx6L+EgZIgPfZRrsKt1RJEzqlcJulCc0lBlDU1VPKcXat2PJETkWmehIUbq2QlipL6Yfftg1HhytYtbhHuW+rllJKWNDFJ1UWMQvgTB4eTuGmRQlJGsONZoRsh5SlQexZXDIxaYIiuWKkTqmlNEYBJ7OUAhpnC5ZtExBuJGkCaztV0DDFXpB1kViBNSG+WqhwC79wRcKNWkp9Mk92jQhjuEkspZLBlMYEFMgyIPrgQIzhprKUAt44uq76e7YNQ5w9mCrclDHcVAo3kqSjVrc5ErChSCoBkD4K2VEBoKuYw+ZVA3xbmf1VtKLqEoVbUgw3ZhEWkw44LrRcEUc23IYfPPssNusFmKaDJkx8rXktDo1ehBvWrYC5dAP2WEf9MuR1ONAjD6NYvTpRuY44Pfhv/Rq8wf0hVtT34Hf69uGO5mV41D076AtFaCm1MDrlZTft7ylgZKLOxRgM7Nfkt1KVNCFqKbWFvx2OAAyuMcLxpQQ0mxfBeSizlGYKNwAZ4ZYhQ4YMGTJkmGWo4kwxsBvOLIbb/IRp6PjYL1w6axZJeZ2zp3Cb7jRT7U9juNG/Zxq6HlVuTadPcYHYwzp5wq1dhVuRWEoLOQOrl/QmtI22K7ku2vZCzsANF66AbTuc+outC2eWcCNZSiFTuPFJE2wJCZG6roAACRVuhZzBxXBTkSCAYH2MsQ/Lvqd/hcSyF+tJBlm21jCGm7cPVdDUfLtikKWUElQC8SEqoQBv0V+hllJO4cYIt+jyV5Wl1FLEcOOyjQbzKaoMVCVNCBRuQmbaCNkpVB1VuEXLltWnsr4yOI4ihpuhBySOZTucnRTwVIOy8fHK9F7tlOSyqIak54gsJqLs/GXJBSyVwk2IN6brGkzXK+jYSBUAMFgucOSpGPOx1rBCaz0Lt8AeSJAsqjrpz/3jy7HLfR0+uG43SsO78BrjfpzrvIh/MS6L2L+7/QclE5UmxiY9wm2wt4B9RwBZ0gRK6poKW7otsIZNwVLaELKUsvOv1owqQdn5GsRwc3xCV2opzRRuADDvRmHPnj1473vfi/PPPx9XXnklPvGJT6DRaMTuc/z4cXziE5/AG97wBmzfvh3XXHMNfvM3fxOHDh3qUKszZMiQIUOGDCokWRLZDWdmKZ2/MA29o4Rou1lKdV1LvMmftsItwVIakAUdsJQmxXxKg6h6RL1NmG2yBcKN2CVLkiylCa0jbUijcOMJi3e9ehN+7pYtfJZDCUEyXYhx0WREUxCPjKiJ2pkjOaI+qQdJEwxusW3ZClmOUKfMhsj1RfiOI0DZdpo606xM6VcgWUpd1w2C8QMhccfijHFZSkXyRGIpdRwXU0Th1uRiuDFLqUThFpB3/OdNoujJSZJSeFbNqGWSdZuqjyhJxEgcURUUl7BCrAPgj6U8hpvfP6pwkzzMiLeUqgm3ZjNZ4ZY2KzAlpIFQ6WZIYrjpWpSEu/XSVfj991wMQG0pdYOyWTk8gQ0A/b0FbpzpvKs1LPzO/30AP37c4xgiCjc7PK/ZfJmoNNGwHBy1B2De+CH859TFqLsmVurH8cu9d0CvT3JtZEryw8NTASnd738mtZSSeSn+brJeiOeOFbGUhgkZdC1su0ik2yTOIiPOH3j2KH79U/fguf0jEJFZSj3Mq1EYGxvDu9/9bjSbTXz605/Ghz/8YXzlK1/Bxz/+8dj9nn32Wdxxxx249dZb8Xd/93f4yEc+gt27d+Otb30rTp061aHWZ8iQIUOGDBlkCDOvKYiKQOHWsSZlmOdol3ADkm2l047hprSUssygOvf3TIOPUzZ9dWiaGG7TspQa4fFIk0WWr5e2K832lCyKkhcuJUhaakk8TCEumoxoYvOBz1I6HYWbG8Qly+d4Qty25SSIWKeseplSS/Y3TdihVLhJlEnMZua6vkWNI9x4hRsXw02hVqJ9FbOUUuIxVLhFrw+BWi6SpTQk+qh6lircXMl8CrOU8mrBMIlBtO20XFoGRbzFN7I5lzRBZu1ksFPEcGvaDioRhVsM4RaJ4SbdjKuLtYW+6roWuXfQtOj5u2JRD/p68l6dfn9ViTaCawAhFBm6iyY3b/ceHsdExRP/nBqvY7IaKijZZqGazQn+XjRQQj6nB/3o7y2gpyuPu+tn4WOjb8Qxuw/9ehU9T3wRLvGKDpW9RDcvH/eIuGLeCB5U0EMUWDt1Srjxo8KuFRFLqS0SbnwMN3atEjNI2+Q8pPbVqZoVKAQpCpmlFMA8s5R++ctfxtTUFD7zmc+gv78fAGDbNj760Y/i/e9/PxYvXizd78ILL8R3v/tdmGbYnQsuuADXXXcdvvGNb+B973tfJ5qfIUOGDBkyZJAgvCmVf89uMAfLyRkVM5wZmI4ds5A3gEpT+f10iV1xwcpsTJ3KUsrH4PIWPdMRa4nNlLVbtJS2FsONKNxSxNjjwBFuyXVKFVjgiYdWyksLPoabxFKqiwq3aBvTIscIEMsJ4pKJsZJECxmFbP6ovo8QPHQ7f8GtoRVLqRYoYwAvSQLNmMjKEZOBOC6gCYSQGOuLbTelsJSyQPGyTLmqmGqW7QQqtGLeCMgWRnTTJvH2Z59wUyjcVPVRxaFsZkQzCpP3sTHciKVU0yIJGRzH5eKD0TLDJB1u1FLajLGUCplYk67plFylr2ljuBm6xpFPXoD/BEupFiXc2PzQNQ2O6+JTX92BQt7A//2NayPK0dBSGtbJ2mwaOtYv6wuUXwv6isiZOgxdw7jThX+avBa/Wf4O8sefh7X3UeTWXwLAs7QC4bj19RS4WHwMNGlCOAZeXDm2Wc7QI3HYAEnSBNvhYhGGCjf+eFtkTFX2VYpM4eZhXo3C3Xffjcsvvzwg2wDg1ltvheM4uO+++5T7lctljmwDgCVLlmBwcBDHjx+freZmyJAhQ4YMGVIgKQvpikU9+KP3XYJfeP3WTjYrwzzGG69eC0PXcPMlK1veNymO23SJFnHdWO72VBUsSYFIvM00ZDay6VlKo+qR6DbeaztZSnOKGG6p2oZ4AiKyPbGf0X6w9zv2DOOORw5Gvp8u+CylYTwq2q4g0D5CQkzcLg2oxY8pVXLC4teKVbjxbRVB55dMoRaWE849lcpJZq01DT3YV1RMBZZSRrhJ4t4xMNKEJl0Qs5RSJQ+LdxdrKY0o3JyA2KP70SQc1IpH+wmI5wlJnKGwPBpcGTKFm0jkkmtBjCKOWkZlhLDtKhRuRrylNE7h5orkVsoYbqytrFRpDDdEz1/T0Dm7rO04cATimR1LanMVVWEskzItnym9xL5GFW68mo9mYV3QV4KmacE8Omr344fVc7zyH/kqXMcb2/6eAlf3QE8+OO60+iCGm0AY0ustuy60mqU0iOEWUbiFilRVggaKLIabh3k1Cnv37sW6deu4z8rlMhYuXIi9e/e2VNa+ffswPDyM9evXz2QTM2TIkCFDhgwtIrCMxtx1rFjUI1UeZDgzsXSoG//3N6/F21+1seV9TcmCg2KmLaXve+1Z+MXXbw2ybRodjOG2fnkZQ+UCzt+4oO3yZPGRREQspS3FcAtVeK0uwHjSLF2dMoKffXZkuILHdp9oqbw04JVMUUJDAz8f2IK3LYWbGcZwY+WIapM4hVtSDLfYOGKSMY3rQcRa678yUpwmOAAo4eaT1kzZI4vhJlGJua7LKdyoZZORbzJbsywBA8BnZeQspZxyLGqZDCylAhHL4nOdGK1y9QbbcB5qWl7kI/9vcjykMdyiCjeqtGPwkiZEiTNTD7PfyiylXuyveIUbzX4Zh4CMFKyghkLhJpZH7a8Ar8ZStYkRwBSBwk0ynqrYiGycbaGvG1f0Bdss6Cty5QPAT2pb4RR64Y4fR/OZHwHw2tPfE2YE7yMEHD1GjPgSY/LR/rD34jiI/bAUWUplCjeWGCKNei3LUuphXt3Zjo+Po1wuRz7v6+vD2NhY6nJc18XHPvYxLFq0CK997Wun1aY0cslXCoKYItOIi5Lh9EY2RzIkIZsjGZIgmyOGyRQ/+mn1u5qhPaS9jrQ7VyjJls8Zkaf5hq5Nax7mBAXdmiW96CMLJPbkP2/OznynC6wFfSV88teumhZ5lHf5/uQk7WbHihEYhpG+bwWf4CgVzMjYqSCLg2ea6Y6b7lt8TdJGORkxc/f5lEg0dA150k8N3pzJ02ya/vt8zmi5DQVfIWO7LrFJ8uU4rrpv1NJZkNSfJ0ouU5gLVNXCkmFouoYrzlmC+585iqu3LeW3F8rWNe8YFvIGKnUroqBhMenYHNRJLLcIISRR/bgAqqRM23WD9rCx6i5Fl79sLojnESV/qDozuHZp8sQlun+NoaSEpmlYucgj5Y+eqsA09QhZlcuROUuaYvrWQPF40Peyc5KNv0tybZqm4RNChKiEnIDO5fTg/LUsJwjizyDGAqMIzi+m9ku4ZtDv6PmazxmR3wrD0GCI8zZn8OedBkQoSn/+sY9NQ+f2AYDe7rw394TxME1dTBobXGPE6ws7TptXDQQhBxYNlmCaOke4NZCDc+5PQX/0S6g/+p8orDsfRv9SLOgrYmSiDsCzmHIkWnBMPYjXa9PUgTobE1/hRs4D9jeF5bhgoTZz/vkJRBVujuPCsaMEtAqFQuvXt06jE+uaeUW4zRQ+/elP48EHH8RnP/tZdHV1tV2OrmsYGOiewZbND5TLpbluQoZ5jmyOZEhCNkcyJIHOka6SZ7krFnOn5e9qhvYwW9eRUjEXvs8bmKo2YRp6mF0tb05rHjqCVHNgoJsj3IoFr/6enuKszPcCUeh0dxcwONgzrfJY9kaGvr6uSLt7uv24Qv5CLWfqqfu2uZBDV9HE5lUDLY9HqSsftiHleBq6hiaA7q58sD27BlHkTGPGjk93d3j8TVNHf384t9l6otSIBvPv7y+13IbenqJfrh4QHguGejDQR+o01Menvy8Mbj442I0ucr4AwEQ9nA/imDfdkFgoFb0x1TUNH37XhXj1nmGct2EBR2DQ7QHA8OdNqWBiZKIOTVDAMPVMV8k7dqysUikPQaSDrq5CMA4M+bzJEW4GOcaMGxrsj64Nu7oLGBjoRlGYJ2bODIiNMjnHGSmZL5j4/9u78zA5ynJt4HdV9TJrz5IMk2USskBC9gXIYmIgISzBsBgCRD0EWQNfWAxHD8iHgIKCOUcJR5FVEBBFFJBDiEFABFnkO4oCCqJZWBIgZJnMPtNbfX90v9Vvbd3V09Uzk577d11cmemprq6qfruHfuZZKtPPRzBgDlTW1VWiLmJeB4eNawAAfNrchepIuS3IVS+9l8gBHxFwi1Sbn48qad2Fw/b3tUikI/3YKlQl3RMsUm4LEIVCQVRI+xJqayowJL2WE7qOZDpSVVkWQEd3HDoUhMJB2/2A1HNWV1eJcPrn5Tl+/5entysrC6Faum719ZWoqDA/LxXlIVRXmY+3trYc9fVVxnt9ZVU5ApagkLhGZem1Gw4HUGnZ97DGCDTVnqVaV1eJsl3miaLl6fcYa7ZXtfS6mXFoA/76z08xY2Ij6uoqUV1pfrzqw48F9r6Fru1vovt3d2HEWd/C8KFV+NeOVLLR8IZq4/0iGMw8x+Hy1M/LwubrKr/+xO8KVTW/HwRD5udMUVUE09tWVIRRm34vsQ5NSCKTPRupzt1zt6Y6//e3/lLMzzUDKuAWiUTQ1tZmu72lpQU1NTUO97B75JFHcNttt+Hb3/425s+fX9DxJJM6Wls7C9rHQKJpKiKRcrS2dpkmAhEJXCOUC9cI5eK0RnrSZSjRaBzNzR39eXg0ABT9fUT66734q3VAUyDiSolEoqB12NbeY/6+tQvJWCaYMuOQIfhodzuahpQXZb3LfYm6uqIFP4a1vKi9vRvNzeaPCN3dqSl9og8WdD2vx73l0oUIBzXP9xFrpEcqD+zs9HauIk7R0xMztu/psQ/RSCSSvj0/cen5TyZ1dEhrRFGA5uYO88TM9LCD1LXO7xiS6YW8v63byL7q6uhBs7wuumOu++3szBxba0sXerqipp+3t3ebtpX309Ka+VnCCNTq6OrowfhhVeho74b8qG1t3ZDpydS6EaV/n+4xBzDaOlLHIp4bcX6tbd22rJzWti5geAQ9UiCzsyuK9o7M+bR3ZI6/O/17KBm3D3hoae1Cc3MH2trNx7u/JROcNOU3pY+ruyuGtrbUNvLrUpynudpPh6YnUBbS0B1N4B/b9piOHbC/lwiiNLfD8nyI1yUAJB3Ws1iHsXjCWH/t7d22Es2Ozh60Wp4rAOjs6EFXKPUeGo0l0JLeproihI7uODq7YmjvsN8PSL1PNjd3oKMjfQyx7L//4+nnpb2jG/uk7dpau0zvA0Dq9dzZaV63Xen3B01Nvdfva25Hl2Vtd6bfLzvSr4F4LCGt41SfvtaW1Gd/6zVqbu4wrQcA6Em/zqzTZuX35QuWT0Jz+zjUlgfQ3NxhDD0R2tt6UL/wy+j++FpEP9mKHb9Yj0jZcuPnIU1BR3oIkPy6bkkfi1hrgrx7ETPssfy/V0ur+Tw6OqPG+o72xNCdHg4StWSH90TjRuA77rBOrRLxgf//fL39/5FIpNxzVtyACriNGzfO1qutra0Nu3fvtvV2c/LMM8/g+uuvx2WXXYaVK1f6ckzxeOl9oEwkkiV5XuQfrhHKhWuEcpHXyJjGagQ0BWOHV3PdkKFY7yPmKYyK7TZAKehxbb2kkrppf0fNGIGjZowAUJz/j5T7Num6XvBj2M7H4XkRsQ65h1s+jxvU1PR0Tvdm/rmOTU96O1djop+0vdPjKvDv+bGWn1mnoco9kgCpaXky/2Mwgi9dmSCE9VyyXSv52JLJJOJxy7FnueZJ6QOpIv3r+lgO1z0eTxq9ndos04RFU35VSW2nSPex9aFKP6YcyIzFzH3GorHMWhblqk59BGPp7aznIQ8JkPtRyVMpxX2sZxqPJxGWS0qhIJHQMay+Au990oYdu9rsPcZcnjfxnFufD9OUVNifB13qWSZP/1QspZapc3eeNJtOjEMsnjRKDCvLUiGE7mjCVrJv3mdmCq2S4z1DHFEsnkRUyqxK9Zczb6vrDmtLTz2muFY90YTtjwni+TKOQzG/dsvDAeNn1td03HJc4tjkdWocivQ8hYMahtVVGN8HLVmdyaSOZFU9yo//Cjo3rkf8gzcwc4iGjZgCQEGkPIh9Ld3pbaX1nP7jh6aar6tTD7e45T3dmrkWjSUQT9jXt5V8P6cJx1YBVT1g/p+vmJ9rBlRR7aJFi/DKK6+gtbXVuG3z5s1QVRULFizIet/XXnsNV1xxBU4//XSsXbu22IdKREREHs08dChuW3cUPjN1eH8fCg0Cct8o8eHL2ry8ENZSo2INR3AjBw/zGV7gxqkhuZUqBRiAvjtnUw95jw8pjt9paIJ5w0KOzExu1q4qiuNzJB+C18mNTkTAqEOaxin6JH1x6aGoqw7jzGPch40EVOdeWU632SfY2pv0Z+sfaHutpLcVvaU63IYmqKKHn+jT5jA0If29nF3U3mXen5yxIrJ1nCbluk0plXuWhaXedsZxQZ5SmrmfuCRyua64bfiQVEnrx3s7befkdO0Vlz5x1sfMNTQhM6XUvm0iqcNpzoamKsb7aTyhS33wUucViydcg+j2oQmOm9mO3xqYVxWnoQn294PMe316gIHT0ATL82ydUir3V3Na1tYAntNEZPlcnFgDvuI50hoPQfnSiwFFQcPe13FC2ZsAgJqqkDQV134s1imrpqFBWuaaOp2HeB2appQqim0CqXjd9sQy588ppd4NqKuwatUqVFZWYu3atXjppZfw6KOPYv369Vi1ahUaGxuN7c4++2wce+yxxvdbt27F2rVrMWbMGJxyyin461//avz3wQcf9MepEBERkcRpWiRRMZiCayLDzRIQKYT1/n4EvfJ6fNOH8sL3Z/sQn2VypfgAa50+WTSmIIa3xxTHn+s6+TmlVM72UBXnx3abrJgvkSEjJnwGtMx+lx4xCt9buwDD6t17WKsOwUDzMcmN/t2Pwzh2L9tY9ieyxbq6zWVpIoNGvF7Fc5RMuk+clG+3Btxiluw3IFU2aOU08RQwB9zKpN5Yom+crsNIbZPXk/i6whTASd02fEiqp9XHezts56Q5rBtVUYxgVbbguNNaEj9O6pkppE4BLLcppZqmmN5PRcafyHCLOmQeCmJ3XoPLmhxw0823OQV+rbcZk21FVlcyaXs+jWOSg0vS/5uUS2vD6bURt5SOOgX33e4rWIc0mIZjHDwL4YVnAwCWVbyB2aHtqJWmlMoB4bg0wEYmB+Ai6X5xnzZ3mTNB04FTsT6j8WQmcKwqtsmn4VAmU07w8v90XiaZDgYDqqS0pqYG999/P2644QasXbsWlZWVWLlyJdatW2faLplMIpHIvAG+8cYbaGtrQ1tbG77whS+Ytv385z+Pm2++uU+On4iIiIj6l/wB0ch6MAURfA649fFnimwZSL3ep6KYMmCsbB94+yzDTTpXz/dJb58jWOfnGcgfchVFgeYQfAFSz11S+tDemwy3oCXDLd8/ZhhBDDhfFzXLdZN/JgJz2YILtvNLbyuyxTosATcjw00zT5dNJHVb9pnIyJJ7p1lLVEVQIp5IGvcvD9k//iaMzCfz7XIJnVOGmy4FsuTLIE7bKWNKznATj7vy6PEY3Vhleu+SM9y8BHacnodMhlumLFNR7Nsmdfv1Fecpr6/O9PMlMveisYStf5mxz6Q5iJnrDxOK9FyLxvyZzD7Ltg63ZSYb2zPcFKTiouIcdSO4ZA4w9zbDzbrMs/1OsGW4WQdYTDoaseaPkfzb0/hi1asIdZ1oXDt5fSY8ZLiNG1GDt99rRktHFH/fvg8zDhkKIBOIrigLYn97FDEpcKqp9gy3cFBDlzRMRYG3PxaEAt6mUpe6ARVwA4Dx48fjJz/5SdZtHnzwQdP3K1aswIoVK4p4VERERER0IAg6BNxMGW4FBsis9+/rDDenLJhCKeITKVyCMJZz1vr4nIH8M9zMGUdO+/PlsABkSjrFfs1ZZPKxAZDaJ/Umw018YBe9yryUdsnEY7oF+9yOHYDponkJFtqzQVP/GudgKSkVARERRMgEGuwZbrpjhpu5Sb4IkMh9xhwz3CzBIUHcT4E5M0kOuIm7yH3RxHFXlNkz3BrSUz/3tmaGXsw8ZChGDDVPc1Sk+xnPmeW45ddltsxUXYcpw826rZxVJtNU1RTQsWa4xeJJx0AdYM9AzJnhJj3X1iCddR3JQcjMsZoz3BJSaWogoJqONfPHBXNAUS43th6vruv2gBt6k+HmXK4pq5h3Jtr3vI/gJ/9A9ws/htq0OnUM0pMkJvoGLG/O8ntRMKDiiMMOwnN/3oH/986nmYCbJcMtlkga+1ZVc1YjkAq4yTTNvoa8nOtgxatARERERCUjELCXWTlljvSWNZDjZ2miF7myWnrD3O8s+2MCfdnDLftxZbtPtkwtt9t6y5pBaQ6K2tej0KsMt/SHWJF9lW+Gm8jUsn6Idjomeylf5msjCJTlFKznJ/YnHtua4ZbZt8ieS32v687DSgBzwK3L0gxeBBZyBdwyGW7mxxCN6VVL1k+m3xggItWmS5Ulw02cuxwAylYOKgdwvfTUc9pHUg4MKvZgsxyckmlqqnRTBN1EkFf0cMtWUmoNbuUKLsvZjNYgna1HmlRmKwSkidRAKtgq9iNucyoplf8YUxF2LylN6rpDSanY1nws2TKArVlfTpsqqorKxecDwTIkd23BoVseRIXSYykpdc5wC2rm4P/cSam2XH/5125jPYsMN7E+4/FE5por5qAdYM7uBFKvTy+/e5jhlsKAGxERERGVDKcebuahCYUFWnL1wCo2t2BOIUxZWB6CUwO6h5tD+Z1jhltBB2ZmHpqQJcPNh8Cl9UNsIM8PtbVVYXzhmEOx+oSJjj9Xs1w3+dtMoML9HOwBt9S/Ilus0yXgZmS4SX29vPRwi8bMAbd4IomNr7yH//fOLgCp4KS155W8L1uGWzowoamKKVvHXFIqzs3+ujT1cDPOLdMPS5RjOgfcMtldC6cPx/iREYwZXm3aRn6unPbhlOHm1EswWw83IBPUFc+XnOFmzfqS9wkAuhgImuP1m5nEClsPN6fArWuGm1yGbATcVNMxZQZdmAOpZSH3ktJUiao1w8353LJmuLkMTbBSq4ei7OgLAC2ImpZ/4auRp1Af22X0KXTr4WbtVzpuZASRiiC6owns2N0BQMpwc8hUVFUFAcv1tgbnA5riKVOcvXtTBlxJKRERERFRb41syJRmiUwZU0CkwGCRKeuqrwJP8uPLATef9ukULHB7TKfvi0Vx/SbLfdRMoCJz1yJnuGneMtys1613QxPMH2LzLSkFgGOPHOX6s2wBXafJr9kuo6ooRv8sIPMUhl2mlArWHm6OU0odgmTWmNEHn7bjXztajO9DAdXxmrtNKRWTTV0z3OTpn9L9xJZySWk0PbQhIE39FLvMlp2mKAqWzT0Yy+YebNsmV/BfznCTe7jZgklZergB4vlIGEMkKqXpqz2WrEJBPC0JPZM5lY3qECgT97GWTTqdgwg0mQKaujngJoKKRvBRhSXDTSoptTxAIumU4WYP7svH7cQ+NMF94+DYw6Ge+g00b9yAIT37sKzl53jo9m2YtexUTxluqpoKrjbUlqO1M4bmtm4AEeO+5VJJqZz1lzvDzR7w9HKugxXDjkRERERUMuZMasTKo8fjyi/OsmU9AN5LE7Nx6y3UF4qR4Sbvxrmk1Pp9HwXcelVSKu4r78dp570/ListW4ZblqBIb66jNeDmd58k0/FafmYqKTUmiXrfn3g+jQy3HpeSUmsPt6Q9u0h861TSKO5nDQYFAqpjcMsoKbVkRInJptbhAWIfOsyBLNt5Svfpioqee5kNjUb1DkFTESTOtu5NQb4cGW5GBpNLhlvSIVFN/MHCuubkgFu3S8BNt1zTnCWl0nNtBH+MgF8vMtwSDhluljJXa4ZbeZYebqmAm+UiObzXON1XZuvhluPlqw0ZjS3TL8Hfok0IKkl8sepVvPvMY1LAzTql1J7NXVcdBgDsa+0B4NDDzVLe7DQ0wXRMmntJqXyrNZtvsOJVICIiIqKSoSoKTpx3MCaOritKDzcg8yGpvzPc/Hr4XBlu/VVS6hTEyEVcHzXHOfn5ISh7hpv92IRChiYIvclwyyZrDzfpa2PaqcdSwdS2qX/FB3iXfvu2DLdYPGnLcBMBuIRDSaNTnzYgde1URbEFSKwZbuIaR+OJ9HGbA26ZktJU0E1sIzj1XBPnag2QyPuTyRlubuTnKts+UiWjmdus+3SaAivv09ZEP6QZPxOBRCtbcCvX0AQRKJOy7dweX1Hsr99MD7d0hlvSvYebKHNN9XCThyZk1o31GiUdAm5uf3jJXlJqXpte3teSwXLc074YT3dNAwCcGP4Tyrt3A3AIuDms0/pIGQBgX1s3ACCeDriJ0uB4IpO9lxqaYD4m6zFrqr2HntPjM8MthQE3IiIiIipJxejhJu+jH+JtRe/h5rTL/hqakKsPmxOj1FH6lOOc4ebfOcg9j1TVPMHPaXqlvG2+gpYPv373ScrWw00OuRlBpRz7UxyuRa6svPJ0Ly2x1n/5+614/A/bTdsYJYsOGW5y4EQmAgfW4FSmPDX1vbimIhMoleHmPKVUBHFyvYYEa7me0/HI+8hVsuv0tXGb6TizTyn10sNNCAVU4zns7sleUmqdOOp6Lg79+pzev4HUmvOS4SYyHEVvNtuUUtUcsDaXlJqPz6mk1Dgexfp9HhluHt6HFEWBDgWbumbinegIhJQEZu7ZBEC3Bcfk78Vx1Fsz3NKBQ3kqqzEgxBKEBIBgwPxHBE1zzhQFmOHmhFeBiIiIiEqSU9NtL82ec1Ec9ttXzBlI/uwz17RD6zXrsww3+WuvGW4OWSdO9/TzFOQPqIrlseVr58eUUusH9mI0JnfLXjOVlLr0r7LtyyGA5zYhVYhUhgAAC6YOQ0NtmeM21pJFmdz8XiaulWZZ0NYMN2vATXUpKU1Kwwig2AMdTlRLBqS8P5kITmbbV7bsSfm+qZLSzG22Hm7JzBRTmVuGWTCgGsHLbpcMNz3PDDc54GYN0jmXlEr3lUpM5aEJrR1RAEBtVSh9TDAeQ9xP3ndZ1h5uSVs2pTgleyDd/TztGW7u29qPRcHPO+YjpqsYGt2JsYHdtrVsHhqU+ldkuDW3mUtK5UxQEYQTfd+sATa5bD6QpYebvI44NCGFV4GIiIiISpIRcFP87bvWnz3ccpVK9m6fma+9DBjouww36TE93kd8yMxVJusna0mpXFZqOg7LwIte9XBzCH74zaksVzxWKtiiIpgOmhXSw81NpDLVI2zSmHpcsmK64zZOU0oFt4CeyLhx6s8FZAIxQaOkVJpS6lhS6tLDTdq3Uwmp9bZsGW7ZXmpuvQKt+0hKGW6KYn9e5SCX+bjSPdwcyhbFNXLr4Za0XNOcGW5KJlBm7eFmzbhSFfPrSg6aiWubSCTR2pkKuIkArjE5VZpSGnDJcHMqu7VluBlBZ+dzcRIMmoPzXt6b5E1a9Er8b884AMDisrcdMtyy9HATJaUiw016nYh+hU5ZhQFVNQ2u0FR7H0BBzpR0WvuDEaeUEhEREVFJMgIHqgJVBZIJn3q4iQ/DJdnDzeEx8+hR5CtzEzdPd3Eq93W6Tv5OKbVfP1VVkEjqpsfRcgRIvPBjSmkubhNIA5qKy05LBcBEtkw+PdzEl7ky3GrSARIAKHfpxyaCJ44lpS73EUFCW0mpS4Zb5rhdhibo5uCNIF+T8rCGtk5zZlRAU9AjDWh1XAseMghVl7VlPQ75OBXFHizJ1cPNuaQ0dS27XAZfWKfIeu3hltR1Y7poJsPOnuFmOnfN/nUsnkR7Z+oi11SlAk7WrDtFMQeFTOvGcrhOPdzk17os2/tjOODeJ86NdX+/756Mz5RtwbTgB9jW+g8AmanDQYeJ3CLDbX9bFMmkbgSSy0KaMUVY9CuUswrFGg1oiu0aKy5vO259GQczhh2JiIiIqCRpUvN18eHGj5JStwygvlD0KaWOJaX9lOEmP6bHhxx1UBU0VcGwIZWZ/ThcJz+fOk2zB2MyaySznfx1b8tyrQ38i5nh5nTdpoytx5Sx9ZkeYx73JW8smrUbN0ublIc1U7+08jLn/BBrQEeWbWgCkK2HmxiaYL6/raTUCGRJmWNu5+NQ3ir3cXPKOEs9hvlfJ4rL2rLeZu7hZl/78lAFY99w76EWDKhGoLcn5jDeFJl+eOLpKayk1D40wVTebMq+Sn3d0hmFOCURwDX6ykllrnIgSc5wswbXEgmHgFv6X2vGppLlXOWScK+/i6yvw13JWvwzNAWqAozf8nP0/PnX0GOp7LWAQ2C4pjIETVWQ1HW0dESN3nahoGYKUAJSkFPaT0BTTc9BtimlOhhxs2LAjYiIiIhKkugfpUoZEb6WlPbD/0kXvYebwz6tAYyBPKX0rOMn4tbLFmLk0EzAzSkqVLwMt9TXmsN6y1UC6JVc3ujUhL9QmQzObNs4Z8G5bZfaNvV1RMpgA8w91yIV1p+5Zbil/o0nnaaU5ujhZsmYMkpKdfN2gmYJuImATWpKaYr5NZT52mmAg5yVaO3BZeU1w80xUK5kssbk47SV1Or2klL5GlkntGqqikAg9XNrEEqwZbjlWidZhiZY329E2bZ8TNbj3p/OwKwqDxrBIt12TAoSUpmo3MNNBKAEp5JScQzWjM1s5xrsTYabwxL5fXgJ/l/POChIIvrnX6Pzf74NPRk3lX5mfk8pRh+7fa3dRoZbKKgZ68/oV5g+JHk/Ac3c0y2QtaTU0ykNKgy4EREREVFJkjPRnHp7+bHfvlb8KaX2fVqDHgN5SqmiKKgoC5puc3qe/DwD84fc9L9GlpjzcRQStCx2hpvRfy7LVcqcSvbzMJWUpv+tLA+ag1LS+rIG4zRVdSxBzZrh5jKlVFwrpx5m8r+2klJrwE0qQZXLE4WcGW6aOYDlxEtAU34dOgXuxOtHDipZs8MA5ymlmiXgYnwdcO7rZpXv0AR52IEYiOE2tMF6Dk493ETJc01V2HhNWkuHVVUxrRU5kG3LcEvqtuBuJsPNvl7chKVtnSbDOnF6T27rTuChjgXYedgXgXAlkns/ROzdl8wZbtLd6qpTZaX72nqMiaShoGpc42jc0sPNkuFmCmqq9sEb5I4BNyIiIiIqSSLbQVWde3v1Vr/2cMuRjdYbbtk5gjVjaCBnuDnux3HfxclwEzSHoKwfPdwAc0DIWv7oh8ryVMCywqWcE8hcv1ynoZijuen7KKiuzARF5YBbjSXgBjgH0IwebtZG9jA3g5eJa2Vtwp+w9nCzNelXTAGohtpyAOlsHqk3mry9UB7uXcBNLFrPU0odNjNKSk338dbDTT4u+XqIr3NlVhrlm3kOTUjq9gw362MpsPRwU+3Xs7k9NTChpiqU6bmX3kYedNFYV4EvLj0UF50yxXStrRluyaRuX2vpzcPWEuQs5ypnuNmGMLhwem5TE1gVdA2bhfDhpwIAon/+NYJKpqee/B5TH0kPTmjtRjRdBhwKaLb3LnGfoKlnm0NJaT/87jtQcWgCEREREZUkOeiR6eFW+AcFP/eVr+JkuGXPJLOXTPVRwA3ZjyuPHdlv8vEUrAEcwLkPmuJTwE0OshUjw23NyVOwe3+3EVhyYpxWjtOQ16vcu62mIoSWdFDEVFLqEHArDwXQgqjptmS6DNIpZOE6NMGlh5su+o1lyXADgNvWLUIiqePNrXtS9/PQw82xpDSQex2ItZ/ttZarpNTp/UF+LxSSSR3WREF5f6YAb9Bbhpt1qIXnoQlS8M/o4WYrKbX0cDNluKW+3i9luIltbRlu6R8sPSIzdECwl5QmbVlv4v7WHm7ZnjOn4HwuTvtr6Ui9HjRNRXDS0Yi+uRl6+1407vojgAbb/WrTgyP2tHQb5x8OqvYJsA5ZhdaS0mxTSsmOGW5EREREVJIq06WFqRK21G2+9HDrx5LS4vRwk792ynDrr5JS6esCikCLXlIqfYhOWsrhTIGBYpSUFmFK6ejGahw+sSHrNpmSR2+ZSwAwrL7C+FoOrJWH3UtKUz+354jImVBWwYDm+JyLYJH12ics5Y9OPdzEcVSVB6Xpn5lAldtraEh6QqTMnC3kEnBTzP86UdXs68npvopiz5hKSmWcTscVcMpwyxVwM/rcmV8PbsTUy4Q8NMGlpNQaNHQamtCTLptMlZRmsucAb1l3jiWlLv3qwnmUlPbmjyRO9xFZegFNgaIFET7i8wCAhp2/R7kStR2HGAjR1pkJXKd6uFky3BT7NQ9o5sCcpqksKc0DA25EREREVJKOmjkCZ58wEccdOcrILvKlh5tDQ/y+UpwppdnPR1UVy3S9fgi4FfCQzoEH/85B/nBqzegxlRrKGW4FPH6oyD3cvBDnless5NZiw4Y4B9xyZrg5lpQCCZcASEBTjKb+MlHOZ+2vl0z35sqV4SYY99Pl25wD4SfOOxhTx9bjnGWHSceXu6RU7KOQDDe3QQrWte9UUipnlZl7BqauYa6AmwjgeS0pFYEyeWhCpoeb9ww36/WsqQxJAdLUbV4mp1rLPZ2HJqT+tWe4ue62V7LtTzwPgUM+A7VuBLR4F75Q+QoqlW7TNQ+n/2jSms6MS5VJK7br5XTNNcs014BqH7xB7lhSSkREREQlqTwcwFEzRwLwuYebyHArmSmlufdXFgogGkuXMfXZhy1/AlROwTVfS0ql62HNcJPXSK6MJK+KPTTBC9VYM7kCKZmfD6/PTI41ZbjJPdwqvGW46Vky3AKaiqCmGr2qBBGoFMGkUFBDTzSRc0qp9alSjQCO89AEaw+3K86cabq/deqnE5HRme3yuj2mdR/W+1iDJUmHgJt5aIJ9veVad2J/CeP6eMuElCemGlNKbUMTzEFDOThoDc5FpB5uYr+6UVKa9ZBMnDLcRADOWnKv+Pz+mO3aiUCYoqoIz1uFzt/cghmhDzAmsBtK5yQA1aljTL/G2jpjAFLZnoqi2EtKRYabZWiCfI01jSWl+WCGGxERERGVPKMEzocPQ/05NMHUeN/nHm7ZPtjJjej76rwd+u33SrGPVr5uCT1LhluOjCSvgkXu4eZFTbonlNOQA5ncC8uU4VaRR4abw6RPORPKStMUxwwsY0qpCLgFRFZV6ue6S4abNSgmZ0xlGvB7D4TLx6a6RO0zQfDeZ7i5ZXY6DU2wDsx07eHmcUppZmhC6t9cAWbxc92ph5tDhpu8O2u5o6xW6uGmW0pK88lyTSTsQxPE2s6nh1tvZHuvaKjJ9FkMjJqOPXMvxSeJGtSoXah65YdIdjQDyLx/t6ZLSsUx20pKRYabZUqt6RqrKgNueWDAjYiIiIhKnvj84EsPt34sKS1mhlu2jD25j1t/VBMVNKXUMcOtOCdhZLiJNSL9zNp4vLfk8t5i9HDzYuzwalz5xVn48omHZd1u9/5u4+uq8sxkUjlQFw557+EmrlpS17OUlKqOzenj6QCJZg24iWwsEXCzNZK3TslMMQ1NUDLnN/PQ7P3vApbyPCdGyW62DLcc68ktCGfdZ1LKKjP259bDTWQJOpTsyqzBrVzZwOLncg8309AbeVtbD7fM17VV5vVTUyn3cBPHJh7T+2swqeuIJ83rTQTcbD3cfH5vcdtdQ22Z7fWiDx2PH7Yeh92Jaqide9G16T+hd7cbr7H2rnSGm3geXaaUyhlumkOGm9sxnbJwLADgmMObPJ5d6WNJKRERERGVvEyfMh/21Y9DE0w93HzK3fKU4SYFRbQ+qqXNNT3VK6dZlsV66qzlcG4B0sIy3Pq/pFRRFEwcXZdzO9G83koOFMjPT64eboGAilg8mTXDLRVws1+XHkvATWQKZkpKddPtgluGWxJShhsUfPuCudjxaTsOOzj7dQmaMtzcAm7pn2fNcJO+duzX5nQf5ww3e0mpc4ab55JS60TQHOtd/DwhPa9y303xvKe+d+/hNntCA8rD/0RXT2rdRapC2L0v9TMjCOhQBpxLIpk0ArZCLOGc4ZZrv5qquK5dJ27vy+NH1NhuC2gq2vRy/KjtWHxj+O+A5o/Q+fQGlE27EEBmvYaNDDfnfoVBy+RXzdJ30O35PGHuaMyb3IiGOvcJx4MNM9yIiIiIqOT5W1JqD6b0Fb+CUDIvwcgyKcuoz85bcfwyb/G4Q8CtgP1lY2347paJU1CG2wAoKc2XNQAmB9aahlYBSGW6WfthAeaSU7GfpA73gJuqmDJ0hFg8FYQRGWsiU9AaHLJeU+vrTDx1uq4bwUJFAaorQpg0pj5n9mTASw+3fEtKPWZxOma4OZSUyoEYp4Bb7iml4l9vQxNEifHu/V1GbzT52pgzsaw93DLHUhYKYP6UYcb3tVXhTA+3PKaUWiUS9qEJriWlOV7b+b5m3Y5z/EingFtq233JKsSOugwIlSO5awvqt2w0bedaUpr+Vg6wBVTV8ly4l5RqqoLG+gqWnEoOjHdoIiIiIqICGBlHfpSUivLU/gi4FaGHm5dsGjkQ0ldDE0wfsQs415hD6WGxS0qtkzDl24DCnjunqZED3YihFabvzVNKNfz35Z/FhksWOt63oiwTcBOZN8mke0mpJmW4yWv14MZUA/mDh1VBVRSMTn9vNNMvqIeb46E48jSlFLmD4LlKSq3HpCDdw82yrVzGaezPkuEkBL32cMtzSmlTQxUqwgF0RxPY/nGr7T5yAFBVLKXalrLIo9ODcgCgujJk7OeDXe24+8m38en+Lk/HZD0fa0mpyHgL24Zs5Ai45lkG7ra7cSMi9n1Lx6LUjED54lRmW8V7L+K0itegwlwGa7124jrLz6+1RDtbhhunl9qxpJSIiIiISl5mqqIf++q/ktLi9HDLr6S0rz5U5dOIPptY3DkwUwwii0ZzCPCaAm4HeEmpV186dgKeevU9XHjSFNPt1VI/t+5owtTfzUpee4FAJivNvaRUMQIGZSENV591OLZ/3IrZE1K91T7/2XE4Yc7B+PM/P8VLb36cyXwSU0ptPdysAbfUv+Yebt6fT2vwwomnDLcsxwjY35/cXudJ3aGkVNpGDuqK7MrcGW7WHm65S0onjKrFX7fswdvvpWpA3TLcrFNKrdew6aAqXHHmDJSFAghoqrFtIqnj1b9/ktlPHi+dRNI+NCGazpgMhawZbtn35VeG26iDquz7tpQrBw6ehfC8L6Dnjz/HorJ3MVRtw/0di6QMN+eJvKagsKaYttNU9x5uzGyzY8CNiIiIiEqen0GyzL4K3lXeTD3cfPpw4yUYKZf19VlFqZwdVkiGW9zeR8waYPBLwpbhJgUGsgQJ8hE6gAJuxxze5NhAXQ7AdPbEs+6jIuxUUqoj7mFoQllIw/AhlRg+pNL4uaIoqCgLGM+BeM6McuB0U3ixRFx7uEkZbvk8nQEvPdyMx3LfT64ArvX9IZPJat4umdSNYKPoL5Yzwy1XDzdLvzQvAebDRqcCbh3d8fR9Mj+Tr5mth5tDhGvq2CFGcNbtofN5T4knkrYAr8hCDAfym1LqNNAjG3l3Q2vK0NEdw4zxQx2DntbrBACh6cejJ1yL6O/vwuTQR/iKuhl/VFYCyDKlVBqKEbRkuFlLShXAoUsmCQP7HZqIiIiIyAdGnzI/erg5NMTvK8XMcMv2QbHUMtys2Sp+yVZSquQIkHglZxz115RSP8ye0ICykIYjDzso63Zy/8CgFHDzMjRBDhRbGb29rA3+FcVSwmgJSjhkuOXTFTDopaTUQ9ap/LNcwxfk7a3nk+rhljoPEaQqtIebnmdJKQDbEA55OqxmCiRZerjlCGC5PXa2Yzpj8SEAMhN0o9J7yKkLx2Lk0Eos/8zBAICgZUppzh5+eb5m5ed2aE0ZNly6EBecNNlxWzlQKv9NofyQI3Fr6wnYnyzH8MB+LNv/MyRbd7tPKVWzZLhp5sEb1vMnM2a4EREREVHJM/qu+ZLhJvbZ9wE3OUvKr/IdbxluB3APN4eAm7Ufk1+MLCmH4IbmW8DtwMlwy2bt56cinkjm7ENX7pThJvUds059DGiKsV045L5v8dxYe7ipqgJNUyASI+0lpanv9d5muAWcA0nmx8i9X/lnWpagUsIIJIp9m7eVe7gFNRU9SJinlGoOAbdA9hPODE1IH5+HCzTqoCpUlgWMDDf5MOXAkKpYzj1HAKs3/cZOmDsai2ePxINPv4tX/vYJeqKZLNll80bj5IVjpePJ77Wcb5Bcfr5CQS3r60W+zrouvyZUfKwPxfdbPoc11c9hZKAZ3X/4CTR1men+4lzkNRrQVFMgT1NVU/ZhKKAhGuu7sv0DzYH7Dk1ERERE5JExpdSHWJHIVGIPt+IyZbgVsB85Q0ooWoabCMA4DU1wKS/N14FUUpqNoiiehj6Um3q4Zco5RUmpbciBphoBg7IsATejpNRa/qgoCGQZSGDq4Sadi1emklKX+3nKcPMQwDVniYrMXPt2YgKnCGxplhJCITM0IfvzJoI9IhDq5fKoqoJzTpxkfF8pDcuQM65y9XCzcnvsXMcUDmrGde2JZQJuTiWs+XCaoJuNfHq5gnVloQDmTDoIsw4dirrqsOVnGlr0CtzbfhQSSgCJnX/HjI6XoSFzbuJ8rUMTNEvfQfn6h5nhlhWvDhERERGVPPHBO1uJmVdGD7f+yHArQg83L1NK5etW6AdOr5zK4Xrj2COaMOvQobhgeaYMy23CZaGS6cy5og5NCJZGwM2rcoeAqTw0wXoNUkMTUtdXnq5rZSspTYrbs2cjyj3cjD5yeTydQTl4kbMcMtvPcq8n1fQaEv/atxXnMWFULSrCAUw+OFPeKV9fMTQhmCvDzVpS6nG9z57QgP+8+DNYteQQLD18lHG7KaNOsfZw87+k1Hjc9L5FSamquE/o9CrvktI8yzcvOmUqLj1tuu15Ftmee5IRbB16NABgSvur+I+ajWhU9wPIXEvNskbl9/yApaQ0lOU1RiwpJSIiIqJB4LSjx2PCtn2YPKYu98Y59OfQhOJmuLlvY8pw64fzLuRcy0IBXHradADA3RvfBgDX/l+FytbDza28NF8i6KEUuJ8DhVwWKsqDk7qOZMIl4KbKPdxyZ7iJ5yxhKil1H2xQWxUCAHy8pwMt7T0AgBHSUIZcAh56uLmVfzptk20/piy4LL0aRcBt3PAILjx5imkbpwy33FNKU//qlqm9XgypKcNxc0abbpMz3FR4618nuF1DL4EzI8MtXVLqVkprLWvOJt8guXz4oQIC7HLw+ZPGBZg++WDsf+lhDEML/r1mE37fPQlKdA5QXmXOcFPNQxM0VbUcEwNu2ZT+n0SIiIiIaNAbMyyCkz4zJu/sAif9OTRBc/gAXSgvPenC/V1S6nP5brxIAbdE0hxgkK+VXz3cQtKkSL+vy0Akr3NR+phM6kYfPmuZndzDLevQBGsPN9PQBPfX2fAhlVgwbRh0AB3dcTTWV2DRjBGez8fUw81tHeQ7NME1i8u2S8eAubiuiqrY9mXqGah5DbhZgpgFrlM54KMoiukccu3bLSHXyzGJzK5ouqQ04LKzfMpE8+3hZspwy1HKm40cfA4FAwhO/Cx+P/J8/DM2DGEljuPL30L3U9+FHo+ant+AZn49pKb45pd1N5jx6hARERER5cEIUPV7Dze/Skpzf7g3l5T2VcAt87XfD9l3U0ql50v65FXINQxKAbfBZsTQVCaZPKXUGuzQNBVl4VRwobI895RSpx5umkugVDhzyaGoqUxlun1p6aF5PRfBLNlzgqehCV56uMH+fqE4bCsy3Jze0xx7uOU4320fteK/Hv4LutOZYYUG6c1TSq0Zbtnv65rh5uGQxHMveri5TUTNJ4iWa6qqlV/BLTnDLZTeTzJUhR+1HYsftx2FtmQZkvs+RM/LPzUdozz1F7C/HobVVfT6mAYDlpQSEREREeVh4GS4+bNPo5m615LSfgi4+Z3JlSjSlFLrVEa3XlMFZbilPzgPpt5JN5w/F7v3d+HjvR340z8+RTKZCZo6ZbgtnjUSyaSOo2eOdN2ntaQ06bGkFACqyoP4v6sPx/62KA5pqsnrXMzBC5cppcgdBDdleXmYxGn8ocCh4VzMCLjZ9+E0FddLgOnt95qlxy40w806NCHzs5wZbjkGU2QjepmJDDe3iaj5BFxXHj0e77zfjCWzmzxtLz+H+WbHyeQ/moj3Dk1VoUPBm7GDEesM46KqZxB790XU68MAlEFR0q8H6RjEc/HNc+egOxrH37fv6/UxDQYMuBERERER5SFbL6S+emzAvyCUl4w9OeBWyITNfMjZOQWNKXVQrAy3xrpyAICaDqSYGtv71MNt1EFVmHXoUBzaVNvrfRxoRg6txMihldi1rxNAqvxTBE3tQxNUDK0px5lLDs26T9vQhDwy3ABgaE05htaU530uch8w195rivlf522870feXnGI2YghIk7Zb3KQR5Qz5z1ps+BBA+bXkZdyWsHtx556uCkiwy1pOw6348vloLoK3Hr5Zz3//jD1Syskw00uKQ2IgFtm51v1EQgdfiqif34cjVseR5N2HHYpDQCc+w6OOqgKAPDO+5nAKtkNvjxkIiIiIqICGBlh/ZDhJn8g7q+hCUVqf2aTTxZLvuI+Z7h94+wjMHdyI9acPAVAJihpOgdThlvvP4YFNBWXnjYdJ8wdnXvjEiP3XRNBU2s/Ma/BTKOk1CnDrQi9EoWgp6EJuYP6TtlrVuY+iOZ9y2Jx915rcoAwmA7UuAWY3I624JJS1VxSaupNl2tKaY5rnPVxRYZbXJSUumW45Zdtms+aMpWUFpDhJpeUhtOBO9M0UlVBaNZJ0EZOgZqM4dLI05gU+sj4mbGd5bmfMrY+dZy9PrLSxgw3IiIiIqI8iM9+/ZLhJn3tXw+33PuTsyPEh89icwoW+MXvDLexwyNGsA1w7uFmynAbBMMOisHISpMy3LR0o/+krkNTFc+vCyN4Z/RwE49hDir4HVgPeOjhJmTNcJO+ztULLvW1exBP9HBzejxNVY3rm+nh5hxg0jTV2Jes0EsYlKeDKt6y+zKP7XJtPMSu7D3cXAJuPgzjcSOfXr6ZhTLz0AR7hpuqKFBUFeVL/w/2PnkLyvZtwerwc4h/NBualimbtpZBjx9Rg/+7+vBeZXsOBsxwIyIiIiLKg5F90g//J20O4PizTy/ZNPKHrFi8OP3PrBTT1/4GPRJFTtMzppQq9tsAbx/2yU5cwqSeyXBTVcUIOOUzhVhzy3BTFNM0Sr+HhJjK89wyxTwEwVPTOrO/dlWH9wuntZdtaAKQyXLL9HBz3s7tfPwcmqDm2cPNtaQ0jymlPdEcQxOKOMBEXgOFTNk2Z7iJTEV78FcJV6Jl7sV4K9qEoJJA19O3orLrY+kY7Ndg/IgaY4gImfGtnoiIiIgoD5lgSj+UlJoe0u8MN2/b6/1QUup7hluRhiYIqsMayScrh5yJ8sFkEoinA2SaqhjB73x6aYnnSHfq4VbMDLdA7mCe17L1z0wbhilj61FbHXb8uan00kOGm9vjzRg/FMOHVKChtix1Di6Bn0AB5ZvZBCwlpfn84cFLMNL1vkaGWzqb0u2885w8mg+/ej+aM9xU2/7kxxnZWIPfhE7AnvBoINaF0X+7F0PV1vR9GELKB0tKiYiIiIjyID7090sPN9OHRH8iX5kebtnP58R5B+PdD5oxe8JQXx43pzwao+crXqShCYJTSalfU0oHM7kMtKs7DiAVSBDX1i0g4sQ1w01VTEEF/3u4yWvCZUqpxyD4uSdOyvpzp5Jmp9e5eD24Pd7Fp06FruvGfd1KG90CcX4OTVCgmAPZvS0p9XBIYo2IgKRbQDHfHm75kI+zoAw3p6EJLuXNZaEAvnXBAiA2G51PfheBve/jS5Uv49a2E/jHgjwx4EZERERElIe6qlQ2SW2Vc1ZJMcmZN36FjIxm6jk+y608erxPj+iN6XOdz5/xnPpM+emQkREEAyrGj4wYt8kfaPmhtXfkoQltnVEAQGV50Lg9rww3Ww83l6EJ/dDDTTH+LeyxzRmW4jb7drEcJaWp+5uDd5qq2EqzXUtKCwxayoEh665yvZbcAnJenlfrvt0DjUXMcJOOoZDHkUtKnTLcrOeqKAoQqkD58Zej7eGrMC64G7NC7yGgze31MQxGDLgREREREeXh+DmjMH5kDQ5tqsm9sc8iFSHMnzIMqgJUlgV92adTNtZA43d8qthlsdPHD8Vt6xa5Blf6oxy5FIigcFLPBNyqyoKZHm55lLvZp5Smb1fs0xv9JAdt3DKmMuWfhT2W56EJ8dwBN6tAQEUiah6g4natCr2GcqDJeoy5jtntob31cLME3FzWVzF7uJmGJhSQ4eZlaILj41fVo23cMajZ8hucVvG/CDQfCTRM7/VxDDYMuBERERER5SEY0DDp4Lp+e/wLTprs6/5EFs1A68xjnlJ64AWorB+O3QYokHe5MtzcMqyciOcgmQR0XTf3cCtihlvQS4abUVJa2GM7TfpVLOswkdSNoGM+5xrUVPTAHHBzCwgV+vINZMlwy3XMhZSUWvftOjShiFNKfRuaIAXcRIDQa6/CznGL0faPP6Ip0Az9hQ2IBS5CcNycXh/LYDLQfq8SEREREVEfEp+zBlpfMVNF6cA6tF5RixjEGSxUVQq4dcQAAFXlUoZbHgEJcZ94IonL//slY/pusXu4eSopNfqtFfZYTlmVphJFS2ZWPo8ngjYBD9mAhQYOzQG3/DLcXKeUeikp1awBN+f1VVnuT7axE9UUcOv9dSwLpnKtQgE1U4Kt5l6LABAIleHW1hPwl56DoehJdD93J6J/exZ6PNrr4xksGHAjIiIiIhrEvA5N6GtO5XCFEn2Mqor4AdmNedogP4b1RqbvGqQMt0BBPdwAoL0rlrldVYpbUirt27WkVDqWQjhN+pVfS9bMrLxKSjV7kDOfoRX5MA1NsGW4Zb+v2zX0VlJq3rlbBuXyz4zB6MYqrDrm0Jz7zJcpI7GA61seTr33yaWlWpZSXZmmKogiiPs7Pgt9zFxAT6DnlZ+i4xdXIrb9z70+psGAJaVERERERIOY14mIfc1UDufTPr/+b7Px2IvbsGLROJ/26B2nlBbOyHCTe7iVB3s1pTRbICZQxOdKURQENAXxhF78klLIgSp7Dzdr77F8zlUE2oIBFd3pXm7FGh5QWIZb7wNu1m3cSkeryoO4/pzilFjKx19Z1vvwzYihlTj2iFFoaqg0bjNlcmZ56YjAnA4V6sJzEBpxCKJv/AZ6xz50P/MDJGcuR3jOyl4fWyljwI2IiIiIaBDL1ky9P5lLSv05ttGN1fjK6TN82Ve+OKW0cOYebqmstMqyoDGJ0i1jzInbc2AtKS3GcxXQVMQTiSyZjj6VlCry14rttkIy3ESwLhSQr1VxMtzk56Ave7hZM9qKlcGXy6pjDkV7VwzDh1Tm3tiFoij4wlJzBp7XTE454BkIBBCaeiyChx2F6OtPIPrXpxD960ZAURA64vNQFGbvyhhwIyIiIiIaxMTnrIFXUupP0GGgkD/4M8Otd0Q8pyeaQDSWyqqSM9x608PNdrtiDkQU43WROs6Ee9BP9FUsMLdTcQhUKVky3PLq4aaJHm5SMGYAZri5xQA99XCzbCPKMvvacUeOKsp+TZmcOUpKM1+nLqgSCCE853QoZVXo+eMvEP3Lk0ju24GyY9dCURlmEhh+JCIiIiIaxMSH8oEW2BLBgGJOAOxLzHArnAgKtKbLSTVVQVlIMwJUeQXcXDOfFEuAoRgBN1ECm33IgJ8ZbkYma5ahCfn1cMuUlArFynCTA3nWRziorjzrfQspKbUH3EorkKR5HZpg6tNn3i40fRnKFp0LaAHE3/8L4tv+5P+BHsBKa8UQEREREVFeRBbNQCspjVSGcOrCsaiuDPX3ofjCaWIk5UcEh41y0vIgFEUxrqdbAMuJWyBNswxNKEY2oghguK4Dv3q4yVmVDr0aC+rhFnAKuBVnXWsOGW5X/9vh2NfWjdGN1Vnv63aNe5fhVlrhE69DE6orgqitCqGqPOS4XfCwRUi270X09ScQe+d5BA+ZV5TjPRCV1oohIiIiIqK8DNShCQBw8sKx/X0IvjFPKR2AF/sAYP2wL6bNiuBJPtmQbuu9L3q4iSCVW4DQKCktMGFMvl6OQxMK6eGmiXMofklp0BRwS/17SFMNgJqc93V9nr30cLM8ARWlFnDzOBwkoKm46cL5WbcJHnYUon/5HyQ+fhfJ/R9DrR3u67EeqEojP5uIiIiIiHploA5NKDWmxu/8FNYr1s/7YmqjCATkk+GWrdTQFIgowssiFEz1AnMPEIqS0kIz3Oxfy/9ar1c+Dycy3AKq0qseevkIFNBTz30SbO79WO9behlu3kpKASAc0mwZkTK1qh7aqNRAmujbv/PnAEsA3+qJiIiIiAYx4wM4s66KSr68xep1VeqsQYGqCnOGmx8BH2sgqhglpcvnj8GCqcMwYVSt48+dyj97o7IsaHxtDaxrqgLNOoAgj3MNapmecEbAs09KSvO7r9vm7OFmHprgx3MXmroUABB75wUku1oL3l8p4Ds9EREREdEgphofxPv5QEoce7gVzlZSmg4oidsDeQYynQJ0qaEJxR0EcPjEBpy3fLKR6eZwEAAKXyejG6uMr63TiOVAWWabPAJu6WwnVZV76GWuVVNDZa+O2UkhGW6umYwentZSD7hpPr8naSOnQG0YCySiiL3124L3VwpKa8UQEREREVFeRHljoeVrlB2nlBbOLcNNXM98SkoB4L/+z2fQHY3jmz/5E7p64sbtXntbFYtffRUPHpYZKJAJtKW+11TFtg7zKikVPdwURcowzOzgyEmNWHpECKMOqnK8fz7koKdfb1Ne3u+s66nkerjlUVLqhaIoCM1aju7f/gDRN38Dtb5p0A9QYIYbEREREdEgxgy3vqH2cxCnFLgOTUjfnG9JaaQyhIPqKlARNmeayYGW/giOloVSx1MeKizAc7A0wTOeSAIwl5YWkuEWkIYmGAFPKTAWDqhYNGMExg6P9O7gJX5lYsnrw8t+7D3cXDISD1DmKaX+7DNw8CwExs0Bkgl0/+4OdL/0APRYtz87PwCVVoiWiIiIiIjyksmmYRComDiltHDWJSp6lKnpQE9vp2SWh4MAeozvTQMu+uGpOvaIUaguD2Hh9MImPdZVh42vP9rTAcDSw82a4ZZPDzdTSWnqNjmA41ou2wuFPh/Txg3Bp/u70FBbhr9t2+d5P9ZAX9jHcxoIAkX4I4CiqChbchF6KusQe+tpxN7+HaAGUPaZL/qy/wMNA25ERERERIOYYkxE7OcDKXH9XaZYCqzXrbrCnOGm9XJoQkWZ+WNxwNTDre+fq9qqME6YO7rg/chB9I7uVMmsuIbOPdy871tMWNVchiaEgv4V08nHqbiOQXD3ldOnQ9eB25/4W2Y/noYmZM6hPKyV3B8l5PPz8z1JUVWUzf8CAqNnIPrmZgSapvq27wPNgCsp3bp1K8455xzMnDkTCxYswPr16xGNRnPe76GHHsKaNWswb948TJw4EZs3b+6DoyUiIiIiOrCJz5Bs5F9czHArnHwN6yNhTBpTn7rdoYdYPqy9uYo9pbQvRSqCpu/F2ThluOU1NCEdUAtI+5FLNkOB4mS49YaSLp/Ndz/y9mUFlvcORKbS6SK8/wdGTkbFsisQGD3d930fKAZUwK2lpQVnn302YrEYfvCDH2DdunV45JFHcPPNN+e87xNPPIHm5mYcddRRfXCkRERERESlQXzILrXsjYGGPdwKV10RNIIg3zhvXqaHmwj49HKiqHX6pBxoOdCDo2tOngIAWP6ZMQCsGW7m65VPSensCQ2YOq4eC6cPN00+FfzMcJOfg6SuF7Cf/I5JNQXcSqucFLCU6h7g63ygGlBh2ocffhgdHR344Q9/iNraWgBAIpHAN7/5TaxZswaNjY1Z76uqKnbs2IFf//rXfXPAREREREQHuPFNNQgHNUwYVdPfh1LSOKW0cNUVIVz1pdmorQ7jkKZaNDen+pKNH1GDv/5rj2kqZz5sGW5qfs31B7JJY+px27pFRsDIyGhVVVtWUz7LsrGuAlecMRNAZj3L9/czw626IoS66jAUxV7+m498p9gWq0R2oFAUBaqiIKnrfE8qkgEVcHvxxRcxf/58I9gGAMuWLcN1112Hl19+GStWrHC9rzU6T0REREREuU1JfyBn1lVxmTLcDvAgTn8aP7IGgYD5s98Jc0djyeyRvW7UX15WuiWlgDmDTx6aUMiUUtP9jIBb5v4jGyp7tS+3/a+/eD50vcAppQWUlJbawAQhoCmIxnW+JxXJgAq4bdu2DaeddprptkgkgoaGBmzbtq2fjoqIiIiIqLSVQlBhoJMvMbNJ/FfIVMyhNWWm70uppNTKKP9UFFhzVnpbVi7ePxRFwS2XLEBPPInqilBBx2mVbzmoH/so1tTVgUTTFCDO3wHFMqACbq2trYhEIrbba2pq0NLS0g9HBNtfTw5kYmpPb6f3UOnjGqFcuEYoF64RyoVrhHIp1TUif2APhrSS+pzR1/xeI4tmjsA77zfjsIPrEAiopucqVGLP1fChFQCAxvpyhC2DAEJBtVfnagxNCKgYUlte+EH6wGmNBKSyUC/nqenmHm6ltA6EVBAygYCmlOT5ZdMXv2sGVMBtoFFVBXV1/qXCDhSRyMB4E6SBi2uEcuEaoVy4RigXrhHKpeTWiNTTqr62oiQ/Z/Q1P9fINefNM76ua+kxvq6vq0SVz9la/amurhJ3X70UdZEyPP3H92w/q6kK573PUDpwV1kZGnDrWl4j8vOY73FWVYYH3Ln5IZgOslVUlOb5eVHM3zUDKuAWiUTQ1tZmu72lpQU1NX3fxDWZ1NHa2tnnj1ssmqYiEilHa2sXEolkfx8ODUBcI5QL1wjlwjVCuXCNUC6lukbaOqOZr9u60BxgCVdvFXuNdHZmAm6trV2I9cR8f4z+FFaBzvZuBC1LsK21C8lYPO/96cnUc9DTHTMGWfQ3pzUSiyWMn+d7nIquD5hz85OoIo5GB85z11d6+z4SiZR7zoobUAG3cePG2Xq1tbW1Yffu3Rg3bly/HFM8Xjq/5IVEIlmS50X+4RqhXLhGKBeuEcqFa4RyKbU1oid16evS/JzR14q2RnTpy6Ress9VpWU6ayLRu3MVvd90feCta3mNyPHFfI8zqKkD7tz8IMqBFQy8566vFPN3zYAq0l20aBFeeeUVtLa2Grdt3rwZqqpiwYIF/XhkREREREREvSc3pGeD8oFNHpRQys9VdaW5VLa3cwk0RQxNKPSIiquQARih4IAKnfgmkM7U4pTS4hhQGW6rVq3Cgw8+iLVr12LNmjXYtWsX1q9fj1WrVqGxsdHY7uyzz8ZHH32EZ555xrjtrbfews6dO7Fv3z4AwBtvvAEAqK+vx5w5c/r2RIiIiIiIiCSlPPmy1MjTKUs54Bax9KbrbdBFXKOBHrQJFNAcP1yqU0rFc1fC67w/DaiAW01NDe6//37ccMMNWLt2LSorK7Fy5UqsW7fOtF0ymUQikTDd9tBDD+Hxxx83vr/33nsBAHPmzMGDDz5Y/IMnIiIiIiJyIX+glQM6NPDIZXYDPYhUiKryoOl7pcQDbgumDcPGV97DjEOG5H3fsvCACp34RlOZ4VZMA27VjB8/Hj/5yU+ybuMUQLv55ptx8803F+moiIiIiIiIei+gqTjm8CZEYwlUlgVz34H6TWVZEAFNRVX5gPu47CtVVaAqCpK6nv6+d/s5ZGQN/vnhfoxurPLx6PxXXRHChssW5pVheszsJrz9/j7Mn9KYe+MDkAj+M+u2OEr7HYSIiIiIiGiA+NKxE/r7EMiD8nAAV581u2TLCGVV5QG0dqamsPY2y+mUhWNx4rzRCAYG/vXKt6z0S8eV9mvWyOZkhltRMOBGREREREREJBkzLNLfh9AnqipCRsCtkKDLgRBsIzsRcGOGW3GU5qgNIiIiIiIiIsqqqow5OIOZMaWUAbeiYMCNiIiIiIiIaBCqLGc/wcGMU0qLiwE3IiIiIiIiokGIAbfBremgKigARgyp6O9DKUnMHyUiIiIiIiIahKoZcBvUViwah2OPHIVIRai/D6UkMcONiIiIiIiIaBCqYsBtUFMUhcG2ImLAjYiIiIiIiGgQYkkpUfEw4EZEREREREQ0CE0eUwcACGhsmk/kN/ZwIyIiIiIiIhqEhtaU46Y181BZxkw3Ir8x4EZEREREREQ0SDXWcUIlUTGwpJSIiIiIiIiIiMhHDLgRERERERERERH5iAE3IiIiIiIiIiIiHzHgRkRERERERERE5CMG3IiIiIiIiIiIiHzEgBsREREREREREZGPGHAjIiIiIiIiIiLyEQNuREREREREREREPmLAjYiIiIiIiIiIyEcMuBEREREREREREfmIATciIiIiIiIiIiIfMeBGRERERERERETkIwbciIiIiIiIiIiIfMSAGxERERERERERkY8YcCMiIiIiIiIiIvIRA25EREREREREREQ+YsCNiIiIiIiIiIjIRwy4ERERERERERER+YgBNyIiIiIiIiIiIh8x4EZEREREREREROQjBtyIiIiIiIiIiIh8xIAbERERERERERGRjxhwIyIiIiIiIiIi8hEDbkRERERERERERD5SdF3X+/sgBipd15FMltbl0TQViUSyvw+DBjCuEcqFa4Ry4RqhXLhGKBeuEcqFa4Ry4RqhXHqzRlRVgaIonrZlwI2IiIiIiIiIiMhHLCklIiIiIiIiIiLyEQNuREREREREREREPmLAjYiIiIiIiIiIyEcMuBEREREREREREfmIATciIiIiIiIiIiIfMeBGRERERERERETkIwbciIiIiIiIiIiIfMSAGxERERERERERkY8YcCMiIiIiIiIiIvIRA25EREREREREREQ+YsCNiIiIiIiIiIjIRwy4ERERERERERER+YgBNyIiIiIiIiIiIh8x4DYIbN26Feeccw5mzpyJBQsWYP369YhGo/19WNQH3n//fVx77bU45ZRTMHnyZCxfvtxxu1/+8pc4/vjjMW3aNJx88sl4/vnnbdu0tbXh6quvxpw5czBr1ixcdtll+PTTT4t9ClRkv/nNb3DxxRdj0aJFmDlzJk455RT86le/gq7rpu24RgavF154Af/2b/+GefPmYerUqTjmmGNw0003oa2tzbTd7373O5x88smYNm0ajj/+eDz66KO2fUWjUXz3u9/FggULMHPmTJxzzjnYtm1bX50K9YGOjg4sWrQIEydOxFtvvWX6Gd9HBq/HHnsMEydOtP33X//1X6btuEbo8ccfx6mnnopp06Zh7ty5OP/889Hd3W38nL9rBq+zzjrL8X1k4sSJeOqpp4zt+D4yuD333HM4/fTTMWvWLCxcuBCXX345PvzwQ9t2fbVOFN36qYpKSktLCz73uc9hzJgxWLNmDXbt2oWbb74ZJ598Mq699tr+PjwqsmeffRY33HADZsyYge3bt0PXdWzcuNG0zVNPPYV///d/x0UXXYR58+Zh06ZNePTRR/HQQw9h5syZxnbnnXcetmzZgiuvvBLhcBgbNmyAqqp49NFHEQgE+vjMyC9nnnkmRo4ciaVLl6Kurg6vvPIK7rnnHqxduxaXXHIJAK6Rwe6JJ57Au+++ixkzZqC2thb/+te/8IMf/ABTpkzBvffeCwD405/+hNWrV2PlypU48cQT8cc//hF33HEHNmzYgBNOOMHY17XXXotNmzbhqquuQmNjI+644w58+OGHeOqpp1BdXd1fp0g++s///E/8+te/xp49e/CrX/0K06ZNA8D3kcHusccew9e//nXcc889ptd6Y2Mjhg8fDoBrhIDbb78dd999Ny666CLMnDkTzc3NePXVV/G1r30NlZWV/F0zyG3ZsgXt7e2m2+6//3789re/xR/+8AfU19fzfWSQe+211/DlL38Zp556Kk466STs378ft956K5LJJJ588kmUlZUB6OPfNzqVtDvuuEOfOXOm3tzcbNz28MMP65MmTdI/+eST/jsw6hOJRML4+sorr9Q/97nP2bY57rjj9CuuuMJ025lnnqmff/75xvevv/66PmHCBP0Pf/iDcdvWrVv1iRMn6k899VQRjpz6yt69e223XXPNNfrs2bON9cM1Qla/+MUv9AkTJhi/R84991z9zDPPNG1zxRVX6MuWLTO+//jjj/VJkybpDz/8sHFbc3OzPnPmTP2uu+7qmwOnotqyZYs+c+ZM/ec//7k+YcIE/c033zR+xveRwe3RRx/VJ0yY4Pg7R+AaGdy2bt2qT548Wf/973/vug1/15DVkiVL9AsuuMD4nu8jg9s3vvENfcmSJXoymTRue/XVV/UJEybo//u//2vc1pfrhCWlJe7FF1/E/PnzUVtba9y2bNkyJJNJvPzyy/13YNQnVDX7S/zDDz/Ee++9h2XLlpluP/HEE/Hqq68apccvvvgiIpEIFixYYGwzbtw4TJo0CS+++KL/B059pr6+3nbbpEmT0N7ejs7OTq4RciR+p8RiMUSjUbz22mum7AIgtUa2bt2KHTt2AABeeuklJJNJ03a1tbVYsGAB10iJuPHGG7Fq1SqMHTvWdDvfRygXrhF67LHH0NTUhKOOOsrx5/xdQ1avv/46duzYgZNOOgkA30cIiMfjqKyshKIoxm0iq1VPF3b29TphwK3Ebdu2DePGjTPdFolE0NDQwF4GZKwB64ej8ePHIxaLGfXu27Ztw9ixY01vXkDqTYfrqPT8+c9/RmNjI6qqqrhGyJBIJNDT04O///3vuO2227BkyRI0NTXhgw8+QCwWs/2uGT9+PIDM+8y2bdswZMgQ1NTU2LbjGjnwbd68Gf/85z+xdu1a28/4PkLC8uXLMWnSJBxzzDG48847kUgkAHCNEPDGG29gwoQJ+NGPfoT58+dj6tSpWLVqFd544w0A4O8astm4cSMqKipwzDHHAOD7CAErVqzA1q1b8dBDD6GtrQ0ffvghvv/972Py5MmYPXs2gL5fJwy4lbjW1lZEIhHb7TU1NWhpaemHI6KBRKwB6xoR34uft7a2Ova84DoqPX/605+wadMmnHvuuQC4Rihj8eLFmD59OlasWIGGhgZ873vfA1D4GolEIlwjB7iuri7cfPPNWLduHaqqqmw/5/sINTQ04NJLL8V3v/td3H333TjqqKOwYcMGfPvb3wbANULA7t278dJLL+GJJ57Addddh9tuuw2KouDcc8/F3r17+buGTOLxOH7zm99gyZIlqKioAMD3EQKOOOII/PCHP8T3vvc9HHHEEVi6dCn27t2Lu+++G5qmAej7dcKOgEREBAD45JNPsG7dOsydOxerV6/u78OhAeauu+5CV1cXtmzZgttvvx0XXXQR7rvvvv4+LBoAbr/9dgwZMgSnnXZafx8KDVCf/exn8dnPftb4fuHChQiHw7j//vtx0UUX9eOR0UCh6zo6Oztx66234rDDDgMAzJgxA0uWLMFPf/pTLFy4sJ+PkAaSl19+Gfv27cPy5cv7+1BoAHn99dfxH//xHzjjjDNw9NFHY//+/fjRj36ECy+8ED/72c+MoQl9iRluJS4SiaCtrc12e0tLiy3VmgYfsQasa6S1tdX080gkYpsKBHAdlZLW1lZccMEFqK2txQ9+8AOj/x/XCAmHHXYYZs2ahdNPPx0/+tGP8Nprr+GZZ54peI20trZyjRzAdu7ciXvvvReXXXYZ2tra0Nrais7OTgBAZ2cnOjo6+D5CjpYtW4ZEIoF33nmHa4QQiURQW1trBNuAVO+1yZMnY8uWLfxdQyYbN25EbW2tKRDL9xG68cYbMW/ePFx11VWYN28eTjjhBNx11114++238cQTTwDo+3XCgFuJc6oxbmtrw+7du209EGjwEWvAuka2bduGYDCIUaNGGdtt377daDYpbN++neuoBHR3d2PNmjVoa2vDPffcY0qf5hohJxMnTkQwGMQHH3yA0aNHIxgMOq4RILOGxo0bhz179tjS8J16jdKBY8eOHYjFYrjwwgtx5JFH4sgjjzQyllavXo1zzjmH7yOUE9cIHXLIIa4/6+np4e8aMnR3d+PZZ5/FCSecgGAwaNzO9xHaunWrKWgPAMOGDUNdXR0++OADAH2/ThhwK3GLFi3CK6+8YkRsgVRjY1VVTRM3aHAaNWoUxowZg82bN5tu37RpE+bPn49QKAQgtY5aWlrw6quvGtts374db7/9NhYtWtSnx0z+isfj+MpXvoJt27bhnnvuQWNjo+nnXCPk5I033kAsFkNTUxNCoRDmzp2Lp59+2rTNpk2bMH78eDQ1NQFIlZCpqorf/va3xjYtLS146aWXuEYOYJMmTcIDDzxg+u/rX/86AOCb3/wmrrvuOr6PkKNNmzZB0zRMnjyZa4SwePFi7N+/H++8845xW3NzM/7+979jypQp/F1Dht/97nfo7Ow0ppMKfB+hESNG4O233zbdtnPnTjQ3N2PkyJEA+n6dsIdbiVu1ahUefPBBrF27FmvWrMGuXbuwfv16rFq1yvbBmkpPV1cXXnjhBQCpN5v29nbjzWXOnDmor6/HpZdeiq9+9asYPXo05s6di02bNuHNN9/ET3/6U2M/s2bNwsKFC3H11VfjyiuvRDgcxi233IKJEyfiuOOO65dzI39885vfxPPPP4+rrroK7e3t+Otf/2r8bPLkyQiFQlwjg9wll1yCqVOnYuLEiSgrK8M//vEP/PjHP8bEiROxdOlSAMDFF1+M1atX4/rrr8eyZcvw2muvYePGjbjllluM/QwbNgwrV67E+vXroaoqGhsbceedd6K6uhqrVq3qr9OjAkUiEcydO9fxZ1OmTMGUKVMAgO8jg9x5552HuXPnYuLEiQCA5557Do888ghWr16NhoYGAFwjg93SpUsxbdo0XHbZZVi3bh3C4TDuuusuhEIhfPGLXwTA3zWU8uSTT2LEiBE4/PDDbT/j+8jgtmrVKnznO9/BjTfeiCVLlmD//v1Gn9lly5YZ2/XlOlF0a44clZytW7fihhtuwF/+8hdUVlbilFNOwbp164zoLZWuHTt2GKOyrR544AHjQ9Ivf/lL3H333fjoo48wduxYXHHFFVi8eLFp+7a2Ntx000145plnEI/HsXDhQlxzzTUM3B7glixZgp07dzr+7LnnnjP+Ysw1Mnjddddd2LRpEz744APouo6RI0fi2GOPxXnnnWeaSPncc89hw4YN2L59O0aMGIELL7wQK1euNO0rGo3illtuwRNPPIGOjg7Mnj0b11xzDcaPH9/Xp0VF9Nprr2H16tX41a9+hWnTphm3831k8Lrxxhvxhz/8AZ988gmSySTGjBmD008/HWeddRYURTG24xoZ3Pbt24ebbroJzz//PGKxGI444gh8/etfN5Wb8nfN4NbS0oIFCxbg7LPPxte+9jXHbfg+Mnjpuo6HH34YP//5z/Hhhx+isrISM2fOxLp162yv/75aJwy4ERERERERERER+Yg93IiIiIiIiIiIiHzEgBsREREREREREZGPGHAjIiIiIiIiIiLyEQNuREREREREREREPmLAjYiIiIiIiIiIyEcMuBEREREREREREfmIATciIiIiIiIiIiIfMeBGREREREXx2GOPYeLEiXjrrbf6+1CIiIiI+hQDbkREREQlQgS45P/mz5+Ps846Cy+88EKv9nnHHXfg2Wef9flIiYiIiEpboL8PgIiIiIj8ddlll6GpqQm6rmPv3r14/PHHceGFF+KOO+7A4sWL89rXnXfeieOPPx5Lly4t0tESERERlR4G3IiIiIhKzKJFizBt2jTj+5UrV2LBggXYuHFj3gE3IiIiIsofS0qJiIiISlwkEkE4HEYgkPlb649//GOsWrUKc+fOxfTp07FixQps3rzZdL+JEyeis7MTjz/+uFGietVVVxk/37VrF66++mosXLgQU6dOxZIlS3DdddchGo2a9hONRnHTTTdh3rx5mDlzJtauXYt9+/YV96SJiIiI+hEz3IiIiIhKTHt7uxHQ2rt3Lx588EF0dnbi5JNPNrZ54IEHsGTJEpx00kmIxWJ46qmncPnll+POO+/E0UcfDQBYv349rrnmGkyfPh1nnHEGAGD06NEAUsG2lStXoq2tDWeccQbGjRuHXbt24emnn0Z3dzdCoZDxWDfeeCMikQguueQS7Ny5E/fffz++9a1vYcOGDX1zQYiIiIj6GANuRERERCXmy1/+sun7UCiE73znO1iwYIFx29NPP42ysjLj+y996UtYsWIF7rvvPiPgdsopp+D666/HqFGjcMopp5j2+f3vfx979uzBI488Yipfvfzyy6Hrumnb2tpa3HvvvVAUBQCQTCbx4IMPoq2tDdXV1X6cMhEREdGAwoAbERERUYm59tprMXbsWADAnj178D//8z+45pprUFlZieOOOw4ATMG2lpYWJBIJHH744Xjqqady7j+ZTOLZZ5/F4sWLTcE2QQTWhDPOOMN02xFHHIGf/OQn2LlzJw477LBenSMRERHRQMaAGxEREVGJmT59uikQtnz5cpx66qn41re+haOPPhqhUAjPP/88br/9drzzzjumnmvWYJmTffv2ob29HYceeqin4xkxYoTp+0gkAgBobW31dH8iIiKiAw0DbkREREQlTlVVzJ07Fw888ADef/99tLS04OKLL8aRRx6J6667Dg0NDQgGg3j00UexcePGojy+E2vpKREREVGpYMCNiIiIaBBIJBIAgM7OTjz99NMIh8P48Y9/bBpu8Oijj3raV319PaqqqvCvf/2rKMdKREREdKBz/nMjEREREZWMWCyGl19+GcFgEOPHj4emaVAUxQjCAcCOHTvw3HPP2e5bUVFhK/1UVRVLly7F888/j7feest2H2auERER0WDHDDciIiKiEvPiiy9i27ZtAFL91p588km89957uPDCC1FVVYWjjjoK9913H84//3wsX74ce/fuxc9+9jOMHj0a7777rmlfU6ZMwauvvor77rsPBx10EJqamjBjxgxcccUVePnll3HWWWfhjDPOwPjx47F7925s3rwZP/vZz4w+bURERESDEQNuRERERCXmv//7v42vw+Ewxo0bh+uvvx6rVq0CAMyfPx/f/va3cffdd+M73/kOmpqa8NWvfhU7d+60BdyuuuoqXHvttdiwYQO6u7vx+c9/HjNmzEBjYyMeeeQR3HrrrXjyySfR3t6OxsZGLFq0yDQBlYiIiGgwUnTm/BMREREREREREfmGPdyIiIiIiIiIiIh8xIAbERERERERERGRjxhwIyIiIiIiIiIi8hEDbkRERERERERERD5iwI2IiIiIiIiIiMhHDLgRERERERERERH5iAE3IiIiIiIiIiIiHzHgRkRERERERERE5CMG3IiIiIiIiIiIiHzEgBsREREREREREZGPGHAjIiIiIiIiIiLyEQNuREREREREREREPmLAjYiIiIiIiIiIyEf/HwqOVALfgsSXAAAAAElFTkSuQmCC\n"
+          },
+          "metadata": {}
+        }
+      ],
+      "source": [
+        "%matplotlib inline\n",
+        "plt.figure(figsize=(15,8))\n",
+        "plt.title(\"Training loss\")\n",
+        "plt.xlabel(\"Batch\")\n",
+        "plt.ylabel(\"Loss\")\n",
+        "plt.plot(train_lossv, label='original')\n",
+        "plt.plot(np.convolve(train_lossv, np.ones(101), 'same') / 101,\n",
+        "         label='averaged')\n",
+        "plt.legend(loc='best')\n",
+        "plt.show()"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "Let's visualize the loss trend on the training and evaluation dataset per epoch.\n",
+        "\n",
+        "As said before, the training loss is decaying, but the validation loss is increasing after the second epoch. This is a signal of overfitting: the model is not really learning from the training set, but rather memorizing it, which hurts its capacility to generalize on the validation set."
+      ],
+      "metadata": {
+        "id": "x601NrqszrIw"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "# Calculate epoch-level losses → lists w/ the avg loss for each epoch\n",
+        "# len(dataloader): number of batches to process the entire dataset in one epoch\n",
+        "  #for i in range(0, len(lossv), len(dataloader): we iterate over the entire loss vector, w/ a step equal to the n. of batches in one epoch (aka step = one epoch)\n",
+        "  #lossv[i:i + len(dataloader)]: we slice the loss vector to select the batch losses for one epoch → over this slice, we calculate the avg → avg loss for the epoch\n",
+        "epoch_train_loss = [np.mean(train_lossv[i:i + len(train_dataloader)]) for i in range(0, len(train_lossv), len(train_dataloader))]\n",
+        "epoch_eval_loss = [np.mean(eval_lossv[i:i + len(validation_dataloader)]) for i in range(0, len(eval_lossv), len(validation_dataloader))]\n",
+        "\n",
+        "# Plot\n",
+        "plt.figure(figsize=(10, 6))\n",
+        "plt.plot(range(1, len(epoch_train_loss) + 1), epoch_train_loss, label='Training Loss', color='blue')\n",
+        "plt.plot(range(1, len(epoch_eval_loss) + 1), epoch_eval_loss, label='Validation Loss', color='orange')\n",
+        "plt.xlabel('Epoch')\n",
+        "plt.ylabel('Loss')\n",
+        "plt.title('Training and Validation Loss (Epoch Level)')\n",
+        "plt.legend()\n",
+        "plt.show()"
+      ],
+      "metadata": {
+        "id": "vNnBW7gmzzHY",
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 573
+        },
+        "outputId": "c57055b3-d69a-4479-a6a0-9509f13a452e"
+      },
+      "execution_count": 31,
+      "outputs": [
+        {
+          "output_type": "display_data",
+          "data": {
+            "text/plain": [
+              "<Figure size 1000x600 with 1 Axes>"
+            ],
+            "image/png": "iVBORw0KGgoAAAANSUhEUgAAA2EAAAIsCAYAAAB7vaE5AAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjguMCwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy81sbWrAAAACXBIWXMAAA9hAAAPYQGoP6dpAACp90lEQVR4nOzdd3hTZRsG8PtkjzalLUNkF2hF9qa0FCgFZIh+gLJFZBRlgyIgIkuWAgJlVAVRFBFRQfaGsl0IgqhMZSijLZ1JM875/ggNDWGUrqTp/buuXtCz8qZv0+bp+5znESRJkkBEREREREQFQubuARARERERERUlDMKIiIiIiIgKEIMwIiIiIiKiAsQgjIiIiIiIqAAxCCMiIiIiIipADMKIiIiIiIgKEIMwIiIiIiKiAsQgjIiIiIiIqAAxCCMiIiIiIipADMKIqMgaN24cIiMjc3TuokWLEBISkscj8ixXrlxBSEgIvv322wJ/7JCQECxatMjx+bfffouQkBBcuXLlkedGRkZi3LhxeTqe3HyvFCVbtmxBo0aNkJaW5u6hZFtkZCSio6PdPYx8ce/3bWJiIurUqYP9+/e7cVREBDAIIyIPFBISkq2PY8eOuXuoRd706dMREhKCv//++4HHzJ8/HyEhIfjjjz8KcGSP7/r161i0aBHOnDnj7qE4ZAbCy5cvd/dQHslms2HRokXo3bs39Hq9Y3tkZOQDX8P9+/d344jzRkhICKZOneruYWSLv78/unbtigULFrh7KERFnsLdAyAiutecOXOcPt+wYQMOHTrksr1y5cq5epxp06ZBkqQcnfvqq69i0KBBuXp8b/Dss89i1apV2LhxI4YOHXrfYzZt2oTg4GA89dRTOX6c5557Dh06dIBKpcrxNR7lxo0biImJQZkyZVCtWjWnfbn5Xikq9u7di4sXL6Jbt24u+6pVq4Z+/fq5bC9ZsmRBDI2y6NGjB1atWoUjR44gNDTU3cMhKrIYhBGRx3nuueecPj9x4gQOHTrksv1eRqMRWq0224+jVCpzND4AUCgUUCj4I7R27dqoUKECNm/efN8g7Pjx47hy5QrGjBmTq8eRy+WQy+W5ukZu5OZ7paj45ptvUK9ePZQqVcplX6lSpR75+qWCUblyZQQHB+O7775jEEbkRkxHJKJCqU+fPujYsSNOnTqFXr16oXbt2pg3bx4AYNeuXRg0aBDCw8NRo0YNREVFYfHixbDZbE7XuPd+iaypX1999RWioqJQo0YNdOnSBSdPnnQ69373hGWmJe3atQsdO3ZEjRo10KFDB8TFxbmM/9ixY+jcuTNq1qyJqKgorFmzJtv3mf30008YPnw4WrRogRo1aqB58+aYMWMGTCaTy/OrW7curl+/jtdeew1169ZFkyZNMHv2bJevRXJyMsaNG4f69eujQYMGePPNN5GSkvLIsQD21bALFy7g9OnTLvs2bdoEQRDQsWNHmM1mLFiwAJ07d0b9+vVRp04d9OzZE0ePHn3kY9zvnjBJkrBkyRJERESgdu3a6NOnD86ePety7u3btzF79mw8++yzqFu3LurVq4cBAwY4pUceO3YMXbt2BQCMHz/ekS6XeT/c/e4JS09Px6xZs9C8eXPUqFEDbdu2xfLly11WzB7n+yKn4uPjMWHCBDRt2hQ1a9ZEp06d8N1337kct3nzZnTu3NnxdXj22Wfx6aefOvZbLBbExMSgTZs2qFmzJho3bowePXrg0KFDD338jIwMHDhwAE2bNs3xc8j8fr18+TL69++POnXqIDw8HDExMS5f0+x+7QH7SnrXrl1Ru3ZtNGzYEL169cLBgwddjvvpp5/QtWtX1KxZE61atcL69etz/FzuJYoiVq5ciQ4dOqBmzZpo2rQpJk2ahKSkJMcx0dHRaNWq1X3P79atGzp37uzyvDp37oxatWqhUaNGGDVqFP79999sjadp06bYu3cvV3eJ3Ih/xiWiQuv27dsYOHAgOnTogE6dOiEwMBAA8N1330Gn06Ffv37Q6XQ4evQoFi5ciNTUVLz55puPvO6mTZuQlpaGbt26QRAEfPzxxxg2bBh27dr1yBWRn3/+GTt27EDPnj2h1+uxatUqDB8+HHv37oW/vz8A4Pfff8eAAQNQokQJDBs2DKIoYvHixQgICMjW8962bRtMJhN69OiBYsWK4eTJk/j888/x33//YeHChU7H2mw29O/fH7Vq1cLYsWNx5MgRrFixAuXKlUPPnj0B2IOZ1157DT///DO6d++OypUrY+fOndn6WgH2ICwmJgabNm1C9erVnR5769ataNCgAZ588kkkJCTg66+/RseOHfHCCy8gLS0N69atw4ABA/D111+7pAA+yoIFC7B06VI0b94czZs3x+nTp/HKK6/AYrE4HXf58mXs2rULzzzzDMqWLYtbt27hq6++Qu/evbF582aUKlUKlStXxvDhw7Fw4UJ069YN9evXBwDUq1fvvo8tSRJeffVVR/BWrVo1HDhwAHPmzMH169cxYcIEp+Oz832RUyaTCX369ME///yDXr16oWzZsti2bRvGjRuH5ORk9O3bFwBw6NAhjB49GqGhoXj99dcBABcuXMAvv/ziOCYmJgaxsbF44YUXUKtWLaSmpuLUqVM4ffo0wsLCHjiGU6dOwWKx4Omnn77vfqvVioSEBJftOp0OGo3G8bnNZsOAAQNQu3ZtvPHGGzhw4AAWLVoEm82GESNGAHi8r31MTAwWLVqEunXrYvjw4VAqlThx4gSOHj2K8PBwx3F///03RowYga5du+J///sfvvnmG4wbNw7Vq1dH1apVszsVDzRp0iR899136Ny5M/r06YMrV67giy++wO+//44vv/wSSqUS7dq1w5tvvomTJ0+iVq1ajnOvXr2KX3/9FWPHjnVsW7p0KRYsWIB27dqha9euSEhIwOeff45evXph/fr1MBgMDx1P9erVsXLlSpw9exbBwcG5fn5ElAMSEZGHmzJlihQcHOy0rXfv3lJwcLD05ZdfuhxvNBpdtr399ttS7dq1pYyMDMe2N998U2rZsqXj88uXL0vBwcFSo0aNpNu3bzu279q1SwoODpb27Nnj2LZw4UKXMQUHB0vVq1eX/v77b8e2M2fOSMHBwdKqVasc26Kjo6XatWtL//33n2PbpUuXpKefftrlmvdzv+cXGxsrhYSESFevXnV6fsHBwVJMTIzTsc8//7z0v//9z/H5zp07peDgYOmjjz5ybLNarVLPnj2l4OBg6ZtvvnnkmLp06SJFRERINpvNsS0uLk4KDg6W1qxZ47hm1q+/JElSUlKS1LRpU2n8+PFO24ODg6WFCxc6Pv/mm2+k4OBg6fLly5IkSVJ8fLxUvXp1adCgQZIoio7j5s2bJwUHB0tvvvmmY1tGRobTuCTJPtc1atRw+tqcPHnygc/33u+VzK/ZkiVLnI4bNmyYFBIS4vQ9kN3vi/vJ/J78+OOPH3jMypUrpeDgYGnDhg2ObWazWerWrZtUp04dKSUlRZIkSZo+fbpUr149yWq1PvBanTp1kgYNGvTQMd3P2rVrpeDgYOnPP/902deyZUspODj4vh+xsbGO4zK/X6dNm+bYJoqiNGjQIKl69epSfHy8JEnZ/9pfunRJeuqpp6QhQ4a4zH/W75nM8f3444+ObfHx8VKNGjWkWbNmPfK5BwcHS1OmTHng/h9//FEKDg6Wvv/+e6ftma+PzO0pKSn3fcyPPvrI6bV95coVqVq1atLSpUudjvvzzz+lp59+2mn7vd+3mX755RcpODhY2rx58yOfHxHlD6YjElGhpVKpXFJ0ADj9ZT01NRUJCQlo0KABjEYjLly48Mjrtm/fHn5+fo7PGzRoAMC+ovIoTZs2Rfny5R2fP/XUU/Dx8XGca7PZcOTIEbRq1crp3pkKFSqgWbNmj7w+4Pz80tPTkZCQgLp160KSJPz+++8ux/fo0cPp8/r16zul9cXFxUGhUDgdJ5fL0bt372yNBwA6deqE//77Dz/++KNj26ZNm6BUKvHMM884rplZWEMURdy+fRtWqxU1atS477gf5vDhw7BYLOjduzcEQXBsz1zRyUqlUkEms/+6s9lsSExMhE6nQ6VKlR77cTPFxcVBLpejT58+TttfeeUVSJLkkmr4qO+L3IiLi0OJEiXQsWNHxzalUok+ffogPT3dMScGgwFGo/GhqYUGgwFnz57FpUuXHmsMt2/fBgCn101WtWvXxieffOLy0aFDB5dje/Xq5fi/IAjo1asXLBYLjhw54ni+2fna79q1C6IoYsiQIY75z3rdrKpUqeJ4nQNAQEAAKlWqlCfzs23bNvj6+iIsLAwJCQmOj+rVq0On0zmqvPr4+CAiIgJbt251ShPcsmUL6tSpgyeffBIAsHPnToiiiHbt2jldr3jx4qhQoUK2qsZmrpQlJibm+vkRUc4wHZGICq1SpUrdt1re2bNn8cEHH+Do0aNITU112ped+5xKly7t9HnmG8vk5OTHPjfz/Mxz4+PjYTKZUKFCBZfj7rftfq5du4aFCxdiz549TveUAHB5vmq12iXN0c/Pz+m8q1evokSJEk5lxQGgUqVK2RoPAHTo0AGzZs3Cpk2b0LhxY2RkZGDnzp2IiIhwemP+3XffYcWKFbh48aJT2mDZsmWz/ViA/WsAABUrVnTaHhAQ4BIIiKKIzz77DKtXr8aVK1ec7ocrVqzYYz1upqtXr6JkyZLw8fFx2p5ZsfPq1atO2x/1fZEbV69eRYUKFVwCjcyxZH6tevbsia1bt2LgwIEoVaoUwsLC0K5dO0RERDjOGT58OF577TW0bdsWwcHBCA8Px3PPPZftypbSA+4x8vf3z9b9YjKZDOXKlXPalvl9mPk1ze7X/p9//oFMJstWFdUHzc+9r6+c+Pvvv5GSkvLAIhjx8fGO/7dv3x67du3C8ePHUa9ePfzzzz84ffq0U4rlpUuXIEkS2rRpc9/rPU7BoHuDUSIqOAzCiKjQyroilCk5ORm9e/eGj48Phg8fjvLly0OtVuP06dN4//33IYriI6/7oCp8D3qDmVfnZofNZkO/fv2QlJSEAQMGICgoCDqdDtevX8e4ceNcnl9BVRQMDAxE06ZNsWPHDkyaNAl79uxBWloann32WccxGzZswLhx4xAVFYX+/fsjMDAQcrkcsbGxebLi8CDLli3DggUL0KVLF4wYMQJ+fn6QyWSYMWNGgRUmyO/vi+wIDAzE+vXrcfDgQcTFxSEuLg7ffvstnn/+ecyePRsA0LBhQ+zcuRO7d+/GoUOHsG7dOnz66aeYMmUKXnjhhQdeOzOYTUpKwhNPPFEQTydP5efrRBRFBAYG4v3337/v/qx/JGnZsiW0Wi22bt2KevXqYevWrZDJZI7V5MzrCYKAjz766L7j1ul0jxxTZnCZ2/sRiSjnGIQRkVf54YcfcPv2bcTExKBhw4aO7VnT79wpMDAQarX6vs2NH9bwONNff/2FS5cuYfbs2Xj++ecd2x9Vve5hypQpg6NHjyItLc1pNezixYuPdZ1nn30WBw4cQFxcHDZt2gQfHx+nioLbt29HuXLlEBMT4/QX+HuLiWRHZmrWpUuXnFZOEhISXFYvtm/fjsaNG2PGjBlO25OTk53ehD7OqkCZMmVw5MgRpKamOq3IZKa7lilTJvtPJpfKlCmDP//8E6IoOq2GZY4l82sF2FMzIyMjERkZCVEUMXnyZHz11Vd47bXXHCuxxYoVQ5cuXdClSxekpaWhd+/eWLRo0UODsKCgIAB3K4zmlCiKuHz5stMqbOb3YebXNLtf+/Lly0MURZw/f/6xi77kpfLly+PIkSOoV6/eff9wlJVOp0OLFi2wbds2jB8/Hlu2bEGDBg2cUpfLly8PSZJQtmzZx1qtzirz52Fuey0SUc7xnjAi8iqZb0KzrjCYzWasXr3aXUNyIpfL0bRpU+zevRvXr193bP/7779x4MCBR55/v+cnSRI+++yzHI8pIiICVqsVX375pWObzWbD559//ljXiYqKglarxerVqxEXF4c2bdpArVY79mf+1T7r2E+cOIFff/31scfctGlTKJVKfP75507Xy1puPevj3rvitHXrVqevPwBHj7nspAhGRETAZrPhiy++cNq+cuVKCILglOKX3yIiInDz5k1s2bLFsc1qtWLVqlXQ6XSOP0bce/+PTCZzBExms/m+x+j1epQvX96x/0Fq1KgBpVKJU6dO5fr5ZP2aSpKEL774Akql0pHOl92vfVRUFGQyGRYvXuyyQlyQK5Dt2rWDzWbDkiVLXPZZrVaX77f27dvjxo0b+Prrr/HHH3+gXbt2TvvbtGkDuVx+39L9kiRl6z6v06dPw9fXN08qPxJRznAljIi8St26deHn54dx48ahT58+EAQBGzZs8Kh+OEOHDsXBgwfRo0cP9OjRA6Io4vPPP0fVqlVx5syZh54bFBSE8uXLY/bs2bh+/Tp8fHywffv2XN1bFBkZiXr16mHu3Lm4evUqqlSpgh07dmS7T1gmvV6PVq1aYdOmTQDglIoIAC1atMCOHTswZMgQtGjRAleuXMGaNWtQpUoVpKenP9ZjBQQE4JVXXkFsbCyio6PRvHlz/P7774iLi3NJsWrRogUWL16M8ePHo27duvjrr7+wceNGl3uPypcvD4PBgDVr1kCv10On06FWrVouxwH2r1njxo0xf/58XL16FSEhITh06BB2796Nvn37OhXhyAtHjhxBRkaGy/aoqCh069YNX331FcaNG4fTp0+jTJky2L59O3755RdMmDDBsVo0ceJEJCUloUmTJihVqhSuXbuGzz//HNWqVXOsiHTo0AGNGjVC9erVUaxYMfz222/Yvn37I4u0qNVqhIeH48iRI45S8lldv34dGzZscNmu1+sRFRXldJ0DBw7gzTffRK1atXDgwAHs27cPgwcPdqTtZfdrX6FCBQwePBhLlixBz5490aZNG6hUKvz2228oWbJkrhuIZ3Xq1Kn7BlmNGjVCo0aN0K1bN8TGxuLMmTMICwuDUqnEpUuXsG3bNrz11ltO6YbNmzeHXq/H7NmzIZfL0bZtW6drli9fHiNHjnS8XqOioqDX63HlyhXs2rULL774Ivr37//Q8R4+fBgtW7bkPWFEbsQgjIi8ir+/P5YtW4bZs2fjgw8+gMFgQKdOnRAaGvrINyYFpUaNGvjoo48wZ84cLFiwAKVLl8bw4cNx4cKFR1ZvVCqVWLZsGaZPn47Y2Fio1Wq0bt0avXr1wnPPPZej8chkMixduhQzZszA999/D0EQEBkZiXHjxjmlPGZHp06dsGnTJpQoUQJNmjRx2te5c2dHj66DBw+iSpUqeO+997Bt2zb88MMPjz3ukSNHQqVSYc2aNTh27Bhq1aqFFStWIDo62um4wYMHw2g0YuPGjdiyZQuefvppxMbGYu7cuU7HKZVKzJo1C/PmzcPkyZNhtVoxc+bM+wZhmV+zhQsXYsuWLfj2229RpkwZjB07Fq+88spjP5dHOXDgwH1XSsuUKYPg4GCsWrUK77//Pr777jukpqaiUqVKmDlzplP10E6dOmHt2rVYvXo1kpOTUaJECbRr1w7Dhg1zrLD26dMHe/bswaFDh2A2m/Hkk09i5MiR2XrtdOnSBcOGDcO///7rUujizJkzTn2uso4/axAml8vx8ccfY/LkyXjvvfeg1+sxdOhQDBkyxHHM43ztR4wYgbJly+Lzzz/H/PnzodVqERISkuPXyoOcOHECJ06ccNk+YsQINGjQAFOnTkWNGjWwZs0azJ8/H3K5HGXKlEGnTp1cetGp1WpERkZi48aNaNq0qaP/YVaDBg1CxYoVsXLlSixevBgA8MQTTyAsLMylqfi9zp8/j7/++sullx0RFSxB8qQ/DxMRFWGvvfYazp07hx07drh7KESPzWazoX379mjXrh1Gjhz52OePGzcO27dvx/Hjx/N+cOTw7rvv4qeffsK3337LlTAiN+I9YUREbmAymZw+v3TpEuLi4tCoUSM3jYgod+RyOUaMGIHVq1cjLS3N3cOh+0hMTMS6deswcuRIBmBEbsZ0RCIiN4iKisL//vc/lCtXDlevXsWaNWugVCoxYMAAdw+NKMfat2+P9u3bu3sY9AD+/v5caSTyEAzCiIjcoFmzZti8eTNu3rwJlUqFOnXqYPTo0S7Nh4mIiMj78J4wIiIiIiKiAsR7woiIiIiIiAoQgzAiIiIiIqICxCCMiIiIiIioALEwRx6QJAmi6Bm31slkgseMhfIG59Q7cV69D+fUO3FevQ/n1Pt40pzKZEK2WkAwCMsDoighIcH9PVEUChn8/fVITk6H1Sq6eziUBzin3onz6n04p96J8+p9OKfex9PmNCBAD7n80UEY0xGJiIiIiIgKEIMwIiIiIiKiAsQgjIiIiIiIqAAxCCMiIiIiIipADMKIiIiIiIgKEKsjEhEREZHHEUURNps1j68pwGSSw2zOgM3mGSXNKXcKck7lcgVksrxZw2IQRkREREQeQ5IkJCcnwGhMzZfr37olgyi6v5Q55Z2CnFOt1gcGQ0C2eoE9DIMwIiIiIvIYmQGYj48/VCp1rt/s3ksuF7gK5mUKYk4lSYLZnIHU1EQAgJ9fYK6uxyCMiIiIiDyCKNocAZiPjyFfHkOhkHlEU1/KOwU1pyqVGgCQmpoIX1//XKUmsjAHEREREXkEm80G4O6bXSJPk/m9mdv7FT1uJez8+fOYPn06jh8/Dr1ej+eeew4jR46ESqV66HmRkZG4evWqy/aTJ09CrbZ/sY4dO4aXXnrJ5Zj27dtj/vz5efMEiIiIiChX8joFkSiv5NX3pkcFYUlJSejbty8qVqyIRYsW4fr165g1axZMJhMmTZr0yPPbtm2LV155xWnb/YK3mTNnIigoyPG5v79/7gdPRERERESUDR4VhK1ZswZpaWmIiYlBsWLFANiXpadMmYLo6GiUKlXqoecXL14cderUeeTjVK1aFTVr1syDERMREREROQsPb/DIYyZMeAft2z+bo+sPHToIOp0Oc+Z88Fjnde36LJo2Dcfo0W/m6HEf1y+//IThwwfj448/w1NPPV0gj1lYeFQQFhcXh9DQUEcABgDt2rXDO++8g0OHDqFz587uGxwRERERUTYsW/aJ0+eDB/dD167dEBX1jGNbmTJlc3z9MWPGQS5//NIOM2a8B1/f/Cl4Qo/Ho4KwCxcuoEuXLk7bDAYDSpQogQsXLjzy/I0bN2Lt2rVQKpVo0KABXn/9dYSEhLgcN2jQINy+fRslSpRAhw4dMGLECGg0mjx7HkRERERUdNWo4ZpxVbLkE/fdnikjwwS1OnvvRytVCnr0QfcRHPxUjs6jvOdRQVhycjIMBtfo3M/PD0lJSQ89NzIyErVq1cKTTz6Jy5cvY9myZejZsyfWr1+PcuXKAQB8fX0xYMAANGzYEGq1GkePHsWKFStw4cIFxMbG5mrsCoX7C01m/kUkJ38ZIc/EOfVOnFfvwzn1TpzXgieK+VuQI7OmgiAAkhtbhS1fHos1az7HggVLsWDBXJw9+ycGDHgVPXv2wdKli3DkyEH8++816PU+qF27LoYNG43ixYs7zr83HTHzesuWfYL335+Jv/76A08+WQZDh45C48ahjvPuTUd8993J+OOP3zFq1FgsWjQPly//g0qVgjBmzHg89VQ1x3mpqamYN282DhzYD7VajWeffR4Ggx8WL/4ABw/+lKuvRXJyEmJiPsChQ3EwGk0IDg7B4MFDUadOPccxJ0/+itjYxTh37i+IooTSpUujR48+aNeuIwQBOHHiVyxZsui++/OLXC7k6v2/RwVhuTFx4kTH/xs0aICwsDC0a9cOy5cvx+TJkwEATz/9NJ5++m4+amhoKEqWLImpU6fi5MmTqFWrVo4eWyYT4O+vz9X485LBoHX3ECiPcU69E+fV+3BOvRPnteCYTHLcuiXL9RvcR3FHYJ31OclkAiwWC6ZOnYju3XvhtdeGwmDwg0IhQ1JSIl5+uT+KFy+B27cTsXr1KgwbNghffrkOCoX9rbsgCBAEOF3ParVi6tSJePHFHihVaiBWrVqJiRPHYv36zfDzK+YYh0x2dxyCICAhIQELFryPl17qBx8fHyxZsghvvfUGvvlmAxQKJQBg5swp+PnnHzF06AiULl0aGzZ8hz/+OAPg4QsRWf+Qcb/jbDYbXn99BK5du4IhQ0YgICAAa9euwahRQ/DRR5/gqaeeRlpaKsaOHYnatetg2rSZUCqVuHjxItLTU6FQyJCWlooxY4Y/cH9eE0UBMpkMfn66XGXSeVQQZjAYkJKS4rI9KSkJfn5+j3WtkiVLon79+jh9+vRDj2vXrh2mTp2KU6dO5TgIE0UJycnpOTo3L8nlMhgMWiQnG2GzsQmhN+CceifOq/fhnHonzmvBM5szIIoibDbJqfmuJAHpefBWSxDs82qziY+1EqbT3V1Fy6msz0kUJVitVgwc+BpatWrjOMZqFTFu3KQs59hQrVoN/O9/7fHDDz+gUaMmAABJkiBJcLqexWLB4MFDERoaDgAoU6Y8XnihEw4ePIi2bds7rml/bNFxneTkJCxaFIugoMoAAKVSjeHDB+PEid9Qu3YdXLx4Afv378XEiVPwzDMdAAANGjRBz55dHWN+8HMWHf/e77iDB+Pw+++nMHfuIseKXYMGTdCt2/P45JPlePfd93Dx4iWkpqZi0KChqFy5CgCgbt2GjsfO3B8dPRRBQa7785rNJkEURSQlpcNotLnsNxi02QryPSoICwoKcrn3KyUlBTdv3nQqKe+J3N153WoFxoxRoVIlYOhQEQoFf1l4kwf98KLCjfPqfTin3onzWnBsNtfISJKAjh11+PFHuRtGZNeokRUbNxpzHYjdKzNgyurIkUP49NPluHjxPNLS0hzbL1/+2xGE3Y9MJkODBo0dn5cu/STUajVu3Ljx0DEUL17CEYABd+83u3nzOgDgjz9+BwCEhzd3eqywsGb46qsvHnrtRzlx4lfo9XqnlEmFQoHmzVti587tAIAnnywLvV6P99+fia5du6NevQZO7aXs+33w3nv3359f7v1DwePyqCTniIgIHD58GMnJyY5t27ZtuzPRYY91revXr+Pnn39+ZCn6zZs3A0ChL1mflCRg3ToFZswAWrfW4K+/PGpqiYiIiHJMENx4A1c+0Wg00Ol0TtvOnDmNcePs93+9/fZULFv2CWJjVwIAMjLMD72eWq2GUql02qZUKmE2Zzz0PB8fH6fPM1MQzWb74926dQsKhcLluLwIdFJSkuHvH+Cy3d8/EMnJ9noQBoMB8+cvhk6nx/Tpk/Dcc20xdOggnD9/zrF/4cIlD9zvqTxqJax79+5YtWoVhgwZgujoaFy/fh1z5sxB9+7dnXqE9e3bF9euXcPOnTsBAJs2bcLevXvRvHlzlCxZEpcvX8aHH34IuVyOfv36Oc57/fXXUaFCBTz99NOOwhwrV65EVFRUoQ/CAgMlfP55BoYO1eD0aTnatNHh3Xcz0LOnJc//akNERERUUAQB2LjRmCfpiID9HqbHXcHIi3TEewn3uWBc3D74+Phg6tRZkMnsf1D/779/8/aBH1Px4sVhtVqRmprqFIglJibm+toGgwGJiQku2xMT42Ew3L0V6emna2Du3IXIyDDhl19+wuLFCzB+/BisXbsBAFC9+sP3eyKPCsL8/Pzw6aefYtq0aRgyZAj0ej26du2KUaNGOR1nzxW+m4NZtmxZ3LhxAzNmzEBKSgp8fX3RpEkTDB8+3FEZEbA3ad64cSNWrFgBi8WCMmXKYPDgwRg0aFCBPcf81Lq1DSdOAD162LB/vxyjRmmwd68cc+ea8Ji31BERERF5DEEA9HlUA02hsN/G4YkyMkxQKBROAdqOHVvdOCIgJMReJfHAgX2OaoOiKOLQoQO5vnatWnWwevUq/PDDUUeqpdVqRVzcPtSqVdvleLVag9DQcFy9egULFsxFRkYG1Gp1tvd7Eo8KwgCgcuXKWLly5UOPWbVqldPnderUcdl2P9HR0YiOjs7N8Dxe6dLAN9+Y8MEHCsyapcL33ytx/LgcS5ca0agR89mJiIiIPFXDho2xdu2XmD9/DiIiWuLUqZPYvn2LW8cUFFQZEREtsWDB+8jIMKFUqdL4/vvvYDZn3Hc1735+/vlH/PvvNadtpUuXQWhoOKpVq46pU9/G4MFDERAQiHXrvkJ8/C306fMKAODw4YPYtGkDIiJaoFSpJ5CQEI9169aiZs3aUKvVOHz4IDZv3oBmze6/31N5XBBGuSeTAcOHmxEWZkV0tBb//CPDc8/pMHasGcOHmyF3332tRERERPQAoaHhePXVYfjmm7XYsmUjatasjTlzPkCPHp3dOq7x4ydh/vw5WLx4AVQqFZ55piOCgirjm2/WZuv8pUsXuWzr2PE5jBv3Nt5/fwEWL16AJUsWwmQyIjj4KcybF+PoU1a2bFnIZAI+/HAJbt9OhMHgh0aNmiA6ekiW/bIH7vdUgiS5s1Wdd7DZRCQkpD36wHymUMjg769HYmKaI9c5JQV44w0Nvv3WfpNlWJgVS5aYULo0p70wuN+cUuHHefU+nFPvxHkteBaLGfHx/yIwsDSUSlW+PEZO7gkjV0OGDIRMJsOiRbHuHkqBzumjvkcDAvSFr0Q95T1fX2DpUhNatLBi3DgNDh1SoEULPRYsMOKZZ1x7GxARERERZbVv325cv/4fgoKqICPDhJ07t+HEieOYMeN9dw+t0GIQVgQIAtC9uxUNG6YhOlqLkyfleOklHfr3N+OddzKQi2bfREREROTltFodtm/fgsuXL8NqtaB8+YqYNGkaIiJauHtohRaDsCKkcmUJmzen49131Vi2TIXly1U4fFiODz80ISSEy/JERERE5Kpx41CnhsqUe+zoW8So1cDUqRn48st0FC8u4swZe0+xVauU4N2BRERERET5j0FYEdWqlQ1796ajeXMrjEYBY8ZoMGCABrdvu3tkRERERETejUFYEVaqlISvvjJi0iQTFAoJGzcqERmpx7FjrGFPRERERJRfGIQVcTIZMHSoBZs3p6NiRRFXrsjw3HNazJ2rgo3FE4mIiIiI8hyDMAIA1K0rYvfuNHTpYoEoCpg9W40uXbS4di17ndCJiIiIiCh7GISRQ2ZPsZgYI/R6CYcPK9CypR5btrCIJhERERFRXmEQRi5efNGK3bvTULu2DYmJAl5+WYs331TDaHT3yIiIiIiICj8GYXRfQUH2nmKvvWYGAHzyiQrPPKPDH3/wW4aIiIjoYcaOHYXu3f/3wP3r1q1BeHgDXL16JVvXCw9vgNWrVzk+Hzp0EMaOHfnI8555pgWWL4/N1mNkOnv2TyxfHguTyeS0fcuWjQgPb4DbBVRK+99/ryE8vAH27t1VII9X0PiOmh5IpQImT87AmjXOPcU+/ZQ9xYiIiIgepHXrtrhy5TLOnDl93/27du1A9eo1UaZM2Rxdf8yYcRg6dGQuRvhgZ8/+hU8++cglCAsNDceyZZ/Ax8cnXx63qGEQRo8UGWnDvn3paNnSCpNJwBtvaPDKKxokJrp7ZERERESep1mzFtBqddi5c5vLvn//vYZTp06ideu2Ob5+pUpBKF++Yi5G+Pj8/f1Ro0ZNKBSsFZAX+FWkbClZUsKXXxqxbJkS776rxubNSvz6qxxLl5rQpAlr2RMRERFl0mg0aNasOfbs2YWhQ0dBJru77rFr13bI5XK0atUGt27dwocfLsbx478gPv4WSpYsiZYto9Cv30CoVKoHXn/o0EHQ6XSYM+cDx7YDB/Zh6dJF+O+/f1G5chWMHv2my3mHDx/E2rWrce7cWZjNZlSoUBH9+0ejSZOmAOwphzNmTAEAdOwYBQB44onSWLduo2Pfpk27UKxYMQBAcnISYmI+wKFDcTAaTQgODsHgwUNRp049l7G2a9cRH364BLdu3US1atXx5psTc7wSmCkjIwMffrgYu3fvQHJyMsqXr4h+/QaiefOWjmMuXDiPJUsW4PffTyMjw4SSJUuhY8fn0KtX32ztzy8MwijbZDLgtdcsaNrUhuhoLS5elOH557UYM8aMUaPM4B9GiIiIKF9IEiCm59HFZIBNfMxTdIDweG17Wrduix07tuL48Z9Rv35Dx/adO7ehQYPG8PcPwPnz52Aw+GHYsFHw9fXF5cv/YMWKDxEffwsTJryT7cc6e/ZPTJz4Jho3bophw0bh2rVrmDRpPMxmi9Nx//57FWFhEejRow9kMgFHjx7GG2+MwIIFS1GvXgOEhoajb9/++PTT5Zg7dxH0eh+oVMr7PqbNZsOYMcPx779X8eqrw+DvH4h169Zg1KghWLp0BZ56qlqW8f2FxMRVGDx4GETRhkWL5mPq1LcRG/vJY31N7zV16kQcO3YEgwcPQdmyFbBt22ZMnDgWM2e+j/Dw5gCAN98cjYCAAIwb9zZ8fHxw5cpl3Lx5w3GNR+3PL3zbTI+tTh17T7Fx4zRYu1aJ995T48AB+6pYmTK8WYyIiIjykCSh2I9toEw65rYhWIo1we0G2x8rEGvYsAmKFfPHrl3bHUHYhQvncOHCefTs+RIAoHLlKk73dtWsWRsajRbvvvsORo9+ExqNJluP9fnnK1Gy5BOYOfN9yOVyAIBarcasWdOcjuvSpZvj/6Ioom7dBrh48QK+//471KvXAP7+/o7VqZCQao4Vr/s5cuQgzpw5jblzF6Fx41AAQOPGoejW7XmsWrUC7777nuPY1NQUrFjxBfz9/QEARqMRM2ZMwY0b11GyZKlsPcd7nTt3Fvv378Xrr49H164vwGoV0aRJU/z3379YseIjhIc3x+3bt/Hvv1cxYsQYhIdHAADq1WvguMaj9ucn3hNGOeLjA8TEmLB4sb2n2NGj9p5imzczriciIqI89pirUJ5AoVCgZcso7Nu3BxaLfUVq587t0Gg0iIiwp8tJkoS1a1ejd+8XEBkZhhYtmmDq1Imw2Wy4di17lRMB4PffTyMsrJkjAAOAli1buRx348Z1TJ/+Dp5/vh2aN2+MFi2a4IcfjuLy5X8e+/mdOPEr9Hq9IwDLfM7Nm7fEyZMnnI6tUiXYEYABQMWKle6MJ+crTidOHAcAREZGOW2PjGyNs2f/hNFohJ+fH554ojRiY2Owdesm3Lhx3enYR+3PT3zHTLnywgtW1K+fhsGDtfj1Vzn69dPi5ZfNmDIlA1qtu0dHREREhZ4g2Feh8igdUSGXwVoA6YiAPSXxu+++xrFjhxEe3hy7du1AWFgEdDodAGDt2tVYvHgBevZ8CfXqNYCvry/OnPkd8+bNhtlszvbjxMffcgpyANxJJVQ7PhdFEePGjUZqaioGDIhGmTLloNVq8fHHy3D9+n+P/dxSUpLh7x/gst3fPxDJyUlO23x9fZ0+VyrtKY5mc8ZjP27Wx1coFDAY/Jy2BwQEQJIkpKamQKvVYt68GHz44RLMmzcbRqMRISHVMGzYKNSpUw+CIDx0f35iEEa5FhQkYdOmdMycqcbixSqsXKnC0aNyxMaaUK3aY/6QIyIiIrqXIAByfd5cSyEDUDDvT2rWrI3SpZ/Ezp3bUaxYgCP1LdPevbsRFhaBwYOHOrZdunTxsR8nMLA4Eu8pW52WluoU5Fy5chl//fUnZs58H82atXBsz8jIWSBkMBiQmJjgsj0xMd4lMMoPBoMfrFYrkpOTERBQzLE9ISEBgiDAx8ce+JUvXwHTp8+G1WrFb7+dwIcfLsabb47Cd99thU6ne+T+/MJ0RMoTKhXwzjsZ+OqrdJQoIeKPP+Ro21aHTz5hTzEiIiIqmgRBQFRUWxw6FIeNG7+Dn5+foxIhAGRkmByrQpl27Nj62I9TrVp1HDp0ADbb3YrVe/fudjomM9hSKO4+3n///YvffnNOHczc/6hVqlq16iAtLQ0//HDUsc1qtSIubh9q1ar92M/hcdWqVQcAXJo57927C1WrhkB7T0qWQqFA3br10avXy0hLS8OtWzcfa39e40oY5amWLe09xYYN02DPHgXefFOD/fvlmD/fhHtWyYmIiIi8XuvWbbFq1SfYsmUjnnuus1OfrYYNG+Prr9fgm2++QrlyFbB9+xZcuZL9e8Ey9e7dFwMH9sX48a/jf//rimvXrmLNms+d0hErVKiIkiVLYdmyGIiiCKMxHcuXx6JEiZJO16pYsSIA4Ntvv0azZi2g0WhQuXIVl8cMDQ1HtWrVMXXq2xg8eCgCAgKxbt1XiI+/hT59Xnns5/Agp0+fctkWEBCI2rXronnzloiJmQ+r1YwyZcpjx46tOHXqJGbOnAvAXrwjJmY+WrVqgzJlyiI1NRWrVn2C0qWfRJkyZR+5Pz8xCKM8V6KEhNWrjYiNVWL6dDW2bLnbUyw0lD3FiIiIqOgICqqCypWr4vz5s2jd+hmnfS+/PBC3b9/Gxx/HAgBatGiFkSNfx5tvjnqsxwgOfgpTp87CsmWL8NZbb6BSpcqYPHkGxoy5m+aoUqnw7rtzMG/ebLz99jiULFkKffu+gl9++Ql//PG707VeeWUQNm3agNWrP0PJkqWwbt1Gl8eUy+V4//0FWLx4AZYsWQiTyYjg4Kcwb16MU3n63Fqz5nOXbfXrN8KCBUswadI0xMYuxmefrURychLKl6+I6dNnOyodBgYGIjAwEKtWfYJbt25Cr/dB7dp1MGnSNMjl8kfuz0+CJDFZLLdsNhEJCWnuHgYUChn8/fVITEyD1eoZ92KdOCFDdLQWFy7IIJNJGDXKjDFj2FMsuzxxTin3OK/eh3PqnTivBc9iMSM+/l8EBpaGUvngZsW5oVDIOJ9epiDn9FHfowEBesjlj77ji/eEUb6qXVvErl1p6NbNAlEUMHeuGv/7nxZXrhS+UrNERERERHmBQRjlOx8fYNEiE5YsMcLHR8KxY/aeYhs3cjmMiIiIiIoeBmFUYLp2tWL37jTUrWtDUpKA/v21eP11NdLzpu0HEREREVGhwCCMClSlShI2bkzHsGH2sqeffaZC27Y6/P47vxWJiIiIqGjgO18qcCoV8PbbZqxdm46SJUX8+ae9p9iKFewpRkRERETej0EYuU2LFjbs3ZuOVq2syMgQMG6cBn37apDg2nydiIiIihAW7yZPlVffmwzCyK1KlJDwxRdGTJtmglIpYds2JVq21OPw4fztzUBERESeJ7M3k9mc4eaREN1f5vemXJ67AnMsT0duJ5MB0dEWhIbaEB2txfnzMvzvf1qMGmXG66+zpxgREVFRIZPJodX6IDU1EQCgUqkhCHnb1kYUBdhsXGnzJgUxp5IkwWzOQGpqIrRaH8hkuVvL4ttb8hi1aonYuTMNb72lwZdfKjFvnhoHDiiwbJkR5crxhyUREVFRYDAEAIAjEMtrMpkMoshmzd6kIOdUq/VxfI/mBoMw8ig+PsCCBSY0b27FG29o8OOPcrRsqce8eSZ06mR19/CIiIgonwmCAD+/QPj6+sNmy9vf/XK5AD8/HZKS0rka5iUKck7lckWuV8AyMQgjj9S5sxX16qXh1Ve1+PlnOQYM0KJPHzOmTcuATufu0REREVF+k8lkkMlUeXpNhUIGjUYDo9EGq5WrYd6gsM4pC3OQx6pYUcL336djxIgMCIKEVatUaNNGh9On+W1LRERERIUX382SR1MqgbfeMuPrr40oVUrEX3/J8cwzOixfzp5iRERERFQ4MQijQiEiwt5TrHVre0+x8ePtPcXi4/O2YhIRERERUX5jEEaFRvHiEj7/3Ih33zVBpcrsKabDwYPsKUZEREREhQeDMCpUBAEYONCCrVvTUaWKDf/9J0OXLlrMmqWClcUTiYiIiKgQYBBGhVLNmiJ27kxHr15mSJKAefPU6NRJh3/+YXoiEREREXk2BmFUaOn1wPz5GfjwQyN8fSX89JMckZF6bNjAzgtERERE5LkYhFGh9/zzVuzZk4b69W1IThYwcKAWo0erkZbm7pEREREREbliEEZeoUIFe0+xkSPtPcU+/9zeU+zUKX6LExEREZFn4TtU8hpKJTBhghnr1hnxxBMizp619xT7+GP2FCMiIiIiz8EgjLxOs2b2nmJt21phNguYMEGDPn207ClGRERERB6BQRh5pcBACZ99ZsSMGfaeYjt2KNCihQ4HDrCnGBERERG5F4Mw8lqCAAwYYMG2bemoWtWG69dl6NpVixkzVLBY3D06IiIiIiqqGISR16tRQ8SOHeno3dveU+yDD+w9xf7+m+mJRERERFTwGIRRkaDXA/PmZeCjj4wwGCT8/LO9p9j69ewpRkREREQFy+OCsPPnz6Nfv36oU6cOwsLCMGfOHJjN5keeFxkZiZCQEJePjIwMp+OuX7+OYcOGoW7dumjUqBHeeustpKam5tfTIQ/z3HP2nmINGtiQkiJg0CAtRo5kTzEiIiIiKjgetQyQlJSEvn37omLFili0aBGuX7+OWbNmwWQyYdKkSY88v23btnjllVectqlUKsf/LRYLBgwYAACYO3cuTCYTZs+ejTFjxiA2NjZvnwx5rPLl7T3F3n9fhfnzVVi9WoUffpAjNtaEmjVFdw+PiIiIiLycRwVha9asQVpaGmJiYlCsWDEAgM1mw5QpUxAdHY1SpUo99PzixYujTp06D9y/fft2nD17Flu2bEFQUBAAwGAwoH///jh58iRq1aqVV0+FPJxCAYwbZ0azZja8+qoG587J0a6dDpMmZWDgQAsE3i5GRERERPnEo9IR4+LiEBoa6gjAAKBdu3YQRRGHDh3Kk+uHhIQ4AjAACAsLQ7FixbB///5cX58Kn7Awe0+xZ56xwGwWMHGiBr17a3HrFqMwIiIiIsofHhWEXbhwwSlAAuwrVSVKlMCFCxceef7GjRtRo0YN1K1bFwMHDsSff/75yOsLgoBKlSpl6/rknQIDJXz6qQkzZ5qgVkvYuVOBli11iItjTzEiIiIiynselY6YnJwMg8Hgst3Pzw9JSUkPPTcyMhK1atXCk08+icuXL2PZsmXo2bMn1q9fj3Llyjmu7+vrm6PrP4pC4f54Vi6XOf1Ljyc62obwcCP699fgr79keOEFLUaMsGD8eAuUSveMiXPqnTiv3odz6p04r96Hc+p9CuucelQQlhsTJ050/L9BgwYICwtDu3btsHz5ckyePDlfH1smE+Dvr8/Xx3gcBoPW3UMotMLDgePHgVGjgA8/FPDBByocPqzCl18C9yyiFijOqXfivHofzql34rx6H86p9ylsc+pRQZjBYEBKSorL9qSkJPj5+T3WtUqWLIn69evj9OnTTte/Xzn6pKQklC5d+vEHfIcoSkhOTs/x+XlFLpfBYNAiOdkIm41V/nJj1iwgNFSOkSPV+OEHAbVrS5g/PwNdutgKdBycU+/EefU+nFPvxHn1PpxT7+Npc2owaLO1KudRQVhQUJDLvVkpKSm4efOmy71cOb3+X3/95bRNkiRcvHgRYWFhubq21er+Sc9ks4keNZ7CqkMHEbVqWfHqqxr88IMCAwdqsHu3BTNmmODjU7Bj4Zx6J86r9+GceifOq/fhnHqfwjanHpU8GRERgcOHDyM5Odmxbdu2bZDJZI8dJF2/fh0///wzatas6XT9P/74A5cuXXJsO3LkCG7fvo3mzZvnevzkfcqVk7B+vRFjxmRAJpOwZo0SUVF6nDzpUS8dIiIiIipEPOqdZPfu3aHX6zFkyBAcPHgQ33zzDebMmYPu3bs79Qjr27cvWrdu7fh806ZNGDNmDL7//nscPXoUX3/9NXr37g25XI5+/fo5jmvbti2qVq2KYcOGYe/evdiyZQsmTJiAFi1asEcYPZBCAbz5phnffmtE6dIiLlyQoV07HZYtU0KS3D06IiIiIipsPCod0c/PD59++immTZuGIUOGQK/Xo2vXrhg1apTTcaIowma7e29O2bJlcePGDcyYMQMpKSnw9fVFkyZNMHz4cEdlRABQKpX4+OOPMX36dIwePRoKhQKtW7fGhAkTCuw5UuHVtKkNe/emYdQoDbZuVWLSJA3i4hRYsMCEEiUYjRERERFR9giSxL/l55bNJiIhIc3dw4BCIYO/vx6JiWmFKie2sJEkYOVKJSZNUiMjQ0DJkiJiYkxo0SLvi3ZwTr0T59X7cE69E+fV+3BOvY+nzWlAgD5bhTk8Kh2RqDAQBKBfPwu2b09HSIgNN27I8OKLOkydqoLF4u7RERERERURNhMUt/YA55cDotndo3ksDMKIcujpp0Vs356Ovn3tL/qYGDWefVaHixcFN4+MiIiIyAtJEuRpf0H7zxL4/dIZxfdVgO+PnYBjA6C8/r27R/dYPOqeMKLCRqcD3nsvA82b2zBqlAa//CJHq1Z6zJljQteuVncPj4iIiKhQEyy3oUzYD1X8bqjid0Nuuuy0X1SXhqxcJ1iLR7lphDnDIIwoD3TsaEWdOml49VUNjh1T4LXXtNi3z4JZswq+pxgRERFRoSXZoEg+7gi6FEk/QpDu3ncvCSpY/MNgDmwFc2ArCMVqwD/AB1JiGuAB94RlF4MwojxStqyE774zYt48FebNU2HtWiV++kmO2FgjatcuPD8UiIiIiAqSzPQvlAl7oLq1C6qEvZBZEpz2W3VVYQ5sBUtgK5gDwgG53rFPIRTO20AYhBHlIYUCGDvWjIgIG159VYMLF2Ro316HiRMzEB1tgYx3YRIREVFRJ2ZAmXgEqvhd9tWu1NPOuxUGWAKawxwYBXNgK4ja8m4aaP5hEEaUD5o0sWHPHntPsS1blHjnHQ3271dg4UITSpZkVwgiIiIqQiQJ8vRzUMXvgjJ+N1QJByGI6Xd3Q4DVUPdOimEUrH4NAJnSjQPOfwzCiPKJvz/wyScmfPqpDZMmqbFnjwItW+oQE2NCy5Z531OMiIiIyFMI1mR7QY1bmQU1/nbab1OVsqcXBraCOTASkirQTSN1DwZhRPlIEICXX7agcWMbBg/W4MwZObp102HIEDPGj8+ASuXuERIRERHlAUmEIvlXqOJ3Qxm/G8qkY/cpqBHqKKhh86lhf6NURDEIIyoA1aqJ2LYtHZMnq/HJJyosXqzCoUNyLFtmRFAQ0xOJiIio8BEyrjuqGKri90BmiXfab9VVvrPaFQVzQDOnghpFHYMwogKi1QKzZ2cgIsLeU+zXX+/2FHvhBfYUIyIiIg8nmqG8fdReUOPWbihSf3PeLfe9U1CjFczFW0HUVnTPOAsBBmFEBaxDh7s9xY4eVWDIEHtPsdmz2VOMiIiIPIss/by9dHz8bqgSD0CwpTntt/jWhbm4vXy8xa+R1xfUyCsMwojcoEwZe0+x+fNVeP99Fb7++m5PsTp12FOMiIiI3EOwpkCZEOcoHy83XnLaL6pKwhwYmaWgRgn3DLSQYxBG5CZyOfD662aEh9t7il28KEOHDjpMmJCBV19lTzEiIiIqAJIIRcpJe+n4W7vuFNS4e5uEJChhKdbkToph1J2CGnyTklsMwojcrEkTG/buTcPo0Rps2qTElCn2nmKLFplQpoy7R0dERETeRjDftKcX3toFVcJeyMw3nfbbtJVgLh4Fc2AULP7hkBS+bhqp92IQRuQBihUDli83YdUqG95+W419++w9xZYuNaNrV3ePjoiIiAo10Qzl7WN3y8ennHDeLfeBJSDCUT5e1AW5aaBFB4MwIg8hCMBLL9l7ig0aZO8p9sILGowZA7zxBpieSERERNkmS7/gKB+vTIiDzJbqtN/iW9vRLNlSrDEgY/PSgsQgjMjDhITYe4pNmaLGihUqzJ0L7N6tYU8xIiIiejBrKlSJB+6Uj98FufGi025RWTxLQY1WkNQl3TRQAhiEEXkkrRaYNSsDkZEihg+39xSLjNRj9mwTunVjTzEiIqIiT5IgT/0Nqlu7oYrfBeXtoxAky93dggIWv8YwF4+CJbAVrL61WFDDgzAII/Jg7dvb0Lw50L27DYcOyTFsmBb799t7ivnyHlkiIqIiRTDfcqQYquL3QGa+4bTfpq14Z6UrCpaAZpAUBjeNlB6FQRiRhytbFli/3oS5cxV47z0V1q2721Osbl32FCMiIvJaogXKpB/ulI/fDWXKcafdklwPs38z+31dga1g01W232ROHo9BGFEhIJcDo0ebERZm7yl26ZK9p9j48WYMGWJm0Q4iIiIvITNeupNiuBvKhP2Q2VKc9lt9asJcPLOgRhNApnbTSCk3GIQRFSKNG9uwZ08aXn9dg++/V2LaNDXi4uSIiTGhVCkW7SAiIip0bGlQJdgLaijjd0ORft5pt6gMvKegRik3DZTyEoMwokKmWDHgo49MaNHChrfeUmP/fntPsUWLTGjVyubu4REREdHDSBLkqafulo9PPAJBMt/dLchh8WvsKB9vNdRhQQ0vxCCMqBASBKB3bwsaNbL3FPv9dzl69NBh8GAz3norA2pmJhAREXkMwRwPVfyeO82S90Bu/s9pv01Twb7SVbwVLP4RkJR+bhopFRQGYUSFWHCwvafY1KlqfPyxCsuWqXD4sL1oR+XKTE8kIiJyC9EKRdKP9p5d8buhSD4OAXd/L0syHcwB4XdWu6Jg01VhQY0ihkEYUSGn0QAzZmSgeXMrRozQ4ORJOVq10mPWLHtPMf5MJyIiyn8y4z93Ugx32QtqWJOd9lt9qsMcGGUvqOEfyoIaRRyDMCIv0batDXv3puO11zQ4dEiB4cO12LfPgvfeY08xIiKiPGdLhyrhgL18fPxuKNLPOu0Wlf4wB0TamyUHRELUlHbTQMkTMQgj8iKlS0tYt86IhQtVmDNHhW+/vdtTrH599hQjIiLKMUmCPPX3uwU1bh+GIGbc3S3IYfVr6KhiaDXUBQS5GwdMnoxBGJGXkcuBUaPMCA+3YvBgLf75R4Znn9Vh3Dgzhg5lTzEiIqLsEszxUCXsc6x2yTP+ddpv05RzBF2WgOaQlMXcM1AqdBiEEXmphg1FR0+xDRuUmD7d3lNs8WL2FCMiIrov0QpF8s/2ghq3dkGR/Ms9BTW0sPiHwVw86k5BjaosqEE5wiCMyIv5+QEffni3p1hcnAItWth7ikVFsacYERGRzHQFqltZC2rcdtpv1Ve7E3S1gqVYU0Cucc9AyaswCCPycoIA9Op1t6fY6dNy9OypQ3S0GRMnsqcYEREVMVYjFDd3Qn1jp72gRtqfTrtFRTGYAyPvlI+PhKgp46aBkjdjEEZURFStKmLr1nRMn67Ghx+qEBurwqFDcnz4oRFVqjA9kYiIvJQkQZ72B1Txu6FO2A0kHIRv1oIakMHq1+BuQQ2/+iyoQfmOQRhREaLRANOnZyAiworhwzU4dUqOqCg9Zs40oXt39hQjIiLvIFgSoUzYdyfNcDfkGVed9ouaMsgIaHWnfHxzSEp/N42UiioGYURFUJs2NuzbZ+8pdvCgAiNG3O0pZjC4e3RERESPSbJBkfSzo1myIulnCLjbmkWSaWDxD4O1RGvoKj+LJFt5WG3MAiH3YRBGVEQ98YSEr782IiZGhVmzVPjuOyV+/lmOZcuMaNCAPcWIiMizyUxX7f264ndDFb/3PgU1nrpbPt4/DJBroVDIoPPTA4lpABiEkfswCCMqwuRyYMQIM8LCXHuKDRvGnmJERORBbCYobx9ypBgq0s447RYVxWAJaGEPvIq3gqgp66aBEj0agzAiQoMGd3uKrV+vxLvv3u0p9sQT/EshERG5gSRBnvaXvWdX/G4oEw9CEE13d0OA1a/+ndWuKFgN9QEZ39pS4cDvVCICABgMQGysCS1bWjF+vAYHDth7ii1caEKbNuwpRkRE+U+w3IYyYb8j8JKbrjjtt6lL29MLA6NgDmwBSRngppES5Q6DMCJyEASgRw8rGjZMw6BBWpw6JUfv3joMHGjGpEnsKUZERHlMskGR/MvdFMPknyBId//wJ8nUsBRrCnNgFMzFW8GmrwaW8iVvwCCMiFxUqSI5eorFxqrw0UcqHD4sx4cfmlC1Kot2EBFRzslM/94pprELqoS9kFkSnfZb9cF3VrtawewfDsh1bhopUf5hEEZE96VWA9Om3e0pdvq0HK1b6/Duuxno2dPCP0QSEVH22ExQ3j5yt3x86u9Ou0WFHywBzR2VDEVteTcNlKjgMAgjoodq3fpuT7EDBxQYNUqD/fvleO89E/z83D06IiLyOJIEefo5qOJ3QnlrN1SJByGIxru7IcBqqHsnxTAKVkMDFtSgIoff8UT0SKVKOfcUW79eiV9+kWPpUiMaNmR6IhFRUSdYku4U1Nh9p6DGP077baonYCluX+kyB7SEpAp000iJPAODMCLKFpkMGD7c3lMsOtreU6xTJx3GjjVj+HAz5HJ3j5CIiAqMJEKRfNwRdCmSfnAuqCGoYPFv6kgxtPlUZ0ENoiwYhBHRY6lf395TbOxYDb79VomZM9U4cMDeU6x0afYUIyLyVrKM/+4U1NgNVfxeyCzxTvutuip3y8cHhANyvZtGSuT5GIQR0WMzGIClS01o0cKKceM0OHhQgZYtdViwwIS2bdlTjIjIK4gZUN4+CtUte88uReop591yX3tBjeJRdwpqVHDTQIkKHwZhRJQjggB07363p9hvv8nRp48OAwbYe4ppNO4eIRERPRZJgjz9PJR3GiWrEg5AENOdDrH41oW5uH21y+LXEJAp3TRYosKNQRgR5UrlyhK2bEnHu++qsWyZCh9/fLenWHAwi3YQEXkywZoMZULc3YIaxktO+0VVScd9XebASEiq4u4ZKJGXYRDmRRQ3tgOJyZCjLGzqypCUgbwJlgqEWg1MnZqB5s2tGDZMg99/v9tTrFcv9hQjIvIYkghFygmo4ndDeWs3lEnHIEjWu7sFJSzFQu1BV/Eo2Hxq8L0EUT7wuCDs/PnzmD59Oo4fPw69Xo/nnnsOI0eOhEqlyvY1Vq5ciZkzZ6JFixaIjY11bD927Bheeukll+Pbt2+P+fPn58n43UXIuAHfn7sAAAx3tokKP9h0QbDpqsCmq5zl38qQlMXcNlbyXq1a2bB3bzqGDtVg/34FRo/WYN8+OebOZU8xIiJ3ETJuOFa6VPF7ILPcctpv1QbdKR8fBbN/M0Dh46aREhUdHhWEJSUloW/fvqhYsSIWLVqE69evY9asWTCZTJg0aVK2rnHz5k0sXrwYgYEP7j8xc+ZMBAUFOT739/fP9djdTVKVgLHqJGiTD8GW9BdkpiuQWZMgSz4OZfJxl+NFZXFHQGbTV4HVEaQFsZoR5UqpUhK++sqIJUuUmDFDje+/V+L4cXtPsUaNmJ5IRJTvRDOUt49BFb8LyvjdUKacdN4t97EX1LiTZijqKrlpoERFl0cFYWvWrEFaWhpiYmJQrFgxAIDNZsOUKVMQHR2NUqVKPfIa7733HiIjI3Ht2rUHHlO1alXUrFkzr4btGQQBpipjofXXIzkxDdaMNMiNFyFPPw952jn7v+nnIU8/B7n5OmSWW5Al3YIy6ZjLpWzq0vddPbPpKgEytRueHBU2MhkwdKgFTZvaMHiwFpcuyfDcczq88YYZI0awpxgRUV6TpZ+3r3Td2g1l4gHIbKlO+y2+dWC5E3RZijUCZNnPMCKivOdRQVhcXBxCQ0MdARgAtGvXDu+88w4OHTqEzp07P/T8n376Cbt27cK2bdswZsyYfB6th5NrYfN5Gjafp112CdYUyNMv2AOyzMDsTpAmsyRAnvEv5Bn/AokHnM6TIIOoKWdPcdTfDdKsusoQNRUAmUd9O5EHqFdPxO7d9p5i33yjxKxZasTFybFkiQlPPsmeYkREOSVYU6BMOADVnUqGcuNFp/2iqgTMgZH21a6ASEjqkm4aKRHdj0e9a75w4QK6dOnitM1gMKBEiRK4cOHCQ8+12WyYNm0aBg8ejJIlH/6DZtCgQbh9+zZKlCiBDh06YMSIEdAUoXraksIXVkNtWA21XfYJloT7rJ7dCdBsKZCb/obc9DeQsNf5moICNm3FLKtmd4M0UVMGEGQF9fTIw/j62nuKtWxpxdixGhw+rEDLlnp88IEJ7dpZH30BIiK6U1DjN0ezZOXtoxAky93dggKWYk0czZKtvjX5u5fIg3lUEJacnAyDweCy3c/PD0lJSQ89d/Xq1TAajXj55ZcfeIyvry8GDBiAhg0bQq1W4+jRo1ixYgUuXLjgVMAjJxQK9/+gk8tlTv/miKI4oC0OW2BjOLXclSQI5huQp52DLM2+eiZLOwdZ+nnI085DEE1QpJ+DIv2cyyUlmQairhJs+ioQdVVg01eGqK8Cm64KJHUpVl16iDyZUw/Rs6eIxo2NGDhQjV9/laNvXy0GDLBgyhQztFp3j65gedO8kh3n1Du5e16FjBtQ3toDxa1dUN7aDZn5ptN+m7YSLCWiYC0eBUtgBKDwdezzqDd4HsTdc0p5r7DOqVe8RuPj47Fw4ULMnj37oVUUn376aTz99N30vNDQUJQsWRJTp07FyZMnUatWrRw9vkwmwN/fc4pZGAz59Y7WB0CQ62ZJBNKvAil/ASln7R/JfwGpZ4HUCxBEE+SpZyBPPeN6rsIH8K165yPY/q/hzr/qBxdXKWryb04LVoMGwLFjwFtvAe+/D3z8sRLHjimxZg3wtGvmrNfzlnmluzin3qnA5lW0ADcPA/9ut38k/uK8X6EHSkUCpdsCpdtC7lsFvMU2Z/ha9T6FbU49KggzGAxISUlx2Z6UlAS/h9S3XrBgAUJCQtCgQQMkJycDAKxWK6xWK5KTk6HT6aBQ3P+ptmvXDlOnTsWpU6dyHISJooTk5PRHH5jP5HIZDAYtkpONsNkKugpdAKBuYv/I2sdRtEJm/OfOitlZx8qZLO0cZMZ/IFhTgcTj9o97iEr/uytnd6o4infuRYPSdcXUG7l3TvPPhAlA48ZyvPaaGr/9JqBBAwnvvmtG377WIrEw6q3zWpRxTr1TQcyrLP0iFDftK13K+P0QbM7vg6y+tWAtEQVL8Vaw+ofeLahhBZCYli9j8mZ8rXofT5tTg0GbrVU5jwrCgoKCXO79SklJwc2bN51Kyt/r4sWL+PHHH9GwYUOXfQ0bNsRHH32EiIiIPB9vVlar+yc9k80metB4ZIC6ov3Dv5XzLjEDcuPfWe4/y3IfWsZVyCyJkCX9CEXSjy5XFVUlYdNVhtWlimMQIC9cfwnJDs+a07zRvLmIPXvszZ337VNg9Gg19uyRYd48E7LU5vFq3jivRR3n1Dvl6bxaU6FKPHCnWfIuKIzO73tEZeDdghqBrexp+46dAER+f+UFvla9T2GbU48KwiIiIrBs2TKne8O2bdsGmUyGsLCwB543YcIExwpYphkzZkCj0WD06NEICQl54LmbN28GAO8rWV8YyNSw6YNh0we77rOl36ngeDc4U9z5V2a+CZn5BmTmG1DePuJ6qqasPSDTVnaq4mjTVmBJXg9TqpSENWuMWLrU3lNs06bMnmImNGlie/QFiIg8nSRBnnoKqlu77hTUOOJaUMOvESzFo2AObAWrb20W1CAqAjwqCOvevTtWrVqFIUOGIDo6GtevX8ecOXPQvXt3px5hffv2xbVr17Bz504AQLVq1VyuZTAYoNPp0LhxY8e2119/HRUqVMDTTz/tKMyxcuVKREVFMQjzNHIdbL41YPOt4bJLsCQ59z3LWsHRehty0xXITVcA7Hc6T4IMora8o6x+1h5oorY8IDCz3h1kMmDIEAvCwmyIjtbi4kUZnn9ei9dfN2PUKPYUI6LCRzDfgip+jz3oit8Dufm6036bpgLMd4IuS0AEJEXRSLEnors8Kgjz8/PDp59+imnTpmHIkCHQ6/Xo2rUrRo0a5XScKIqw2R7/r+RVq1bFxo0bsWLFClgsFpQpUwaDBw/GoEGD8uopUAGQlH6w+tWD1a/ePTukOyX2z7kEZ4r08xBsaZAbL0FuvARV/C7nUwUVbLqKrqtnusoQ1aX5V8kCUKeOvafYm29q8PXXSsyZo8aBA/ZVMfYUIyKPJlqgTPoRyjs9uxTJv0LA3Z9bkkwHc0CzO+XjW8Gmq8LKwERFnCBJEt/d5JLNJiIhwf03xyoUMvj765GYmFaocmILhCRBlvHffVbPzkFuvAhBzHjwqTKtU/8za+b/9VUgKYvn6y/SojqnX3+twNixGqSlCfD3lzB/vgnt23tPT7GiOq/ejHPqnR42rzLj31Bl9uxK2A+Z1fm2CKtPDft9XcWjYCnWBJCpC3Lo9AB8rXofT5vTgAB94SvMQZRvBAGipjRETWlYAsKd90k2yExXswRnWYI04yUIohGK1FNQpJ5yuayoMNxZPbu3SXVlSEr/Anpy3ueFF6yoXz8Ngwdr8euvcrz8shYvv2zGlCkZRa6nGBF5CFsaVAkH76523dMXU1QGwBzQ0h50BbaCqH7CTQMlosKAK2F5gCthXky02Cs43u/+M9Nlp3QTl1OVgS6BmVVfBTZtkL0/WjYU9Tk1m4GZM9VYvNheUKVaNRtiY0146qnC/bUo6vPqjTinXkYSIVhvQ2W+CkP6IVgub4Ei4TAEyXz3EEEOq19DmAPvFNQw1OG9xYUAX6vex9PmlCthRHlBprTfI6avAqCt8z6bCXLjRdcALe0c5Ob/ILPEQ5YUD2XSDy6XtalLO6U4Ov6vrQTINQXz3AoBlQp4550MRERYMXSoBmfOyNGmjQ5Tp2agb18Lb6kgouwRzZCZ4yFY4iEz34LMcguCOR4yyy3IzLcgWBLs2zP3WRIgSHfvPVfe+demKe8oHW8JiICkLOaWp0NEhR9XwvIAV8LIhTUVcuMFKO7TA01miX/gaRIEiJpyd1MafapCV6oGkqQyMCvLATLlA8/1djduCBg+XIM9e+x/O+rQwYJ580zwL4RZn3yteh/OaQGSJAi21LsBlfnWnf/H3w2u7gRTjgDLmpSjhxIVfpCVaIr0Yi1g8o9iQQ0vwNeq9/G0Oc3uShiDsDzAIIweh2BJvM/q2XnIjeddbuzOShIUsGkruK6e6apA1JQtEhUcRRGIjVVi+nQ1LBYBZcqIhbKnGF+r3odzmguSCMGS+IAVqqyBVsLdYx5STOmBDwMZJGUARFVxiKrikJSB9v8rAyGpAiEqi9/ZFwhJaf9XodJyXr0MX6vex9PmlOmIRB5KUvrD6tcAVr8G9+yQIFhu2dMZ7zSnVhjPQ5VxEVLyWXuBkDvl9oEdzqfK1LBpK2UJzrL0QFM/4TV/uZXJgFdftaBpUxsGDbrbU2zMGHtPMQV/ohG5n5hxzwpVluAq62qVI9BKhIDHf+MkyTR3gqjikFQBjiDKEVzdG2gp/YvEH6uIqHDgWxYiTyEIkFQlYFWVgNU/FBmw/3VH5a/H7YQUiGlXXe89M56HPN1eYl+R9gcUaX+4XFaS67M0pw7KEqRVgaQMKJQBWu3a9p5i48dr8NVXSrz3nr2n2JIlJpQty8V9ojwjSRCsyVmCqfj7rFDd3SeY4yGzpeTooURFMYjKAEh3Aih7cJW5QhXoFFyJykBAri+UP7+IiAAGYUSFgyCDqCkDUVMGloDmzvtEK2Smy04pjoo7/5cZ/4FgS4My5SSUKSddLisqit2/QIiuMiSlXwE9uZzx8QEWLTKheXMrxo7V4OhRBSIj9Zg3z4SOHb2npxhRnhKtEKyJWQKoW/bVKadUwHin+6yyVgTMLkmQZ1mFcg2isu6zB1qBRfqeVyIqehiEERV2MgVEXSWIukqwIMp5n2i+U2L/3D2rZ+chN12BzHobsuSfoUz+2eWyoqqEc3NqR5AWBMh1BfTkHq1r17s9xY4fl+OVV7To29eMqVPZU4yKAJvxvvdSPagSoGC5/dDWGg8iyXRZ7pfKGlzdm/5nv+dKUhTjKhUR0UMwCCPyZjIVbPqqsOmruu6zpUOefvGeFTT7vzLzDcjMNyEz34Ty9hHXU9VlXFfP9FVg01YEZKr8f173qFRJwsaN6Zg9W4VFi9T49FMVjh2TIzbWhGrV3H+TLlG2SBIE622XkulZgymnSoDmWxDE9Bw9lKj0vyfdzzmIujcV0JP+8EJE5A0YhBEVVXIdbL7VYfOt7rJLsCbf594z+/9l1tuQZ1yFPOMqkBjndJ4EGURt+bvNqbMWCNGUB2T59yNHpQLeftuMZs1sGDpUgz/+kKNtWx2mTMnAyy+zpxi5gWi5e5/Ufav93S1UkRl4CdLjp9JKgtKlCMUDC1SoikNS+Ofra5GIiB6NJerzAEvUU37xxDkVzPGuJfYze6DZUh94niQoYdNWdF0901WGqH4yT6uW3bxp7ym2e7f9jWa7dhZ88IHn9BTzxHmlR5AkwJbmuF/q3iBKbo2HWroNa9p1IOMmZJYEyKy3c/RQotzXcZ+UqCpuL1Rxn3uoMoMrSWFg6l8+4WvV+3BOvY+nzSlL1BNRvpBUgbCqAmEt1uieHRJk5uv3XT2TGy/YKzimn4Ui/azrNWXaeyo33l1Jk1QlHvsNZokSEr74woiPPlJi6lQ1tm5V4sQJOZYuNSE0tHD1FKN8ktmb6qHV/u4pVCGaHnnZe3+pShAemOLnFFxlrlYpAwG5Jn+eMxEReQwGYUSUNwQBovoJiOonYPEPc94niZCZspbYz7KKZrxk74GWehqK1NMulxXlvs7l9fVVslRwDHjgcGQyIDragtBQG6KjtTh/Xob//U+LUaPMGDOGPcW8jphxpxjFo6r9ZUn9y1FvKnWWghR3G/8K6hLQFnsSqVZfWOVZV6qKAYI8758vEREVanwbQkT5T5BB1JaDqC0HS2BL532iFTLT346y+o7Vs/QLkJn+gcyWAlnKcShTjrtcVlQG3Ke8vr2iIxQ+AIBatUTs3JmGt97S4MsvlZg7195TbOlSE8qVYza2R5IkCLYUCFn7UmUJplyb/SZAZk3O0UOJCj97I98sBSqce1PZ/81cyXpQbyqFQgatvx4WD0mHISIiz8YgjIjcS6aAqKsMs64ygDbO+2wmyI2Xstx3lmUlLeNf+303SQlQJv3oclmb6glHYKbVV8HStyrj+ZbBGPLm0/jhB52jp9izz7KnWL6TbHeq/WWuSN1y3Et1N9ByXq3KVW+q+5RMt6cCFr/nPqsAt1TzJCIiYhBGRJ5LroHN5ynYfJ5y3WdLgzz9AuTp5+yraGl3UxxllluQm/+D3PwfcPuQ45QX9cALMQL+Sy6HU38H4+yBqthxsRJad64IhX/lOyX22TD2kWymu6tQWVerXKr9ZW5PzEVvqsC791JlXa3KskJlr/wXeKc3Vd4VeCEiIsovDMKIqHCS62HzrQmbb03cu2YiWG7ff/Us/QJk1iSUNvyD0jX/Qeuau+wnnLH/Iwly2DQVXO49s+mqQNSU9c57eyQJgjXJJYhyTgXMslpluQXBlrNqsKKimEu1P0cwdZ9KgOxNRURE3opBGBF5HUlZDFa/+rD61b9nhwTBEu8IzK79cR5nf76Icv7nUPWJs9Cr06EwXoDCeAGI3+l8qqDKUsHR+T40UV3ac0qEi1Z7MOVUhCJr+l+8S3CV495UyjsV/u4EUa7V/orfXclSBrA3FRER0R38jUhERYcgQFIVh1VVHNZiTRD4JCDVsvcU27VLjif9r6FXpzMYPeB3GISsq2gXIUhmKNL+gCLtD5fLSnI9bNogWO9ZPbNXcAzMXYBmS3twtT+nVMA7gVaOe1P5OO6Tcgmg7gRVWfexNxUREVHOMQgjoiKtePGsPcWexHuflsHnOyKxZIkJYWF3eopJNshMl++mON65/0yRfg4y0z8QbGlQpP4GRepvLtcXFcVceqDBtzJgUUCZcAUK4837pP9l7U1lfOzndLc3VeA9BSkyV6uyVv4rzt5UREREBYxBGBEVeYIADBqU2VNMg3Pn5Ojc2d5T7PXXzVAo5BC1FSFqK8IS2Mr5ZNEMufFv595nmR+my5BZb0OW/AuUyb+4PK5PNscnCSrnhr4uwVXxe4Irf++8f42IiMhLMAgjIrqjZk0RO3em46231Fi9WoV589Q4cECBZcuMD+4pJlPBpq8Km76q6z6bEXLjRafVM3n6OSiMlyBTamFVBMKmCLhPsYpAxwqVpCoOSe7D1D8iIiIvwiCMiCgLvR744IMMtGhhw5gxGvz4oxwtW9p7inXq9JgFLORa2Hyehs3naafNCoUM/v56pLCxLxERUZHEhipERPfx/PNW7NmThvr1bUhOFjBggBZjxqiRlrPq7EREREQODMKIiB6gQgUJ33+fjpEjMyAIElatUqFNGx1OneKPTiIiIso5vpMgInoIpRKYMMGMdeuMKFVKxNmzcrRrp8Py5UpID7hNjIiIiOhhGIQREWVDs2Y27NuXjjZtrMjIEDB+vAYvvaRFfDwLZhAREdHjYRBGRJRNgYESVq0yYsYME1QqCdu3K9CypQ4HD7IcPBEREWUfgzAioscgCMCAARZs25aOqlVt+O8/Gbp00WLmTBUsFnePjoiIiAoDBmFERDlQo4aIHTvS0bu3GZIkYP58NZ57Tod//mF6IhERET0cgzAiohzS64F58zLw0UdGGAwSfvpJjshIPdavZwtGIiIiejAGYUREufTcc/aeYg0a2HuKDRqkxahR7ClGRERE98cgjIgoD5Qvb+8pNnq0vafYF1+o0Lq1Dr/9xh+zRERE5IzvDoiI8ohCAYwbZ8Y33xjxxBMizp2z9xT76CP2FCMiIqK7GIQREeWx8HAb9u5NxzPPWGA2C3jrLQ1699bi1i0W7SAiIiIGYURE+SIwUMKnn5owc6YJarWEnTvtPcUOHGBPMSIioqKOQRgRUT4RBKB/f3tPseBgG65fl6FrVy2mTVOypxgREVERxiCMiCifVa9u7ynWp09mTzEVGjYEjh7lj2AiIqKiiO8AiIgKgE4HzJ2bgeXLjShWTMKJE0D79loMHarBjRu8V4yIiKgoYRBGRFSAnn3Wih9/TMeAAYAgSFi7VonQUD0++kgJq9XdoyMiIqKCwCCMiKiABQYCH30E7NhhQp06NqSk2CsoRkXpcPQoC3cQERF5OwZhRERuUr++iK1b0/Heeyb4+0v4/Xc5OnXS4bXXNLh+nSmKRERE3opBGBGRG8nlQN++Fhw5koo+fcwQBAnr1tlTFGNjmaJIRETkjRiEERF5gIAAe+GObdvSUbeuDampAt5+W4NWrXQ4coQpikRERN6EQRgRkQepW9eeojhvngkBASLOnJHjued0GDxYg//+Y4oiERGRN2AQRkTkYWQyoHdvCw4fTkPfvvYUxW+/tacoLlnCRs9ERESFHYMwIiIPFRAAvPdeBrZvT0f9+jakpQmYPFmDyEgdDh1iiiIREVFhxSCMiMjD1akjYvPmdMyfb0JgoIg//5Tjf//TITpag3//ZYoiERFRYcMgjIioEJDJgF697CmK/frZUxS/+06Jpk31WLyYKYpERESFCYMwIqJCxN8fmD07Azt33k1RnDJFg5YtdThwgCmKREREhQGDMCKiQqhWLXuK4oIFRhQvLuKvv+To0kWHQYM0uHaNKYpERESezOOCsPPnz6Nfv36oU6cOwsLCMGfOHJjN5se6xsqVKxESEoLo6GiXfdevX8ewYcNQt25dNGrUCG+99RZSU1PzavhERAVGJgN69LDi8OE09O9vhkwmYf16e4riokUqPOaPTiIiIiogHhWEJSUloW/fvrBYLFi0aBFGjRqFtWvXYtasWdm+xs2bN7F48WIEBga67LNYLBgwYAAuXbqEuXPnYvLkyTh48CDGjBmTl0+DiKhAFSsGzJxpT1Fs2NCG9HQB06ap0bKlDvv3M0WRiIjI0yjcPYCs1qxZg7S0NMTExKBYsWIAAJvNhilTpiA6OhqlSpV65DXee+89REZG4tq1ay77tm/fjrNnz2LLli0ICgoCABgMBvTv3x8nT55ErVq18vT5EBEVpJo1RWzcmI61axWYOlWNs2fleOEFHTp1smDKlAyUKSO5e4hEREQED1sJi4uLQ2hoqCMAA4B27dpBFEUcOnTokef/9NNP2LVr1wNXtuLi4hASEuIIwAAgLCwMxYoVw/79+3M9fiIid5PJgO7drThyJA0DB9pTFL//XomwMD0WLmSKIhERkSfwqCDswoULTgESYF+pKlGiBC5cuPDQc202G6ZNm4bBgwejZMmS2b6+IAioVKnSI69PRFSY+PkB776bgV270tG4sRXp6QKmT1ejeXM99u5liiIREZE7eVQ6YnJyMgwGg8t2Pz8/JCUlPfTc1atXw2g04uWXX37o9X19fXN0/UdRKNwfz8rlMqd/qfDjnHqngpzXOnWALVsysHatDe+8o8T58zJ066ZDx45WzJhhRtmyTFHMC3yteifOq/fhnHqfwjqnHhWE5VR8fDwWLlyI2bNnQ6VSFfjjy2QC/P31Bf64D2IwaN09BMpjnFPvVJDzOngw0KMHMHkysGgRsGmTArt3KzBxIjBmDKBWF9hQvBpfq96J8+p9OKfep7DNqUcFYQaDASkpKS7bk5KS4Ofn98DzFixYgJCQEDRo0ADJyckAAKvVCqvViuTkZOh0OigUChgMhvuWo09KSkLp0qVzPG5RlJCcnJ7j8/OKXC6DwaBFcrIRNpvo7uFQHuCceid3zuukSUDXrgLeeEONI0fkeOstYMUKETNnmhEVZSvQsXgTvla9E+fV+3BOvY+nzanBoM3WqpxHBWFBQUEu92alpKTg5s2bLvdyZXXx4kX8+OOPaNiwocu+hg0b4qOPPkJERASCgoLw119/Oe2XJAkXL15EWFhYrsZutbp/0jPZbKJHjYdyj3Pqndw1r8HBwPr16fjmGwUmT1bj/HkZXnxRg/btLZg2LQPlyjFFMaf4WvVOnFfvwzn1PoVtTj0qCIuIiMCyZcuc7g3btm0bZDLZQ4OkCRMmOFbAMs2YMQMajQajR49GSEiI4/rff/89Ll26hIoVKwIAjhw5gtu3b6N58+b586SIiDyQIABdu1rRtq0Vc+ao8fHHSmzZosTevQqMGGHGa6+ZodG4e5RERETeSZAkyWP+5JmUlIQOHTqgUqVKiI6OxvXr1zFr1iw8++yzmDRpkuO4vn374tq1a9i5c+cDr9WnTx/odDrExsY6tlksFnTu3BkAMHr0aBiNRsyZMwchISFOxz0um01EQkJajs/PKwqFDP7+eiQmphWqvwTQg3FOvZMnzuuZMzKMH6/G4cP2v81VqiRixgwTWrViimJ2eOKcUu5xXr0P59T7eNqcBgTos5WO6FFlRPz8/PDpp59CLpdjyJAhmDt3Lrp27Ypx48Y5HSeKImy2x39joFQq8fHHH6NixYoYPXo03nnnHTRt2hRz587Nq6dARFQoVasm4rvvjFi2zIhSpURcvChDjx46vPSSBv/8I7h7eERERF4lVyth165dw7Vr19CgQQPHtj/++AMrVqyA2WxGx44dERUVlScD9WRcCaP8wjn1Tp4+rykpwPvvq/HRR0pYrQI0GgnDh5sxdChTFB/E0+eUcobz6n04p97H0+a0QFbCpk+fjpiYGMfnt27dwksvvYSdO3fip59+wrBhw7Bjx47cPAQRERUwX19gypQM7N2bjvBwK0wmAXPmqNGsmR47d7LRMxERUW7lKgg7efIkmjZt6vh8/fr1MJlM2LBhA+Li4hAaGooVK1bkepBERFTwQkJEfPONER9+aMQTT4j4+28ZevXSoU8fLS5dYooiERFRTuUqCEtKSkJgYKDj83379qFhw4YoX748ZDIZWrdu7VJynoiICg9BAJ5/3orDh9MwZIgZCoWE7dsVaNZMjzlzVDAa3T1CIiKiwidXQVhAQACuXbsGAEhOTsavv/6KZs2aOfbbbDZYrdbcjZCIiNzOxwd4550M7NuXjmbNrMjIEPD++/YUxe3bmaJIRET0OHLVJ6xp06ZYtWoVfHx8cOzYMUiShFatWjn2nzt3DqVLl871IImIyDMEB4tYt86IjRsVePttNf75R4Y+fXRo3dqK6dNNqFTJY7qeEBEReaxcrYSNGTMGQUFBmD17Ng4dOoSxY8eiXLlyAACz2YytW7ciNDQ0TwZKRESeQRCATp2sOHQoDcOGZUCplLBzpwIREXrMmqVCerq7R0hEROTZ8qRZc0pKCtRqNVQqlWObyWTCpUuX8MQTT6BYsWK5fQiPxhL1lF84p97J2+b17Fl7o+e4OHtyRfnyIqZNy8Azz1ghFJH6Hd42p2THefU+nFPv42lzWqDNmn19fZ0CMADQaDR46qmnvD4AIyIq6qpWFfH110YsX25EmTIi/vlHhr59tejZU4sLF4pIFEZERPQYchWEHTlyBB9//LHTtnXr1qFFixZo2rQpZsyYAZvNlqsBEhGR5xME4NlnrTh4MA0jRthTFHfvZooiERHR/eQqCFu0aBH++OMPx+d//vkn3nnnHQQEBKBRo0ZYtWoVli9fnutBEhFR4aDXA2+9ZUZcXBpatLDCbBYwb569iuLmzQrkPgGeiIio8MtVEHb+/HnUqFHD8fmGDRvg4+ODL774Ah988AFeeOEFbNiwIdeDJCKiwqVyZQlffWXEihVGlC0r4vJlGfr106J7d6YoEhER5SoIMxqN8PHxcXx+4MABhIeHQ6vVAgBq1qzp6CNGRERFiyAAHTvaUxRHjcqASiVh7157iuKMGSqkub+eERERkVvkKggrXbo0fvvtNwDA33//jbNnzyI8PNyxPykpyaVgBxERFS06HTB+vD1FsVUre4riBx+oER6ux8aNTFEkIqKiJ1fNmp999lksXrwY169fx7lz5+Dn5+fUrPn06dOoWLFibsdIREReIChIwurVRmzbpsDEiWpcvixD//5aNG9uxcyZJlSpwmiMiIiKhlythA0ePBiDBg3Cf//9h9KlS2Px4sUwGAwAgNu3b+OHH35AZGRkngyUiIgKP0EA2rWz4sCBNIwenQG1WsL+/Qo0b67H9OlMUSQioqIhT5o1F3Vs1kz5hXPqnTivd124IGDiRA127bInZjz5pIipUzPw7LOFq9Ez59Q7cV69D+fU+3janBZos2YASEtLw/nz53H+/Hmk8U+ZRESUDUFBEr74wojPPktH+fIirl2TYcAALV54QYuzZ/PsVxQREZFHyfVvuJMnT6JPnz5o1KgROnbsiI4dO6JRo0Z46aWXHEU7iIiIHkQQgGeeseHAgTSMGWNPUYyLU6BFCx2mTlUhNdXdIyQiIspbuUpHPHHiBPr06QOlUomOHTuicuXKAOz9wzZv3gyLxYJVq1ahVq1aeTZgT8R0RMovnFPvxHl9uIsXBbz9tgY7dthTFEuXtqcodurkuSmKnFPvxHn1PpxT7+Npc5rddMRcBWEvv/wyrl69itWrV6NEiRJO+27duoUePXqgbNmy+OSTT3L6EIUCgzDKL5xT78R5zZ4dO+R46y0N/v7b/susWTMrZs7MQHCw533NOKfeifPqfTin3sfT5rRA7gk7ceIEunXr5hKAAUDx4sXx4osv4tdff83NQxARURHVpo09RXHs2AxoNBIOHLCnKE6erGaKIhERFWq5CsJkMhlsNtsD94uiCJmMN1YTEVHOaDTA66+bceBAGp55xgKrVcCSJSo0barHd9+x0TMRERVOuYqQ6tatiy+++AJXr1512Xft2jWsXr0a9erVy81DEBERoUIFCZ99ZsLq1emoWFHEf//JEB2tRZcuWvzxB//YR0REhYsiNyePHj0avXr1Qrt27dC6dWtUrFgRAHDx4kXs3r0bMpkMY8aMyYtxEhERISrKhvDwNCxZosKCBSocPKhAZKQcAwZY8MYbGfD1dfcIiYiIHi3XzZrPnTuH+fPn4/DhwzAajQAArVaLsLAwDB06FP7+/ihVqlSeDNZTsTAH5RfOqXfivOaNf/4R8PbbamzdqgQAlCol4p13MtClS8FXUeSceifOq/fhnHofT5vTAqmOmJUoikhISLjz4AGQyWRYunQpFi5ciDNnzuTFQ3gsBmGUXzin3onzmrf27JFj/HgNLl60/9ILDbVi1qwMVKtWcF9bzql34rx6H86p9/G0OS2Q6ohOF5LJULx4cRQvXpzFOIiIqMBERtoQF5eG8eMzoNVKOHJEgchIHd5+W43kZHePjoiIyBWjJSIiKvTUamDUKDMOHkxDhw4W2GwCYmNVCA3V4+uvWUWRiIg8C4MwIiLyGuXKSfjkExPWrElHUJCImzdlGDJEi+ee0+L0af7KIyIiz8DfSERE5HUiI23Yvz8Nb72VAZ1OwtGjCkRF6TBxIlMUiYjI/R67RP3p06ezfeyNGzce9/JERER5Qq0GRowwo0sXC955R42NG5X48EMVvvtOgUmTMvDiiwVfRZGIiAjIQRDWpUsXCNn8rSVJUraPJSIiyg9ly0pYvtyEffssmDBBjXPn5Bg2TItVq+xVFGvUcH81LSIiKloeOwibOXNmfoyDiIgoX7VoYcO+felYtkyFefNU+OEHBaKi5HjlFQvefDMDfn7uHiERERUVedYnrChjnzDKL5xT78R5db9r1wS8844aGzbYGz0XLy46UhRz0mWFc+qdOK/eh3PqfTxtTgu8TxgREVFh8eSTEj76yIR169JRtaoNt27JMHy4Fh076vDbb/zVSERE+Yu/aYiIqMiKiLBh7950TJpkgk4n4aef5GjdWodx49S4fdvdoyMiIm/FIIyIiIo0lQoYOtSCI0fS8L//WSCKAlasUKFpUz1Wr1ZAdH92CxEReRkGYURERABKl5YQG2vCt9+mIyTEnqI4cqQWHTrocPIkf10SEVHe4W8VIiKiLMLDbdizJx2TJ5ug10v4+Wd7iuLYsWokJrp7dERE5A0YhBEREd1DqQRee82eoti5swWSJGDlShVCQ/X4/HMlUxSJiChXGIQRERE9wBNPSFi2zITvvkvHU0/ZkJAgw+jRGrRvr8Ovv/JXKBER5Qx/gxARET1CWJgNu3enY+pUE3x8JPzyixxt2+rw+utqJCS4e3RERFTYMAgjIiLKBqUSGDzYnqLYtas9RfGzz1QIDfXBypUK2GzuHiERERUWDMKIiIgeQ6lSEpYsMWHDhnRUq2ZDYqKA0aPVaNIE+OUX/lolIqJH428LIiKiHAgNtacoTp9ugq+vhJ9+Alq31mDMGDXi4wV3D4+IiDwYgzAiIqIcUiiAQYMs+OEHI/r0ASRJwKpV9kbPK1cqmaJIRET3xSCMiIgol0qVkvDZZ8CWLUY8/bQ9RXHsWA2eeUaHn3/mr1oiInLG3wxERER5pEkTEbt2pWPGDHuK4okTcrRrp8eoUWrcusUURSIismMQRkRElIcUCmDAAHsVxW7dLACAL76wpyiuWMEURSIiYhBGRESUL0qWlLBokQmbNqWhRg0bbt8WMG6cBm3b6vDjj/z1S0RUlPG3ABERUT5q1EjEjh3pmDnTBINBwsmTcnTooMeIERrcvMkURSKiosjjgrDz58+jX79+qFOnDsLCwjBnzhyYzeZHnvf666+jTZs2qFOnDho2bIhevXrh4MGDTsdcuXIFISEhLh8vvvhifj0dIiIiKBRA//72FMUePewpil9+qUTTpnosX84URSKiokbh7gFklZSUhL59+6JixYpYtGgRrl+/jlmzZsFkMmHSpEkPPddiseDll19GxYoVkZGRgXXr1mHQoEH47LPP0KBBA6djR48ejcaNGzs+1+v1+fJ8iIiIsipRQsKCBSb07m3GuHEa/PabHOPHa/DFF0rMmmVCo0aiu4dIREQFwKOCsDVr1iAtLQ0xMTEoVqwYAMBms2HKlCmIjo5GqVKlHnjuggULnD6PiIhAq1atsGHDBpcgrEKFCqhTp05eD5+IiChbGja0pyh+9pkSM2aoceqUHB076tGtmwVvv52BkiUldw+RiIjykUelI8bFxSE0NNQRgAFAu3btIIoiDh069FjXksvl8PX1hcViyeNREhER5Z5cDvTrZ09R7NXLnnb/1Vf2FMWPP1bCanXzAImIKN94VBB24cIFBAUFOW0zGAwoUaIELly48MjzJUmC1WpFYmIili9fjr///hvdunVzOW7y5MmoVq0aQkNDMXHiRNy+fTuvngIREdFjKV5cwvz5Gdi6NQ21a9uQnCxgwgQNoqJ0OHpU7u7hERFRPvCodMTk5GQYDAaX7X5+fkhKSnrk+evWrcPEiRMBADqdDvPnz0fdunUd+1UqFXr06IHw8HAYDAacOHECy5Ytw6lTp/D1119DqVTmeOwKhfvjWblc5vQvFX6cU+/EefU+eTGnjRsDu3aZsGqVAlOnqvD773J06qRDt24WTJ5sQalSTFEsaHyteh/OqfcprHMqSJLkMT/Vq1evjhEjRmDQoEFO2zt27Ii6deti2rRpDz0/ISEBV69eRWJiIrZt24aNGzciJiYGzZs3f+A5+/btQ3R0NObPn4/27dvnaNySJEEQWGaYiIjyxq1bwIQJwMcfA5IEGAzA1KnAkCH2SotERFS4edSPcoPBgJSUFJftSUlJ8PPze+T5AQEBCAgIAGAvzJGUlIT33nvvoUFY8+bNodPpcPr06RwHYaIoITk5PUfn5iW5XAaDQYvkZCNsNlbY8gacU+/EefU+eT2ncjkwezbw4osyjB2rwvHjcowcCXz4oYg5czLQtCm/bwoCX6veh3PqfTxtTg0GbbZW5TwqCAsKCnK59yslJQU3b950uVcsO6pXr464uLi8Gt5DWa3un/RMNpvoUeOh3OOceifOq/fJ6zmtXVvEli1WfPGFEu++q8bvv8vQsaMWXbpYMHlyBlMUCwhfq96Hc+p9CtucelTyZEREBA4fPozk5GTHtm3btkEmkyEsLOyxr/fzzz+jXLlyDz1m7969SE9PR82aNR/7+kRERPlNLgdeesmCI0dS8dJLZgiChG++USI0VI9ly5RgEWAiosLHo1bCunfvjlWrVmHIkCGIjo7G9evXMWfOHHTv3t2pR1jfvn1x7do17Ny5E4D9vq7169ejRYsWKF26NJKSkrBp0yYcPHgQ8+bNc5w3a9YsCIKAOnXqwGAw4OTJk4iNjUWNGjUQFRVV4M+XiIgouwICgPffz0Dv3haMG6fBL7/IMWmSBl9+qcTMmRlo2tTm7iESEVE2eVQQ5ufnh08//RTTpk3DkCFDoNfr0bVrV4waNcrpOFEUYbPd/WVTrlw5mM1mzJ07F4mJifD390dISAhWrVqFRo0aOY6rXLkyvvzyS6xduxYmkwmlSpVC165dMXz4cCh4pzMRERUCdeqI2LIlHatXKzF9ugpnzsjx/PM6dO5sT1F84gmmKBIReTqPqo5YWNlsIhIS0tw9DCgUMvj765GYmFaocmLpwTin3onz6n3cNaeJicDMmWp8+qkSkiRAr5fwxhsZGDjQglx0XaE7+Fr1PpxT7+NpcxoQoM9WYQ6PuieMiIiIss/fH5gzJwM7dqSjfn0b0tIETJ6sQWSkDgcPstEzEZGnYhBGRERUyNWuLWLz5nR88IERgYEi/vxTjs6ddYiO1uDff9nHkojI0zAIIyIi8gIyGdCzpxVHjqThlVfMkMkkfPedEk2b6hETo4TZ7O4REhFRJgZhREREXqRYMWDWrAzs3JmOBg3sKYpTp2rQsqUOcXFMUSQi8gQMwoiIiLxQzZoiNm1Kx8KFRhQvLuLsWTm6dtVh4EANrl1jiiIRkTsxCCMiIvJSMhnQvbs9RXHAAHuK4oYN9hTFhQtVTFEkInITBmFERERezs8PmDHDnqLYqJEV6ekCpk9Xo0ULHfbtY4oiEVFBYxBGRERURNSsKWLjRiMWLbKnKJ47J8eLL+rQv78GV68yRZGIqKAwCCMiIipCBAHo1s2eojhwoD1FceNGJcLC9FiwQIWMDHePkIjI+zEIIyIiKoL8/IB3383A7t3paNzYnqL47rtqtGihx969TFEkIspPDMKIiIiKsOrVRXz/vRGLFxtRooSI8+dl6NZNh379NLhyhSmKRET5gUEYERFREScIwAsv2FMUo6PNkMslbN5sT1H84AOmKBIR5TUGYURERAQAMBiAadPsKYqhoVYYjQJmzFCjeXM99uxhiiIRUV5hEEZEREROnn5axPr1RixdakSpUiIuXJChe3cd+vbV4J9/mKJIRJRbDMKIiIjIhSAAXbpYcfhwGgYPtqcobt2qRHi4HvPmqWAyuXuERESFF4MwIiIieiBfX2Dq1Azs3ZuOsDArTCYBs2apERGhx65dTFEkIsoJBmFERET0SE89JeLbb42IjTXiiSdEXLokQ8+eOrz0kgZ//80URSKix8EgjIiIiLJFEID//c+eovjaa2YoFBK2bVOiWTM93ntPBaPR3SMkIiocGIQRERHRY/HxASZPtqcoNmtmT1F87z17iuKOHUxRJCJ6FAZhRERElCMhISLWrTPiww+NKF1axN9/y9C7tw69e2tx6RJTFImIHoRBGBEREeWYIADPP2/FoUNpGDo0AwqFhB07FGjWTI85c5iiSER0PwzCiIiIKNd8fIBJk8zYvz8dERFWZGQIeP99NZo102P7dqYoEhFlxSCMiIiI8kzVqiK+/tqIjz824sknRfzzjwx9+ujQq5cWFy8yRZGICGAQRkRERHlMEIBOnaw4eDANw4dnQKmUsHOnAhEResyapUJ6urtHSETkXgzCiIiIKF/4+AATJ5qxf38aWrSwpyjOm2dPUdyyRQFJcvcIiYjcg0EYERER5asqVSR89ZURK1YYUaaMiMuXZXj5ZS169tTiwgWmKBJR0cMgjIiIiPKdIAAdO9pTFEeOzIBKJWH3bnuK4syZTFEkoqKFQRgREREVGL0emDDBnqLYsqUVZrOA+fPVCA/XY9MmpigSUdHAIIyIiIgKXOXKEtasMeKTT4woW1bElSsyvPKKFt26aXH+PFMUici7MQgjIiIitxAEoEMHe4ri6NH2FMV9++wpiu++q0JamrtHSESUPxiEERERkVvpdMC4cWbExaWhVSsrLBYBCxbYUxQ3bmSKIhF5HwZhRERE5BGCgiSsXm3Ep58aUb68iKtXZejfX4sXX9Ti3DmmKBKR92AQRkRERB5DEIB27aw4cCANY8ZkQK2WsH+/As2b6zFtmgqpqe4eIRFR7jEIIyIiIo+j1QJvvmlPUWzd2p6iuGiRPUXx+++ZokhEhRuDMCIiIvJYlSpJ+OILI1atSkf58iKuXZNhwAAtunbV4q+/+DaGiAon/vQiIiIij9e2rQ0HDqThjTcyoNFIOHBAgRYtdJgyRc0URSIqdBiEERERUaGg1QJvvGFPUWzb1gqrVcDixSo0barH+vVMUSSiwoNBGBERERUqFStKWLXKiC++SEeFCiL++0+GQYPsKYp//sm3NkTk+fiTioiIiAql1q3tKYpjx95NUWzZUod33mGKIhF5NgZhREREVGhpNMDrr5tx4EAannnGAqtVwNKl9hTFb79liiIReSYGYURERFToVagg4bPPTFi9Oh0VK9pTFAcP1qJzZy3++INvd4jIs/CnEhEREXmNqCgb4uLSMG5cBrRaCYcO2VMUJ01SIyXF3aMjIrJjEEZEREReRaMBRo824+DBNLRvb4HNJmDZMhVCQ/VYt44pikTkfgzCiIiIyCuVKydh5UoT1qxJR6VKIm7ckOG117R4/nktfv+db4GIyH34E4iIiIi8WmSkPUVxwgR7iuKRIwq0aqXD22+rkZzs7tERUVHEIIyIiIi8nloNjBxpxqFDaejY0Z6iGBtrT1Fcu5YpikRUsBiEERERUZFRtqyEFStM+OqrdFSuLOLmTRmGDtWiUyctTp/m2yIiKhj8aUNERERFTsuWNuzbl4aJEzOg00k4dkyBqCgd3npLjaQkd4+OiLwdgzAiIiIqktRqYPhwe4pip072FMWPPrKnKK5Zo4AounuEROStGIQRERFRkVamjISPPzbh66/TUaWKDbduyTB8uBbt22tw4AB4vxgR5TkGYUREREQAmje3Yd++dLz9tj1F8Ycf5IiIAJ55RoOtW7kyRkR5h0EYERER0R0qFTBsmBmHD6ehb18L1Grgxx/l6NtXi2bNdFi9WoGMDHePkogKO48Lws6fP49+/fqhTp06CAsLw5w5c2A2mx953uuvv442bdqgTp06aNiwIXr16oWDBw+6HJeSkoIJEyagUaNGqFu3LoYPH44bN27kx1MhIiKiQurJJyXMn2/GpUvAqFFmGAwSzp6VY+RILRo21CMmRomUFHePkogKK48KwpKSktC3b19YLBYsWrQIo0aNwtq1azFr1qxHnmuxWPDyyy9jyZIlmDNnDooVK4ZBgwbhp59+cjpu5MiROHToECZPnoz3338fFy9exMCBA2G1WvPraREREVEh9cQTwNtvW3D8eComTzahdGkR//0nw9SpGtSp44Np01S4fl1w9zCJqJBRuHsAWa1ZswZpaWmIiYlBsWLFAAA2mw1TpkxBdHQ0SpUq9cBzFyxY4PR5REQEWrVqhQ0bNqBBgwYAgOPHj+PgwYNYvnw5wsPDAQCVKlVC+/btsWPHDrRv3z5/nhgREREVar6+wGuvWTBggAXffqtATIwKf/0lx6JFasTGqvDiixYMGWJG5cqs4kFEj+ZRK2FxcXEIDQ11BGAA0K5dO4iiiEOHDj3WteRyOXx9fWGxWJyubzAYEBYW5tgWFBSEatWqIS4uLtfjJyIiIu+mUgHdu1sRF5eOzz5LR6NGVpjNAj7/XIWmTfXo10+Dn3/2qLdXROSBPOqnxIULFxAUFOS0zWAwoESJErhw4cIjz5ckCVarFYmJiVi+fDn+/vtvdOvWzen6lSpVgiA4pw0EBQVl6/pEREREACCTAc88Y8OmTUZs3JiOZ56xQJIEbN6sRLt2ejz/vBa7dslZ3p6I7suj0hGTk5NhMBhctvv5+SEpG+3r161bh4kTJwIAdDod5s+fj7p16zpd39fX977XP3XqVC5GDigU7o9n5XKZ079U+HFOvRPn1ftwTr1Tduc1LExCWJgZf/xhQUyMEl9/rcDhw/aPatVEDB9uQefOViiVBTFqehi+Vr1PYZ1TjwrCcqtVq1Z46qmnkJiYiG3btmHkyJGIiYlB8+bN8/VxZTIB/v76fH2Mx2EwaN09BMpjnFPvxHn1PpxT75TdeQ0NtX/Mng188AEQGwucOSPDq6+qMXOmGqNHA/37Az4++TteejS+Vr1PYZtTjwrCDAYDUu5T7zUpKQl+fn6PPD8gIAABAQEA7IU5kpKS8N577zmCMIPBgP/++y/H138QUZSQnJye4/Pzilwug8GgRXKyETYbO0p6A86pd+K8eh/OqXfK6bzq9cBbbwFDhwIrVigRG6vAP//IMHIkMHmyhAEDLBg40IISJfJv7HR/fK16H0+bU4NBm61VOY8Kwu53b1ZKSgpu3rzpcq9YdlSvXt2p4EZQUBCOHDkCSZKc7gu7ePEigoODcz5wAFar+yc9k80metR4KPc4p96J8+p9OKfeKafzqtcDw4ZlYODADKxdq8TixSpcvCjD+++rEBOjRI8eFrz6qhkVK/LGsYLG16r3KWxz6lHJkxERETh8+DCSk5Md27Zt2waZTOZU0TC7fv75Z5QrV87p+klJSThy5Ihj28WLF/H7778jIiIid4MnIiIiug+NBnjpJQsOH07D8uVG1K1rg8kk4JNPVGjSRI9BgzQ4edKj3pIRUT7zqFd89+7dodfrMWTIEBw8eBDffPMN5syZg+7duzv1COvbty9at27t+Hzfvn0YOXIk1q9fj2PHjmHHjh0YPnw4Dh48iCFDhjiOq1u3LsLDwzFhwgRs3boVe/bswfDhwxESEoI2bdoU6HMlIiKiokUuB5591opt29Lx3XfpiIy0QhQFrF+vRFSUHl27arF/PysqEhUFHpWO6Ofnh08//RTTpk3DkCFDoNfr0bVrV4waNcrpOFEUYbPZHJ+XK1cOZrMZc+fORWJiIvz9/RESEoJVq1ahUaNGTud+8MEHmDlzJiZNmgSr1Yrw8HBMnDgRCoVHfSmIiIjISwkCEBZmQ1iYEadPyxATo8L69QrExdk/atWyYehQMzp2tIJvT4i8kyBJ/HtLbtlsIhIS0tw9DCgUMvj765GYmFaocmLpwTin3onz6n04p96pIOf18mUBy5ap8MUXSqSn2+9br1BBxKuvmtGjhwXawlX4zWPxtep9PG1OAwL02SrM4VHpiERERERF0f/bu+/oqOp1jePPlEzKhBCigguQehFBiAkBKSpNVBAVEZByKJeOJ4iCosABFUSaBwtF6YgoingQRYoUERUEISAooiKxUC5BiiSZyWQmM/v+wSHHnIBAJNPy/azFktkleXfe/Jz9sPf+zXXXGXruuVzt2pWtJ57I1VVX+fTLL2aNGBGllBS7pk616fTpQFcJ4EohhAEAAASJhATp8cfdSktzaOJElypV8unECbMmT45UcnKsRo+O1OHDpot/IQBBjRAGAAAQZGJipL59Pdq2zaHZs3NUp45XTqdJc+bY1KCBXX//e5S+/ZbTOCBUMXoBAACClNUqtW+fp40bnVq61KnbbsuT12vSu+9GqHlzu7p2jdbWrcyoCIQaQhgAAECQM5mkFi28+te/crRunUPt2nlkNhvauNGq+++P0d13x+jDD636w+TRAIIYIQwAACCEJCX5NHeuS1u3OtSrl1uRkYbS0izq0ydat95q1+LFEXK5Al0lgD9DCAMAAAhB1aoZev75XKWlOTR0aK5KlzZ08KBZjz0Wpfr17Zo2zabMzEBXCeB8CGEAAAAhrGxZQyNHurV7d7bGjXOpfHmfjh83a/z4SCUlxWrs2Ej93/8xoyIQTAhhAAAAYSA2Vho0yKMdOxyaPj1HN9zgVXa2STNn2lS/vl2PPhqpH37g1A8IBoxEAACAMBIRIXXunKfNm516802nGjXKk8dj0pIlNt16q109e0Zpxw5OAYFAYgQCAACEIZNJuuMOrz74IEerVjnUpo1HJpOhtWsj1LatXffeG6116yzy+QJdKVDyEMIAAADCXIMGPi1a5NLnnzv1t7+5ZbMZ2r7dqu7dY9S8eYzeftsqtzvQVQIlByEMAACghKhRw6cXX8zVzp0ODR6cq1KlDH33nUVDhkTr5pvtevXVCGVnB7pKIPwRwgAAAEqYa6819NRTZ2dUHDMmV+XK+XT0qFlPPx2l5ORYTZhg0/HjzKgIFBdCGAAAQAkVFyc9/LBbO3c69OKLLv3P/3h15oxJL70UqZQUux5/PFLp6YQx4EojhAEAAJRwkZHS3/7m0eefO7VwYY5SUrzKzTXp9ddtatzYrr59o/TVV5w2AlcKowkAAACSJLNZats2T6tXO/X++07dcUeeDMOklSsjdOeddj3wQLQ+/tgiwwh0pUBoI4QBAACgAJNJatzYqzffzNEnnzj04IMeWa2GPv/cqi5dYtSyZYz+9S+r8vICXSkQmghhAAAAuKDatX2aMcOlL790aOBAt2JiDO3bZ9FDD0WrUSO75s2LkMMR6CqB0EIIAwAAwEVVrGjo2WdztXt3tkaMyNXVV/v0669mjRoVpZQUu6ZMsenkSSbxAC4FIQwAAACXrEwZadgwt9LSHJo82aXKlX06dcqsf/4zUvXq2TVqVKR+/ZUwBvwZQhgAAAAuW3S01Lu3R9u2OTR3bo4SE73KyTFp3jybGja0a9CgKH3zDaeawPkwMgAAAFBkFovUrl2e1q936t13nWrWLE9er0nLl0eoZUu7OneO1mefMaMi8EeEMAAAAPxlJpPUtKlXy5blaONGh9q398hsNrRpk1UdOsTorrtitHKlVV5voCsFAo8QBgAAgCuqbl2fZs92aft2h/r0cSs62tBXX1nUt2+0mjSxa9GiCLlcga4SCBxCGAAAAIpF5cqGJk3KVVqaQ489lqsyZQz99JNZw4dHqV49u156yabffw90lYD/EcIAAABQrK6+2tCTT7qVlpat555zqWJFn06cMGvChEglJ8fqqacidfQoMyqi5CCEAQAAwC9iY6X+/T3avt2hV17JUa1aXjkcJs2aZVP9+nY9/HCUvv+e01OEP37LAQAA4FcREVLHjnn65BOn3nrLqVtuyVNenklLl0bottvs6t49Wtu2WQJdJlBsCGEAAAAICJNJuv12r957L0dr1jh0zz0emUyG1q2z6r77YtS2bYzWrLHK5wt0pcCVRQgDAABAwKWk+LRggUtbtzrUo4dbNpuhHTss6tUrWrfdFqMlS6zKzQ10lcCVQQgDAABA0Khe3dDUqWdnVHzkkVzFxRk6cMCiRx+NVoMGds2cGaGsrEBXCfw1hDAAAAAEnXLlDP3jH27t3p2tp5926dprfTp2zKyxY6OUnByr8eNtyshgRkWEJkIYAAAAglapUlJqqkc7dzr08ss5qlHDq8xMk6ZNi1RKil2PPRapgwcJYwgthDAAAAAEPZtN6to1T5995tTrrzvVoIFXbrdJixfb1KSJXb17R2nXLk5tERr4TQUAAEDIMJul1q29WrXKqZUrnbrrrjwZhkmrVkWodWu77r8/Whs3WmQYga4UuDBCGAAAAEJSw4ZeLV6co88+c6hLF48iIgxt3WpV164xat48RsuWWeXxBLpKoDBCGAAAAEJazZo+TZvm0o4dDj30kFt2u6H9+y1KTY1Ww4Z2zZkToezsQFcJ/AchDAAAAGGhfHlDY8fmavfubP3jH7m65hqfDh82a/ToKKWkxGrChAj99lugqwQIYQAAAAgz8fHSI4+4lZbm0PPPu1S1qk+nT5v0z3/aVKmSNHy4TT//zIyKCBxCGAAAAMJSVJTUq5dHW7c6NH9+jpKTvXK5pPnzI9SokV0DBkTp6685HYb/8VsHAACAsGaxSPfem6cNG1z6+GPp9tvz5POZtGJFhG6/3a5OnaK1eTMzKsJ/CGEAAAAoEUwmqUULadmyXH38sUMPPOCRxWJo82arOnWK0R13xGjFCqvy8gJdKcIdIQwAAAAlTp06Ps2a5dL27Q716+dWdLShvXstGjAgWo0b27VgQYRycgJdJcIVIQwAAAAlVqVKhiZMyNWuXQ4NH56rhASffvnFrBEjopSSYtcLL9h0+nSgq0S4IYQBAACgxLvqKkPDh7u1a5dDEye6VKmSTydOmDVpUqSSk2M1ZkykDh9mRkVcGYQwAAAA4N9iYqS+fT3ats2hWbNydOONXjmdJs2ebdPNN9uVmhqlb7/lFBp/Db9BAAAAwH+xWqUHHsjTxx87tXSpU7fdlqe8PJOWLYtQ8+Z2desWra1bmVERRUMIAwAAAC7g7IyKXv3rXzlat86h++7zyGw2tGGDVfffH6O7747RqlVW+XyBrhShhBAGAAAAXIKkJJ/mzXNp61aHevVyKzLSUFqaRb17R+uWW+x6440I5eYGukqEAkIYAAAAcBmqVTP0/PO5SktzaOjQXJUubejgQbOGDTs7o+K0aTZlZga6SgSzoAthBw8eVO/evZWUlKRbbrlFU6ZMkdvt/tN9jh8/rilTpqhdu3ZKTk5W06ZN9dhjj+nIkSMFttu+fbtq1qxZ6M/QoUOL85AAAAAQhsqWNTRypFu7d2dr3DiXypf36fhxs8aPj1RSUqzGjo3UsWPMqIjCrIEu4I/OnDmjXr16qUqVKpo+fboyMjI0adIkuVwuPfXUUxfcb9++fVq/fr06dOigm266SadPn9arr76qTp066cMPP1RCQkKB7SdOnKhq1arlvy5TpkyxHRMAAADCW2ysNGiQR336ePTee1bNnGnTd99ZNHOmTXPmRKhTJ49SUz2qUYMHx3BWUIWwt99+Ww6HQzNmzFB8fLwkyev1auzYsRo4cKDKlSt33v1SUlK0Zs0aWa3/OZx69eqpefPmWrFihfr06VNg+xo1aqhu3brFdhwAAAAoeWw2qXPnPHXqlKcNGyyaMcOmbdusWrLEpiVLbGrd2qOHH3arQQPCWEkXVLcjfvrpp2rcuHF+AJOkNm3ayOfzacuWLRfcLy4urkAAk6Rrr71WCQkJOn78eHGVCwAAABRiNkt33unVBx/kaNUqh9q08UiS1q6NUNu2dt17b7TWrbMwo2IJFlQhLD09vcBtgtLZgHXNNdcoPT39sr7WTz/9pJMnT6p69eqF1g0YMEC1atVS06ZNNXnyZLlcrr9UNwAAAHA+DRr4tGiRS1u2ONStm1sREYa2b7eqe/cYNW8eo7fftuoi0x8gDAXV7YiZmZmKi4srtLx06dI6c+bMJX8dwzA0fvx4lS1bVm3bts1fXqpUKfXr108NGjRQZGSktm3bpgULFig9PV2zZ8/+S7VbrYHPsxaLucB/EfroaXiir+GHnoYn+hp+AtnTWrWkGTM8+sc/8jRrllULF0bou+8sGjIkWpMm+fTQQx717JmnUqX8XlpIC9VxGlQh7EqZPn26tm3bpnnz5ikmJiZ/ee3atVW7du38140bN1bZsmU1btw47d27V4mJiUX6fmazSWXK2P9y3VdKXFx0oEvAFUZPwxN9DT/0NDzR1/ATyJ6WKSNNmyY9+6w0a5b00kvS0aNmjRkTqalTI/X3v0tDhkgXmAoBFxBq4zSoQlhcXJyysrIKLT9z5oxKly59SV/jnXfe0cyZM/Xcc8+pcePGF92+TZs2GjdunL755psihzCfz1BmprNI+15JFotZcXHRyszMkdfLTcbhgJ6GJ/oafuhpeKKv4SfYejpggNSrl7R0qVUzZkToxx/NmjBBmjrVULdueUpN9ahaNSPQZQa1YOtpXFz0JV2VC6oQVq1atULPfmVlZem3334r9KzY+axfv17PPPOMhgwZoo4dOxZXmeeVlxf4pp/j9fqCqh78dfQ0PNHX8ENPwxN9DT/B1FOLRerWza3Ond1au9aqGTNsSkuzaOHCCC1aZNU99+Rp8GC3kpKCo95gFUw9vRRBdfNk06ZNtXXrVmX+4SPG165dK7PZrFtuueVP992+fbuGDRumTp06KTU19ZK/56pVqySJKesBAAAQMBaL1LZtnlavdur9951q1SpPPp9JH3wQoTvvtKtDh2ht2mSRwYWxsBBUV8K6dOmixYsXKzU1VQMHDlRGRoamTJmiLl26FPiMsF69euno0aNav369JOngwYNKTU1VlSpV1K5dO3311Vf52yYkJKhSpUqSpMcff1yVK1dW7dq18yfmeO2119SqVStCGAAAAALOZJIaN/aqceMcffutWTNn2vTee1Z99tnZP3XqeDV4sFv33Zcna1CdyeNyBFXrSpcurUWLFunZZ59Vamqq7Ha7OnbsqKFDhxbYzufzyev15r/es2ePsrKylJWVpa5duxbYtn379po0aZKksx/SvHLlSi1YsEAej0cVKlTQoEGDNGDAgOI/OAAAAOAy1K7t08yZLo0cadLs2TYtXhyhb76xaNCgaE2Y4NNDD7nVtatHf5iHDiHCZBhc1PyrvF6fTp1yBLoMWa1mlSlj1+nTjpC6JxYXRk/DE30NP/Q0PNHX8BPqPT19Wlq40KZ58yJ04sTZp4oSEnzq29ejPn08uuqqkndaH2w9TUiwX9LEHEH1TBgAAACA8ytTRho2zK20NIcmT3apcmWfTp0y6/nnI5WSYteoUZH69VdToMvEJSCEAQAAACEkOlrq3dujL75waM6cHNWt65XTadK8eTY1bGjXoEFR+uYbTvODGd0BAAAAQpDVKt1/f542bHBq2TKnmjXLk9dr0vLlEWrZ0q7OnaP1+efMqBiMCGEAAABACDOZpGbNvFq2LEcbNjjUvr1HZrOhTZuseuCBGLVuHaOVK636w7x2CDBCGAAAABAmEhN9mj3bpW3bHOrd262oKEO7d1vUt2+0mjSxa9GiCLlcga4ShDAAAAAgzFSpYmjy5Fzt2uXQsGG5io839NNPZg0fHqWUFLteesmm338PdJUlFyEMAAAACFNXX21oxAi3du3K1vjxLlWs6NNvv5k1YUKkkpNj9dRTkTp6lBkV/Y0QBgAAAIS52FhpwACPtm93aObMHNWq5ZXDYdKsWTY1aGDXkCFR+v57ooG/8JMGAAAASoiICKlTpzx98olTb73lVJMmefJ4THr77QjddptdPXpEa9s2S6DLDHuEMAAAAKCEMZmk22/3asWKHK1Z41Dbth6ZTIY++siq++6LUdu2MVqzxiqfL9CVhidCGAAAAFCCpaT4tHChS1u3OtSjh1s2m6EdOyzq1StaTZvG6K23rHK7A11leCGEAQAAAFD16oamTs1VWppDQ4bkqlQpQz/8YNEjj0Srfn27Zs6MUFZWoKsMD4QwAAAAAPnKlTM0erRbX32Vraefdunaa306dsyssWOjlJwcq/HjbcrIYEbFv4IQBgAAAKCQUqWk1FSPduxw6OWXc1SjhleZmSZNmxaplBS7HnssUgcPEsaKghAGAAAA4IIiI6WuXfP02WdOLVqUo/r1vXK7TVq82KYmTezq3TtKu3YRKy4HPy0AAAAAF2U2S23a5Gn1aqc++MCpu+7Kk2GYtGpVhFq3tqt9+2ht3GiRYQS60uBHCAMAAABwWRo18mrx4hx9+qlDXbp4ZLUa2rLFqq5dY9S8eYyWLbPK4wl0lcGLEAYAAACgSG64wadp01zaudOhQYPcstsN7d9vUWpqtBo2tGvOnAg5HIGuMvgQwgAAAAD8JeXLGxo3Lle7d2dr1KhcXX21T4cPmzV6dJTq1YvV5Mk2nTjBJB7nEMIAAAAAXBHx8dKjj7q1a5dDzz/vUtWqPp0+bdLUqWdnVBwxIlI//0wYI4QBAAAAuKKioqRevTzautWh+fNzlJTkVU6OSQsW2NSokV0DB0bp669LbhQpuUcOAAAAoFhZLNK99+bpo4+cWr7cqRYt8uTzmfTeexG6/Xa7OnWK1qeflrwZFQlhAAAAAIqVySTdeqtXS5fmaONGhx54wCOLxdDmzVZ17BijO++M0fvvW5WXF+hK/YMQBgAAAMBv6tb1adYsl7Zvd6hfP7eiow3t2WNR//7RatzYroULI5STE+gqixchDAAAAIDfVapkaMKEXO3a5dDw4blKSPDpl1/MevLJKKWk2PXCCzadPh3oKosHIQwAAABAwFx1laHhw91KS3NowgSXrrvOpxMnzJo0KVLJybEaMyZShw+H14yKhDAAAAAAAWe3S/36ebR9u0OvvpqjG2/0yuk0afZsm26+2a7U1Cjt3x8e8SU8jgIAAABAWLBapQ4d8vTxx069/bZTt96ap7w8k5Yti1CzZnZ16xatL74I7RkVCWEAAAAAgo7JJLVs6dXy5Tn66COH7r3XI5PJ0IYNVrVrF6O7747Rhx9a5PMFutLLRwgDAAAAENSSk32aP9+lL75wqGdPtyIjDaWlWdSzZ5Tq1JEOHQqtZ8YIYQAAAABCQrVqhv75z1ylpTn06KO5Kl3a0P790r59oRVrQqtaAAAAACVe2bKGRo1ya+9ep3bvllq39ga6pMtiDXQBAAAAAFAUpUpJlSop5D5PjCthAAAAAOBHhDAAAAAA8CNCGAAAAAD4ESEMAAAAAPyIEAYAAAAAfkQIAwAAAAA/IoQBAAAAgB8RwgAAAADAjwhhAAAAAOBHhDAAAAAA8CNCGAAAAAD4ESEMAAAAAPyIEAYAAAAAfkQIAwAAAAA/IoQBAAAAgB8RwgAAAADAjwhhAAAAAOBHJsMwjEAXEeoMw5DPFxw/RovFLK/XF+gycAXR0/BEX8MPPQ1P9DX80NPwE0w9NZtNMplMF92OEAYAAAAAfsTtiAAAAADgR4QwAAAAAPAjQhgAAAAA+BEhDAAAAAD8iBAGAAAAAH5ECAMAAAAAPyKEAQAAAIAfEcIAAAAAwI8IYQAAAADgR4QwAAAAAPAjQhgAAAAA+BEhDAAAAAD8iBAGAAAAAH5kDXQBuLhffvlF8+fP1549e3TgwAFVq1ZNH3744UX3MwxDc+fO1ZIlS3Tq1CnVqlVLI0eOVFJSUvEXjYsqal9btmypI0eOFFq+d+9eRUZGFkepuERr1qzRBx98oH379ikzM1OVK1dWjx491KFDB5lMpgvux1gNXkXtKeM0uG3evFlz587Vjz/+qOzsbJUrV06tWrXS4MGDVapUqT/dd9myZZo3b56OHj2qqlWraujQoWrRooWfKseFFLWnPXr00Jdffllo+erVq1W9evXiLBmXyeFwqE2bNsrIyNC7776runXrXnDbUHhfJYSFgAMHDmjz5s266aab5PP5ZBjGJe03d+5cTZs2TY8//rhq1qypN998U3369NH777+v6667rpirxsUUta+SdNddd6lPnz4FltlstitdIi7Ta6+9pgoVKmjEiBEqU6aMtm7dqjFjxujYsWMaPHjwBfdjrAavovZUYpwGs99//12JiYnq0aOH4uPjdeDAAU2fPl0HDhzQggULLrjfqlWrNGbMGA0aNEiNGjXS6tWrNXjwYL355ptBdXJXEhW1p5JUr149PfnkkwWWVaxYsTjLRRG88sor8nq9l7RtSLyvGgh6Xq83/+9PPvmk0bZt24vu43K5jHr16hlTp07NX5abm2u0aNHCePrpp4ujTFymovTVMAyjRYsWxtixY4urLPwFJ0+eLLRs9OjRRr169Qr0+48Yq8GtKD01DMZpKFq6dKlx/fXXG8eOHbvgNnfeeacxbNiwAss6d+5s9OvXr7jLQxFcSk+7d+9uDBgwwI9VoSh+/PFHIykpyXjrrbeM66+/3ti7d+8Ftw2V91WeCQsBZvPlt2nXrl3Kzs5WmzZt8pfZbDbdcccd+vTTT69keSiiovQVwS0hIaHQslq1aik7O1tOp/O8+zBWg1tReorQFB8fL0nyeDznXX/o0CH9/PPPBcaqJN1999364osv5Ha7i7tEXKaL9RShY/z48erSpYuqVq160W1D5X2Vs8AwlZ6eLkmqVq1ageXVq1fX0aNH5XK5AlEWrpCVK1eqTp06Sk5OVv/+/fX9998HuiRcQFpamsqVK6fY2Njzrmeshp6L9fQcxmnw83q9ys3N1b59+zRz5ky1bNnygrehnRur/30SWL16dXk8Hh06dKjY68XFXU5Pz/nyyy+VlJSkunXrqnv37tqxY4efqsWlWLt2rX744QelpqZe0vah8r7KM2FhKjMzUzabrdAD4HFxcTIMQ2fOnFFUVFSAqsNf0bJlSyUmJqp8+fI6dOiQZs2apW7dumnFihXBc58zJEk7d+7U6tWrCz1r8EeM1dByKT2VGKehokWLFsrIyJAk3XbbbZo6deoFtz1z5oyks2Pzj869PrcegXU5PZWkBg0aqF27dqpSpYqOHz+u+fPnq3fv3lq8eLGSk5P9UTL+RE5OjiZNmqShQ4de9B++zgmV91VCGBBiRo8enf/3+vXr65ZbblGbNm00f/58PfPMM4ErDAUcO3ZMQ4cOVcOGDdWzZ89Al4Mr4HJ6yjgNDXPmzFFOTo5+/PFHvfrqqxo0aJAWLlwoi8US6NJQRJfb0yFDhhR43bx5c91zzz165ZVXNHfuXH+UjD/x6quv6qqrrlKHDh0CXcoVRwgLU3FxcXK73crNzS3wLwGZmZkymUwqXbp0AKvDlVS2bFmlpKRo3759gS4F/5aZman+/fsrPj5e06dP/9Pn/xiroeFyeno+jNPgdMMNN0iSkpOTVbduXbVr107r169X69atC217bixmZWXpmmuuyV+emZlZYD0C63J6ej4xMTFq1qyZPvroo+IsE5fgyJEjWrBggWbOnKmsrCxJyn8W1+l0yuFwyG63F9ovVN5XCWFh6tx9sD/99FP+/5Cks/fJli9fPiguwwLhyOVyaeDAgcrKytLSpUsv+plDjNXgd7k9RWiqWbOmIiIi9Ouvv553/bmxmp6eXuBZk/T0dEVERHCbaRC6WE8R3A4fPiyPx6MBAwYUWtezZ0/ddNNNeueddwqtC5X3VUJYmKpXr55iY2O1Zs2a/F9Aj8ejdevWqWnTpgGuDldSRkaG0tLS1K5du0CXUuLl5eXp0UcfVXp6ut58802VK1fuovswVoNbUXp6PozT4Ldnzx55PJ4LTuJw3XXXqUqVKlq7dq1atWqVv3z16tVq3LgxnwEXhC7W0/NxOp365JNP/vSDgOEftWrV0uuvv15g2f79+zVx4kSNHTv2gj0KlfdVQlgIyMnJ0ebNmyWdvTSbnZ2ttWvXSpJuvvlmJSQkqFevXjp69KjWr18vSYqMjNTAgQM1ffp0JSQk6Prrr9dbb72l33//XX379g3YseA/itLXDz/8UJs2bVKzZs1UtmxZHTp0SHPmzJHFYlHv3r0Ddiw4a+zYsdq0aZNGjBih7OxsffXVV/nrateuLZvNxlgNMUXpKeM0+A0ePFh16tRRzZo1FRUVpe+++07z589XzZo18wPWqFGjtGLFCn377bf5+z388MN6/PHHValSJTVs2FCrV6/W3r179cYbbwTqUPBvRenpzp07NW/ePN1xxx2qUKGCjh8/roULF+q3337Tyy+/HMjDgc7eVtiwYcPzrrvxxht14403SlLIvq8SwkLAyZMn9cgjjxRYdu7166+/roYNG8rn8xX6FPH+/fvLMAwtWLBAp06dUq1atTR//nxumQgSRelrxYoVdfz4cU2YMEFZWVkqVaqUGjVqpCFDhtDXILBlyxZJ0qRJkwqt27hxoypWrMhYDTFF6SnjNPglJiZq9erVmjNnjgzDUIUKFdSpUyf17ds3/4rW+cbqPffco5ycHM2dO1dz5sxR1apVNWPGDGbRCwJF6ek111wjj8ejF198Ub///ruio6OVnJyssWPHKjExMVCHgssUqu+rJsMwjEAXAQAAAAAlBR/WDAAAAAB+RAgDAAAAAD8ihAEAAACAHxHCAAAAAMCPCGEAAAAA4EeEMAAAAADwI0IYAAAAAPgRIQwAgABbvny5atasqa+//jrQpQAA/MAa6AIAAPCH5cuXa+TIkRdcv3TpUiUlJfmvIABAiUUIAwCUKEOGDFHFihULLa9UqVIAqgEAlESEMABAidK0aVPVrVs30GUAAEowngkDAODfDh8+rJo1a2r+/Pl67bXX1KJFCyUmJqp79+764YcfCm3/xRdfqFu3bkpKSlL9+vX10EMP6eDBg4W2y8jI0KhRo3TrrbeqTp06atmypZ5++mm53e4C27ndbk2cOFGNGjVSUlKSUlNTderUqWI7XgBAYHAlDABQomRnZxcKNiaTSWXKlMl/vWLFCjkcDnXr1k25ublavHixevXqpZUrV+rqq6+WJG3dulX9+/dXxYoVNXjwYLlcLr3xxhvq2rWrli9fnn/LY0ZGhjp27KisrCw9+OCDqlatmjIyMvTRRx/J5XLJZrPlf9/x48crLi5OgwcP1pEjR7Ro0SKNGzdOL730UvH/YAAAfkMIAwCUKP/7v/9baJnNZiswM+Gvv/6qdevWqVy5cpLO3sLYqVMnzZ07N39yjylTpqh06dJaunSp4uPjJUmtWrVS+/btNX36dE2ePFmS9MILL+jEiRN65513CtwG+cgjj8gwjAJ1xMfHa8GCBTKZTJIkn8+nxYsXKysrS6VKlbpiPwMAQGARwgAAJcpTTz2lqlWrFlhmNhe8O79Vq1b5AUySEhMTddNNN2nz5s0aOXKkjh8/rv3796tfv375AUySbrjhBjVp0kSbN2+WdDZEbdiwQS1atDjvc2jnwtY5Dz74YIFl9evX12uvvaYjR47ohhtuKPIxAwCCCyEMAFCiJCYmXnRijsqVKxdaVqVKFa1Zs0aSdPToUUkqFOYkqXr16vr888/ldDrldDqVnZ2tGjVqXFJt5cuXL/A6Li5OkpSZmXlJ+wMAQgMTcwAAECT++4rcOf992yIAILRxJQwAgP/yyy+/FFr2888/q0KFCpL+c8Xqp59+KrRdenq6ypQpo5iYGEVFRSk2NlYHDhwo3oIBACGFK2EAAPyXDRs2KCMjI//13r17tWfPHjVt2lSSVLZsWdWqVUsrVqwocKvgDz/8oC1btqhZs2aSzl7ZatWqlTZt2lRg4o9zuMIFACUTV8IAACXKp59+qvT09ELL69Wrlz8pRqVKldS1a1d17dpVbrdbr7/+uuLj49WvX7/87Z944gn1799fnTt3VseOHfOnqC9VqpQGDx6cv92wYcO0ZcsW9ejRQw8++KCqV6+u3377TWvXrtWSJUvyn/sCAJQchDAAQIkybdq08y6fOHGibr75ZknS/fffL7PZrEWLFunkyZNKTEzUmDFjVLZs2fztmzRponnz5mnatGmaNm2arFarGjRooOHDh+u6667L365cuXJ655139PLLL2vlypXKzs5WuXLl1LRpU0VFRRXvwQIAgpLJ4F4IAAAkSYcPH9btt9+uJ554Qn379g10OQCAMMUzYQAAAADgR4QwAAAAAPAjQhgAAAAA+BHPhAEAAACAH3ElDAAAAAD8iBAGAAAAAH5ECAMAAAAAPyKEAQAAAIAfEcIAAAAAwI8IYQAAAADgR4QwAAAAAPAjQhgAAAAA+BEhDAAAAAD86P8B+1WOBETmkBwAAAAASUVORK5CYII=\n"
+          },
+          "metadata": {}
+        }
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "IQLpN-Q1jvW7"
+      },
+      "source": [
+        "## Evaluation\n",
+        "\n",
+        "For a better measure of the quality of the model, let's see the model accuracy, precision, recall and F1 score for the two data sets (tweets and news headlines)."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "#Redefine the evaluate function → classification report + confusion matrix\n",
+        "def evaluate(loader):\n",
+        "  model.eval()\n",
+        "\n",
+        "  n_correct, n_all = 0, 0\n",
+        "\n",
+        "  all_predictions = []\n",
+        "  all_labels = []\n",
+        "\n",
+        "  for batch in loader:\n",
+        "    batch = tuple(t.to(device) for t in batch)\n",
+        "    b_input_ids, b_input_mask, b_labels = batch\n",
+        "\n",
+        "    with torch.no_grad():\n",
+        "      outputs = model(b_input_ids, token_type_ids=None,\n",
+        "                      attention_mask=b_input_mask)\n",
+        "      logits = outputs[0]\n",
+        "\n",
+        "    logits = logits.detach().cpu().numpy()\n",
+        "    predictions = np.argmax(logits, axis=1)\n",
+        "\n",
+        "    labels = b_labels.to('cpu').numpy()\n",
+        "    n_correct += np.sum(predictions == labels)\n",
+        "    n_all += len(labels)\n",
+        "\n",
+        "    #Update preds and labels for the classification report\n",
+        "    all_predictions.extend(predictions)\n",
+        "    all_labels.extend(labels)\n",
+        "\n",
+        "  print('Accuracy: [{}/{}] {:.4f}'.format(n_correct, n_all,\n",
+        "                                          n_correct/n_all))\n",
+        "\n",
+        "  report = classification_report(all_labels, all_predictions, digits= 4)\n",
+        "  print(\"Classification Report:\\n\", report)\n",
+        "\n",
+        "  # Create confusion matrix and plot\n",
+        "  conf_matrix = confusion_matrix(all_labels, all_predictions)\n",
+        "  plt.figure(figsize=(8, 6))\n",
+        "  sns.heatmap(conf_matrix, annot=True, fmt='d', cmap='Blues',\n",
+        "              xticklabels=[str(i) for i in range(conf_matrix.shape[1])],\n",
+        "              yticklabels=[str(i) for i in range(conf_matrix.shape[0])])\n",
+        "  plt.title('Confusion Matrix')\n",
+        "  plt.xlabel('Prediction')\n",
+        "  plt.ylabel('Gold')\n",
+        "  plt.show()"
+      ],
+      "metadata": {
+        "id": "JVFFeXBAMHc_"
+      },
+      "execution_count": 32,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 33,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 781
+        },
+        "id": "mDIYn1Mqjz-2",
+        "outputId": "b1b1c15f-cb51-42bb-db8a-5177cf6034ae"
+      },
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "------Test set 1 (Tweets):------\n",
+            "Accuracy: [985/1263] 0.7799\n",
+            "Classification Report:\n",
+            "               precision    recall  f1-score   support\n",
+            "\n",
+            "           0     0.7876    0.7754    0.7814       641\n",
+            "           1     0.7722    0.7846    0.7783       622\n",
+            "\n",
+            "    accuracy                         0.7799      1263\n",
+            "   macro avg     0.7799    0.7800    0.7799      1263\n",
+            "weighted avg     0.7800    0.7799    0.7799      1263\n",
+            "\n"
+          ]
+        },
+        {
+          "output_type": "display_data",
+          "data": {
+            "text/plain": [
+              "<Figure size 800x600 with 2 Axes>"
+            ],
+            "image/png": "iVBORw0KGgoAAAANSUhEUgAAApgAAAIsCAYAAABWatmqAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjguMCwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy81sbWrAAAACXBIWXMAAA9hAAAPYQGoP6dpAABL/ElEQVR4nO3de3zP9f//8fs25rj3HGKykU21JmMTOWzmTIaUVCqHhHSQ6FtthKg+kUNEyGF0IHxSKVrICpFIKYlyeC+HydnOW9vY7w8/70/v3g7P8Zod3K6fyy6fz/v1fL6e7+f7/fl+vp/H5/58vp5vt9zc3FwBAAAAFnEv6AkAAACgeKHABAAAgKUoMAEAAGApCkwAAABYigITAAAAlqLABAAAgKUoMAEAAGApCkwAAABYigITAAAAlqLABHDV/vzzTz322GO64447FBgYqDVr1lg6/qFDhxQYGKhPPvnE0nGLsl69eqlXr14FPQ0AuCAKTKCYOHDggEaNGqU2bdooODhYDRo0UI8ePfTee+8pMzMzX987Ojpau3fv1tChQzV+/HjVrVs3X9/vWoqOjlZgYKAaNGhwwe/xzz//VGBgoAIDAxUTE5Pn8Y8ePapp06Zp165dVkwXAAqFEgU9AQBXb+3atXr22Wfl6emprl276tZbb1V2drZ+/PFHTZgwQXv37tWrr76aL++dmZmpbdu26YknnlDPnj3z5T18fX21fft2lShRMP8vq0SJEsrMzNTXX3+tyMhIp7bly5erVKlS+vvvv69o7GPHjuntt9+Wr6+vgoKCjO+7kmIWAK4VCkygiDt48KCGDh2q6tWr67333lPVqlUdbY888oj279+vtWvX5tv7nzp1SpJks9ny7T3c3NxUqlSpfBv/cjw9PdWgQQN98cUXLgXmihUr1LJlS61ateqazCUjI0NlypSRp6fnNXk/ALgSLJEDRdzcuXOVnp6u//znP07F5Xk33XST+vTp43idk5Oj6dOnq23btqpbt65at26tN998U1lZWU73tW7dWgMHDtTWrVvVvXt3BQcHq02bNlq2bJmjz7Rp09SqVStJ0vjx4xUYGKjWrVtLOre0fP5f/9O0adMUGBjodG3jxo166KGH1LBhQ4WGhqpDhw568803He0X24O5adMmPfzwwwoJCVHDhg315JNPat++fRd8v/379ys6OloNGzbUHXfcoWHDhikjI+NSX62Tzp07a/369UpOTnZc2759u/7880917tzZpX9iYqLeeOMNdenSRaGhoWrQoIH69++v33//3dFn8+bN6t69uyRp2LBhjqX285+zV69e6ty5s3bs2KFHHnlE9evXd3wv/96DGRUVpeDgYJfP369fPzVq1EhHjx41/qwAcLUoMIEi7ptvvlGNGjXUoEEDo/4jRozQ1KlTVadOHQ0bNkyNGjXSrFmzNHToUJe++/fv17PPPquwsDBFR0fL29tb0dHR2rNnjySpXbt2GjZsmKRzBdj48eM1fPjwPM1/z549GjhwoLKysjR48GBFRUWpdevW+umnny5533fffaf+/fvr5MmTGjRokB599FFt27ZNDz30kA4dOuTSf8iQIUpLS9Nzzz2njh076pNPPtHbb79tPM927drJzc1Nq1evdlxbsWKFAgICVKdOHZf+Bw8e1Jo1a9SyZUtFR0erX79+2r17t3r27Oko9mrXrq3BgwdLkh588EGNHz9e48ePV6NGjRzjJCYmasCAAQoKCtLw4cPVuHHjC87vpZdeUqVKlRQVFaUzZ85IkhYvXqwNGzZoxIgR8vHxMf6sAHC1WCIHirDU1FQdPXpUbdq0Mer/+++/69NPP9X999+v1157TdK5ZfRKlSpp3rx5+v7779WkSRNH//j4eC1cuFANGzaUJHXs2FEtWrTQJ598oqioKN12220qX768xo4dqzp16qhr1655/gwbN25Udna25syZo0qVKhnfN378eHl7e2vJkiWqUKGCJKlt27a69957NW3aNL3xxhtO/YOCgvT66687XicmJmrp0qV64YUXjN6vfPnyatmypVasWKHu3bvr7Nmzio2NVY8ePS7YPzAwUKtWrZK7+//+d3zXrl3VsWNHLV26VE8//bRuuOEGRUREaOrUqQoJCbng93f8+HGNGTPmou9zns1m03/+8x/169dPs2fPVufOnfXGG2+obdu2V/TvCwBcDRJMoAhLTU2VJJUrV86o/7p16yRJffv2dbr+2GOPObWfd/PNNzuKS0mqVKmS/P39dfDgwSue87+d37sZFxens2fPGt1z7Ngx7dq1S/fee6+juJSk2267Tc2aNXP5HJJcCrSGDRsqMTHR8R2a6NKli7Zs2aLjx4/r+++/1/Hjx9WlS5cL9vX09HQUl2fOnNHp06dVtmxZ+fv7a+fOncbv6enpqW7duhn1DQ8P14MPPqjp06frmWeeUalSpfTKK68YvxcAWIUCEyjCypcvL0lKS0sz6p+QkCB3d3fVrFnT6XqVKlVks9mUkJDgdP3GG290GcPb21tJSUlXOGNXkZGRatCggUaMGKFmzZpp6NChio2NvWSxefjwYUmSv7+/S1vt2rV1+vRppaenO12vXr260+vzhW1ePkuLFi1Urlw5xcbGavny5QoODtZNN910wb5nz57Vu+++q/bt2ys4OFhNmjRR06ZN9ccffyglJcX4PX18fPL0QE9UVJQqVKigXbt2acSIEapcubLxvQBgFZbIgSKsfPnyqlq1qmNPpCk3Nzejfh4eHlcyrUu+x/n9geeVLl1aCxcu1ObNm7V27Vp9++23io2N1ZIlSzRv3ryrmsM//XOp+p9yc3ONx/D09FS7du20bNkyHTx4UIMGDbpo33feeUdvvfWW7rvvPj377LPy9vaWu7u7Xn/99Ty9Z+nSpY37StKuXbt08uRJSdLu3bvzdC8AWIUEEyjiWrVqpQMHDmjbtm2X7evr66uzZ89q//79TtdPnDih5ORk+fr6WjYvm83m9MT1eefTx39yd3dX06ZNNWzYMMXGxmro0KH6/vvvtXnz5guOfT6NjI+Pd2mz2+2qWLGiypYte5Wf4MK6dOminTt3Ki0tTZ06dbpov1WrVqlx48Z6/fXX1alTJ4WHh6tZs2Yu34lpsW8iPT1dw4YN080336wHH3xQc+fO1fbt2y0bHwBMUWACRVz//v1VtmxZjRgxQidOnHBpP3DggN577z1J55Z4JTlenzd//nyndivUrFlTKSkpTsfyHDt2TF999ZVTv8TERJd7zx84/u+jk86rWrWqgoKCtGzZMqeCbffu3dq4caOln+PfGjdurGeffVYjR45UlSpVLtrPw8PDJan88ssvXY4LKlOmjCRdsBjPq4kTJ+qvv/7SuHHjFB0dLV9fX0VHR1/0ewSA/MISOVDE1axZUxMnTtTQoUMVGRnp+CWfrKwsbdu2TStXrnQ8JHLbbbfp3nvv1ZIlS5ScnKxGjRrp119/1aeffqq2bds6PUF+tSIjIzVx4kQNGjRIvXr1UmZmphYtWiR/f3/99ttvjn7Tp0/X1q1b1aJFC/n6+urkyZP68MMPVa1aNd1xxx0XHf/FF1/UgAED9OCDD6p79+7KzMzUggUL5OXldcml66vl7u6up5566rL9WrZsqenTp2vYsGEKDQ3V7t27tXz5ctWoUcOpX82aNWWz2bR48WKVK1dOZcuWVb169Vz6Xc6mTZv04YcfatCgQbr99tslSWPHjlWvXr00ZcoUvfjii3kaDwCuBgUmUAy0adNGn3/+uWJiYhQXF6dFixbJ09NTgYGBio6O1gMPPODo+9prr8nPz0+ffvqp1qxZoxtuuEEDBw60vCirWLGi3n77bY0bN04TJkyQn5+fnnvuOe3fv9+pwGzdurUSEhL08ccf6/Tp06pYsaLuvPNOPfPMM/Ly8rro+M2aNdPcuXM1depUTZ06VSVKlFCjRo30wgsv5Lk4yw9PPPGEMjIytHz5csXGxqpOnTqaNWuWJk2a5NSvZMmSGjdunN58802NHj1aOTk5Gjt2bJ4+Q2pqql566SXVqVNHTzzxhON6w4YN1bt3b82fP1/t27dXSEiIVR8PAC7JLTcvu80BAACAy2APJgAAACxFgQkAAABLUWACAADAUhSYAAAAsBQFJgAAACxFgQkAAABLUWACAADAUtftQetlQvPvlz4AFKxjm6YW9BQA5BOv0gWXjeVn7ZCx7e18G7sgkGACAADAUtdtggkAAJAnbuRypvimAAAAYCkSTAAAABNubgU9gyKDBBMAAACWIsEEAAAwwR5MYxSYAAAAJlgiN0YpDgAAAEuRYAIAAJhgidwY3xQAAAAsRYIJAABggj2YxkgwAQAAYCkSTAAAABPswTTGNwUAAABLkWACAACYYA+mMQpMAAAAEyyRG+ObAgAAgKVIMAEAAEywRG6MBBMAAACWIsEEAAAwwR5MY3xTAAAAsBQJJgAAgAn2YBojwQQAAIClSDABAABMsAfTGN8UAAAALEWCCQAAYIIE0xgFJgAAgAl3HvIxRSkOAAAAS5FgAgAAmGCJ3BjfFAAAACxFggkAAGCCg9aNkWACAADAUiSYAAAAJtiDaYxvCgAAAJYiwQQAADDBHkxjFJgAAAAmWCI3xjcFAAAAS5FgAgAAmGCJ3BgJJgAAACxFggkAAGCCPZjG+KYAAABgKRJMAAAAE+zBNEaCCQAAAEuRYAIAAJhgD6YxCkwAAAATLJEboxQHAACApUgwAQAATLBEboxvCgAAAJYiwQQAADBBgmmMbwoAAACWIsEEAAAwwVPkxkgwAQAAYCkSTAAAABPswTTGNwUAAGDCzS3//iySlpamiIgIBQYG6tdff3Vc79WrlwIDA13+9u3b53R/SkqKhg8frjvvvFOhoaEaPHiwjh07lud5kGACAAAUEzNmzNCZM2cu2NagQQNFRUU5XfPz83N6PWTIEO3du1ejR49WqVKlNGXKFA0YMEAff/yxSpQwLxspMAEAAEwU8iXyffv26cMPP1RUVJRefvlll3abzaaQkJCL3r9t2zZt2LBBMTExCg8PlyT5+/srMjJSq1evVmRkpPFcCvc3BQAAACOvvfaaevToIX9//yu6f/369bLZbAoLC3NcCwgIUFBQkNavX5+nsSgwAQAATBTiPZgrV67U7t279fTTT1+0z5YtWxQSEqLg4GD17NlTP/zwg1O73W6Xv7+/3P41n4CAANnt9jzNhyVyAACAAtamTZtLtsfFxV20LSMjQ+PGjdPQoUNVvnz5C/Zp1KiRunbtqlq1aunYsWOKiYlR37599cEHHyg0NFSSlJycLC8vL5d7vb29tWPHjjx8GgpMAAAAI/9O9gqLmTNnqnLlyrrvvvsu2mfw4MFOr1u2bKnOnTtrxowZmjNnjuVzosAEAAAoYJdKKC8lISFB8+bN0/Tp05WSkiJJSk9Pd/xzWlqaypUr53Jf2bJl1aJFC61atcpxzWaz6ciRIy59k5KS5O3tnad5UWACAAAYKIwJ5qFDh5Sdna3HH3/cpa13796qX7++/vvf/xqNFRAQoE2bNik3N9fps8bHx+vWW2/N07woMAEAAEwUvvpSQUFBev/9952u7dq1S2PHjtWYMWMUHBx8wfvS09O1du1ap/aIiAjNmDFDmzZtUrNmzSSdKy537typ/v3752leFJgAAABFlM1mU+PGjS/Ydvvtt+v222/X1q1bNXfuXLVr106+vr46duyY5s+fr+PHj+utt95y9A8NDVV4eLiGDx+uqKgolSpVSpMnT1ZgYKDat2+fp3lRYAIAABgojEvkJqpUqaLs7GxNnjxZiYmJKlOmjEJDQzVmzBjVq1fPqe+UKVM0duxYjRo1Sjk5OQoPD9eIESPy9Cs+kuSWm5uba+WHKCrKhA4q6CkAyCfHNk0t6CkAyCdepQvuCO/yD7ybb2On/vfRfBu7IJBgAgAAGCiqCWZB4Jd8AAAAYCkSTAAAAAMkmOZIMAEAAGApEkwAAAADJJjmKDABAABMUF8aY4kcAAAAliLBBAAAMMASuTkSTAAAAFiKBBMAAMAACaY5EkwAAABYigQTAADAAAmmORJMAAAAWIoEEwAAwAAJpjkKTAAAABPUl8ZYIgcAAIClSDABAAAMsERujgQTAAAAliLBBAAAMECCaY4EEwAAAJYiwQQAADBAgmmOBBMAAACWIsEEAAAwQYBpjAITAADAAEvk5lgiBwAAgKVIMAEAAAyQYJojwQQAAIClSDABAAAMkGCaI8EEAACApUgwAQAADJBgmiPBBAAAgKVIMAEAAEwQYBojwQQAAIClSDABAAAMsAfTHAUmAACAAQpMcyyRAwAAwFIkmAAAAAZIMM2RYAIAAMBSJJgAAAAmCDCNkWACAADAUiSYAAAABtiDaY4EE0Xai/06KGPb29r60XCn6yVKuGv44x21c/loJW6erJ3LRyuqfwd5eDj/n/zsMT2Vse3ti/5Vr+J9LT8OcF1LT0/TrBnT9MyTA9S6eRM1rB+k5Z99esl7crKzdf+9ndWwfpA+eG/eJft++cVyNawfpOZN7rBy2gAugAQTRZZv1Qp6sV97pab/7dI2/7U+6tYuVO999r1+2nlAdwbX0uinu6hGtUoa9NoiR7+Yjzfq681/ON3r5iZNe6mH9h8+pcPHk/L9cwA4J/F0oubMmqFqN96oW24N1I9bt1z2nsWLFurIX39dtl96epqmTp6oMmXKWjFVXKdIMM1RYKLIGvvcvdqy/U95eLircoVyjut31Kmp7h3u0Ouzv9SrM7+QJM1dukEnE9M0uGcrvbNknXbsOSxJ2rw9Xpu3xzuN2ywkQOXKlNLi2B+u3YcBoBuqVNHKuPW64YYq2vnbDvV++P5L9j918qTmzp6hPn376Z0Z0y7ZN2b2OypbrpwaNmqstd/EWTltXEcoMM2xRI4iKaxBbd3bJkQvTPz4Am03S5I+WvWj0/WPVv0od3d3dW9/6eWxBzo21NmzZ7Xky63WTRjAZXl6euqGG6oY95/21pu66SZ/dex09yX7Hdj/pz5c8J6GPh8ljxIeVztNAAYoMFHkuLu76c2o+zV/2Sb9tvewS7un57lgPiMz2+l6emaWJCk0qMZFxy5Rwl33tWug73+J14G/Tlk4awBW2vHrdn2xfJn+78Xoy6ZKkyaMVcNGjRXevMU1mh2KKzc3t3z7K24oMFHkDOjeXDVvrKRXZqy4YPueP49KkpqGBDhdDwutLUmqXrXCRcdu17SObqhYXou/ZHkcKKxyc3M1Ydx/1K5DR9WrH3rJvhvWr9X3m77T0OejrtHsAEiFcA/m8ePHtXHjRtntdiUmJkqSKlSooICAAIWFhalKFfPlExQ/lbzLaeSTnTRuzkqdOJ16wT4rN/ym/YdPauzQe5WRmaVtuw6oUd1zD/lkZ59RmVIlLzr+gx0bKis7Rx+v3pZfHwHAVVr+2afau3e33pg05ZL9srOz9OaEcbqv+4MKqH3ztZkcirfiFzTmm0JTYGZnZ+uNN97Q4sWLdebMGVWpUkXe3ueOiElKStLx48fl4eGhHj16KDo6WiVKFJqp4xp6+enOOp2cphmL1l20z99ZObr3mZlaML6fFk8aIEnK/DtbL721TC/266DUDNenziWpXBlPdW4ZrK++26VTSWn5Mn8AVyc1NVXTp05W7z6PqVq1Gy/Zd+EH7ykxMVEDnxp0jWYH4LxCU6VNmTJFn332mUaNGqWOHTvKy8vLqT01NVVffvmlJkyYoNKlS+v5558voJmioNSuWUX9uoXphYkf68Z/nE9Z2rOESpbwUM0bKyklLVOnk9O1y35Ed3T/j4ICqqmirax22Y8o4+9sjf+/+7Thx70XHL9Lq/oqV6YUD/cAhdiC9+YpOztb7Tp01OGEBEnSsaNHJEnJyck6nJCgKlWr6O/MvzVvzjvq/sBDSktNU1rquf/RmJ6ertzcXB1OSFDp0qVVqXLlAvssKHqK417J/FJoCszPPvtMw4YNU7du3S7YXr58ed1///1yd3fX5MmTKTCvQ9WrVJCHh7vejLpfb0a5Hl/yR+wrenvhN05Plu+yH3H86w7hdeTh4e5y7uV5PSIbKiUtUyvWbbd+8gAsceTIX0pOTtID3bq4tM2fO0vz587SwiWfyMvLpvT0dL3/bozefzfGpe/dkW3VolUbTZry9rWYNnDdKTQFZlpamqpVq3bZftWqVVNaGsuX16Od+w7rgaGzXa6//HRneZUrrefHL5X90IkL3lu6VEmNerKz/jqepP+udE0ob6hYXq3vvE3/XbXV5elzAIVHj4d7qmWrNk7XTp06pddffVld7r5XLVq1lq+vn0qUKKGJk13Pxlz84QL9uv1n/WfcxDwdiQRIRSPBTEtLU8eOHXX06FEtXbpUwcHBjraPPvpIc+fO1eHDh+Xv76+hQ4eqVatWTvenpKRo7NixWrNmjbKzs9W8eXONGDFCVatWzdM8Ck2BGRISonfeeUfBwcEuy+Pnpaam6p133lFo6KWfGkTxdDIxTcvXuqaLgx459x+Of7YteOMx/XU8SbvsR2QrV1q972kif98bdO/gmRf85Z/u7RuoZEkPLY5leRwoSEsWLVRKSrJOHD8mSVq/7hsd/f9L4D0e6qnbgm7XbUG3O91zfqk84Oab1bJ1W8f1f/7r89Z+E6ffdvx6wTbgcopAfakZM2bozJkzLte/+OILjRw5Uk888YSaNGmi2NhYDRo0SAsXLlRISIij35AhQ7R3716NHj1apUqV0pQpUzRgwAB9/PHHeXr+pdAUmCNHjlSfPn3UokULNWvWTAEBAY5CMzU1VXa7Xd99953KlSund999t2Ani0Lvp50H1OvuJup3X5gy/s7Wxm379Oiwd7V9d8IF+/eIbKSjJ5P19ebfr/FMAfzTgvfn6a/D/zvf9pu4r/RN3FeSpMhOd6v8RQIIANK+ffv04YcfKioqSi+//LJT29SpU9WpUycNGTJEktSkSRPt3r1b06dP15w5cyRJ27Zt04YNGxQTE6Pw8HBJkr+/vyIjI7V69WpFRkYaz8UtNzc315qPdfWSk5O1aNEiffvtt7Lb7UpOTpYk2Ww2BQQEKCIiQj169JDNZrvq9yoTylOFQHF1bNPUgp4CgHziVbrgjvC+5YWV+Tb2ngl3XfUYffv21W233aaWLVuqd+/ejiXygwcPqm3btpo+fbratv1fev/+++9r/Pjx+umnn+Tp6am33npLCxYs0JYtW5y2A9x7770KDAzUuHHjjOdSaBJM6VwhOXDgQA0cOLCgpwIAAFBkrFy5Urt379a0adP022+/ObXZ7XZJ59LIf6pdu7ays7N18OBB1a5dW3a7Xf7+/i57TQMCAhxjmCpUBSYAAEBhlZ97MNu0aXPJ9ri4uIu2ZWRkaNy4cRo6dKjKly/v0p6UlCRJLivA51+fb09OTr7gczDe3t7asWPHpT/Av/BTkQAAAEXYzJkzVblyZd13330FPRUHEkwAAAAD+XlM0aUSyktJSEjQvHnzNH36dKWkpEg694MC5/85LS3N8cuIKSkpTj+5ff5Zl/PtNptNR44c0b8lJSU5+piiwAQAACiiDh06pOzsbD3++OMubb1791b9+vU1adIkSef2YgYEBDja7Xa7SpYsqRo1akg6t9dy06ZNys3NdSqm4+Pjdeutt+ZpXhSYAAAABgrjOZhBQUF6//33na7t2rVLY8eO1ZgxYxQcHKwaNWqoVq1aWrlypdNT5LGxsWratKk8PT0lSREREZoxY4Y2bdqkZs2aSTpXXO7cuVP9+/fP07woMAEAAAy4uxe+CtNms6lx48YXbLv99tt1++3nfpjgmWee0fPPP6+aNWuqcePGio2N1fbt27VgwQJH/9DQUIWHh2v48OGKiopSqVKlNHnyZAUGBqp9+/Z5mhcFJgAAQDHXuXNnZWRkaM6cOZo9e7b8/f319ttvu/w64pQpUzR27FiNGjVKOTk5Cg8P14gRI/L0Kz5SITto/VrioHWg+OKgdaD4KsiD1m9/aXW+jf3bf/KWEBZ2HFMEAAAAS7FEDgAAYCA/jykqbkgwAQAAYCkSTAAAAAMEmOZIMAEAAGApEkwAAAAD7ME0R4EJAABggALTHEvkAAAAsBQJJgAAgAECTHMkmAAAALAUCSYAAIAB9mCaI8EEAACApUgwAQAADBBgmiPBBAAAgKVIMAEAAAywB9McBSYAAIAB6ktzLJEDAADAUiSYAAAABlgiN0eCCQAAAEuRYAIAABggwDRHggkAAABLkWACAAAYYA+mORJMAAAAWIoEEwAAwAABpjkKTAAAAAMskZtjiRwAAACWIsEEAAAwQIBpjgQTAAAAliLBBAAAMMAeTHMkmAAAALAUCSYAAIABAkxzJJgAAACwFAkmAACAAfZgmqPABAAAMECBaY4lcgAAAFiKBBMAAMAAAaY5EkwAAABYigQTAADAAHswzZFgAgAAwFIkmAAAAAYIMM2RYAIAAMBSJJgAAAAG2INpjgITAADAAPWlOZbIAQAAYCkSTAAAAAPuRJjGSDABAABgKRJMAAAAAwSY5kgwAQAAYCkSTAAAAAMcU2SOBBMAAACWIsEEAAAw4F4IA8x169Zpzpw52rt3r1JTU+Xj46O2bdtq0KBB8vLykiRFR0fr008/dbl3zpw5ioiIcLzOysrS5MmT9fnnnystLU2hoaEaOXKkAgIC8jwvCkwAAIAiKjExUfXq1VOvXr1UoUIF7dmzR9OmTdOePXs0b948R78aNWpo4sSJTvfWrl3b6fVrr72m2NhYRUdHy8fHR++8844effRRffHFF45i1RQFJgAAgIHCuAeza9euTq8bN24sT09PjRw5UkePHpWPj48kqXTp0goJCbnoOEeOHNHSpUv18ssvq3v37pKk4OBgtWrVSosXL9aAAQPyNC/2YAIAABhwc8u/PytVqFBBkpSdnW18z4YNG3T27FndddddTuOEhYVp/fr1eZ4DBSYAAEARd+bMGf3999/67bffNH36dLVu3Vp+fn6O9v379+uOO+5Q3bp11a1bN61Zs8bpfrvdrsqVK8vb29vpeu3atWW32/M8H5bIAQAADLgp/5bI27Rpc8n2uLi4S7a3atVKR48elSQ1b95ckyZNcrQFBQUpODhYN998s1JSUrRo0SI9/fTTeuuttxyJZXJy8gX3WdpsNiUlJeX141BgAgAAFHWzZ89WRkaG9u7dq5kzZ+qJJ57Q/Pnz5eHhoT59+jj1bd26tXr06KGpU6c6LYlbiQITAADAQH4eU3S5hPJybrvtNklSaGiogoOD1bVrV3311VcXLCDd3d3Vvn17TZgwQZmZmSpdurRsNptSU1Nd+iYnJ7ssm5tgDyYAAEAxEhgYqJIlS+rAgQPG9wQEBOjEiRMuy+F2u/2KzsGkwAQAADDg5uaWb39W+uWXX5Sdne30kM8/nT17VitXrtQtt9yi0qVLS5LCw8Pl7u6u1atXO/olJSVpw4YNToexm2KJHAAAoIgaNGiQ6tatq8DAQJUuXVq///67YmJiFBgYqLZt2yohIUHR0dHq1KmTbrrpJiUlJWnRokXasWOHpk2b5hinWrVq6t69u8aPHy93d3f5+Pho1qxZ8vLyUo8ePfI8LwpMAAAAA4XwnHXVq1dPsbGxmj17tnJzc+Xr66v7779f/fr1k6enp8qVK6fy5ctr5syZOnnypEqWLKm6detqzpw5at68udNYI0aMULly5TRp0iSlpaWpQYMGmj9/fp5/xUeS3HJzc3Ot+pBFSZnQQQU9BQD55NimqQU9BQD5xKt0we3u6xbzY76N/Um/O/Jt7ILAHkwAAABYiiVyAAAAA4VxibywIsEEAACApUgwAQAADFh9nFBxRoIJAAAAS5FgAgAAGCDANEeCCQAAAEuRYAIAABhwJ8I0RoEJAABggPLSHEvkAAAAsBQJJgAAgAGOKTJHggkAAABLkWACAAAYcCfANEaCCQAAAEuRYAIAABhgD6Y5EkwAAABYigQTAADAAAGmOQpMAAAAAyyRm2OJHAAAAJYiwQQAADDAMUXmSDABAABgKeMEc9iwYXke3M3NTa+//nqe7wMAAChs2INpzrjA3Lx5s8u1zMxMnTp1SpLk7e0tSUpKSpIkVapUSWXKlLFijgAAAChCjAvMr7/+2un13r179dhjj2ngwIHq06ePKlWqJEk6deqU3nvvPS1btkyzZ8+2drYAAAAFhPzS3BXvwXz11VcVERGhoUOHOopL6VxyOXToUDVv3lyvvvqqJZMEAABA0XHFBeYvv/yiOnXqXLQ9KChIv/zyy5UODwAAUKi4u7nl219xc8UFpre3t9avX3/R9vXr18vLy+tKhwcAAChU3Nzy76+4ueIC88EHH9TatWv15JNP6rvvvtOhQ4d06NAhbdy4UU888YTWr1+vHj16WDlXAAAAFAFXfND6U089paysLMXExGjt2rVObR4eHnr88cf11FNPXe38AAAACgWOKTJ3Vb/kM2TIEPXu3VubNm1SQkKCJMnX11dNmzZ1evAHAAAA14+r/qnISpUqqVOnTlbMBQAAoNAiwDRnXGAePnz4it6gevXqV3QfAAAAiibjArN169ZXtPdg165deb4HAACgsCmOxwnlF+MC8/XXX2dzKwAAAC7LuMDs1q1bfs4DAACgUCNnM3fVD/mcl5mZKUkqXbq0VUMCAAAUGqzkmruqAvPw4cOaNm2a1q1bp9OnT0uSKlasqBYtWmjQoEHy9fW1ZJIAAAAoOq64wNy3b58efvhhpaSkqFmzZqpdu7YkyW6367PPPtM333yjDz/8UAEBAZZN1kqnf3i7oKcAIJ9UDHuhoKcAIJ9kbJ5QYO99xT9/eB264gJz0qRJcnd316effqrAwECntt27d+vRRx/VpEmTNH369KueJAAAAIqOKy7Gf/jhB/Xq1culuJSkW2+9VY888oi2bNlyVZMDAAAoLNzc3PLtr7i54gIzJyfnkg/0lClTRjk5OVc6PAAAAIqoKy4wg4KC9NFHHyklJcWlLTU1VUuXLlWdOnWuanIAAACFhbtb/v0VN1e8B/OZZ57RgAED1LFjR3Xr1k21atWSJMXHx+vTTz9VYmKiRo0aZdU8AQAAUERccYHZtGlTzZ49W+PHj9fs2bOd2oKCgjRhwgQ1adLkqicIAABQGBTHpDG/XNU5mM2aNdOyZct0/PhxHT58WJJUvXp1ValSxZLJAQAAFBbF8WGc/JLnAvOvv/6Su7u7fHx8JEl///23VqxY4Wj/6aefJEk+Pj6KjIy0aJoAAAAoKvJUYP7xxx+69957NXz4cPXs2VOSlJ6erjfeeENubm7Kzc119PXw8FDt2rUveIwRAABAUcMSubk8PUW+ZMkSVa9eXQ8//LBL24QJExQXF6e4uDh99dVXqlq1qpYsWWLZRAEAAFA05CnB3Lx5s9q1ayd3d9e6tHLlyk6/Pd65c2d9/fXXVz9DAACAQoAtmObylGAmJCS4/LZ4iRIldNttt6lcuXJO1/38/BwP/gAAAOD6keeHfP65z1KSvLy8tGzZMpd+/96TCQAAUJS5E2Eay1OC6ePjo99//92o7++//+540hwAAADWW7dunXr27KkmTZqobt26atOmjcaOHevyS4tff/217r77bgUHB6tDhw76+OOPXcbKysrSG2+8obCwMIWEhKhv376y2+1XNK88FZhhYWFavny5Tp48ecl+J0+e1PLlyxUWFnZFkwIAAChs3PPx70olJiaqXr16GjNmjGJiYtS3b18tW7ZMzz77rKPP1q1bNWjQIIWEhGjOnDnq2LGjXnrpJa1cudJprNdee00fffSRhg4dqmnTpikrK0uPPvroBX8W/HLytET+2GOP6dNPP9Wjjz6q119/XcHBwS59fv31Vw0fPlw5OTnq27dvnicEAABQGBXGFfKuXbs6vW7cuLE8PT01cuRIHT16VD4+Ppo5c6bq1aunV155RZLUpEkTHTx4UFOnTtVdd90lSTpy5IiWLl2ql19+Wd27d5ckBQcHq1WrVlq8eLEGDBiQp3nlqcD08/PTm2++qeeee04PPPCAatasqVtvvVVly5ZVenq6du/erQMHDqh06dKaOHGiatSokafJAAAA4OpUqFBBkpSdna2srCxt3rxZzz//vFOfyMhIrVixQocOHZKfn582bNigs2fPOgrO8+OEhYVp/fr1+VtgSlKrVq30+eefa86cOVq7dq2++uorR1uVKlXUvXt39e/fXzfddFNehwYAACi0CvNDPmfOnFFOTo727t2r6dOnq3Xr1vLz89PevXuVnZ3tcgpQ7dq1JUl2u11+fn6y2+2qXLmyvL29XfotXbo0z/O5ot8ir1GjhiNmTU1NVVpamsqVK6fy5ctfyXAAAADXtTZt2lyyPS4u7pLtrVq10tGjRyVJzZs316RJkyRJSUlJkiSbzebU//zr8+3Jycny8vJyGddmszn65MUVFZj/VL58eQpLAABQ7BXiAFOzZ89WRkaG9u7dq5kzZ+qJJ57Q/PnzC2w+V11gAgAA4OpcLqG8nNtuu02SFBoaquDgYHXt2lVfffWVbr75ZklyeRI8OTlZkhxL4jabTampqS7jJicnuyybm7iaJ+MBAACuG+5u+fdnpcDAQJUsWVIHDhxQzZo1VbJkSZfzLM+/Pr83MyAgQCdOnHBZDrfb7S77N01QYAIAABQjv/zyi7Kzs+Xn5ydPT081btxYq1atcuoTGxur2rVry8/PT5IUHh4ud3d3rV692tEnKSlJGzZsUERERJ7nwBI5AACAgcL4FPmgQYNUt25dBQYGqnTp0vr9998VExOjwMBAtW3bVpL05JNPqnfv3ho9erQ6duyozZs3a8WKFZo8ebJjnGrVqql79+4aP3683N3d5ePjo1mzZsnLy0s9evTI87woMAEAAIqoevXqKTY2VrNnz1Zubq58fX11//33q1+/fvL09JQkNWzYUNOmTdOUKVO0dOlSVa9eXa+99po6duzoNNaIESNUrlw5TZo0SWlpaWrQoIHmz59/wafLL8ctNzc315JPWMRk5hT0DADkl4phLxT0FADkk4zNEwrsvV9dszffxh7Z9uZ8G7sgkGACAAAYsPphnOKMh3wAAABgKRJMAAAAA24iwjRFggkAAABLkWACAAAYYA+mORJMAAAAWIoEEwAAwAAJpjkSTAAAAFiKBBMAAMCAWyH8qcjCigITAADAAEvk5lgiBwAAgKVIMAEAAAywQm6OBBMAAACWIsEEAAAw4E6EaYwEEwAAAJYiwQQAADDAU+TmSDABAABgKRJMAAAAA2zBNEeBCQAAYMBdVJimWCIHAACApUgwAQAADLBEbo4EEwAAAJYiwQQAADDAMUXmSDABAABgKRJMAAAAA/xUpDkSTAAAAFiKBBMAAMAAAaY5CkwAAAADLJGbY4kcAAAAliLBBAAAMECAaY4EEwAAAJYiwQQAADBAKmeO7woAAACWIsEEAAAw4MYmTGMkmAAAALAUCSYAAIAB8ktzFJgAAAAGOGjdHEvkAAAAsBQJJgAAgAHyS3MkmAAAALAUCSYAAIABtmCaI8EEAACApUgwAQAADHDQujkSTAAAAFiKBBMAAMAAqZw5CkwAAAADLJGboxgHAACApUgwAQAADJBfmiPBBAAAgKVIMAEAAAywB9McCSYAAAAsRYIJAABgoDCmcl9++aU+//xz/fbbb0pOTtZNN92kXr166b777nMkrr169dKWLVtc7o2NjVXt2rUdr1NSUjR27FitWbNG2dnZat68uUaMGKGqVavmeV4UmAAAAEXUu+++K19fX0VHR6tixYr67rvvNHLkSB05ckSDBg1y9GvQoIGioqKc7vXz83N6PWTIEO3du1ejR49WqVKlNGXKFA0YMEAff/yxSpTIW8lIgQkAAGCgMO7BnDlzpipVquR43bRpUyUmJmr+/Pl66qmn5O5+Lne12WwKCQm56Djbtm3Thg0bFBMTo/DwcEmSv7+/IiMjtXr1akVGRuZpXoUx7QUAACh03PLx70r9s7g8LygoSKmpqUpPTzceZ/369bLZbAoLC3NcCwgIUFBQkNavX5/neVFgAgAAFCM//vijfHx8VL58ece1LVu2KCQkRMHBwerZs6d++OEHp3vsdrv8/f1dUtqAgADZ7fY8z4ElcgAAAAP5uULepk2bS7bHxcUZjbN161bFxsY67bds1KiRunbtqlq1aunYsWOKiYlR37599cEHHyg0NFSSlJycLC8vL5fxvL29tWPHjjx8knMoMAEAAIqBI0eOaOjQoWrcuLF69+7tuD548GCnfi1btlTnzp01Y8YMzZkzJ1/mQoEJAABgwD0ffyzSNKG8mOTkZA0YMEAVKlTQtGnTHA/3XEjZsmXVokULrVq1ynHNZrPpyJEjLn2TkpLk7e2d5/mwBxMAAKAIy8zM1MCBA5WSkqK5c+decKn7cgICAhQfH6/c3Fyn6/Hx8QoICMjzeBSYAAAABtzc8u/vSuXk5GjIkCGy2+2aO3eufHx8LntPenq61q5dq+DgYMe1iIgIJSUladOmTY5r8fHx2rlzpyIiIvI8L5bIAQAAiqgxY8bom2++UXR0tFJTU/Xzzz872urUqaPt27dr7ty5ateunXx9fXXs2DHNnz9fx48f11tvveXoGxoaqvDwcA0fPlxRUVEqVaqUJk+erMDAQLVv3z7P86LABAAAMOCWj3swr9TGjRslSePGjXNpi4uLU5UqVZSdna3JkycrMTFRZcqUUWhoqMaMGaN69eo59Z8yZYrGjh2rUaNGKScnR+Hh4RoxYkSef8VHktxy/73Yfp3IzCnoGQDILxXDXijoKQDIJxmbJxTYe8f+dizfxo68Pe+/912YsQcTAAAAlmKJHAAAwEB+HlNU3JBgAgAAwFIkmAAAAAby86ciixsSTAAAAFiKBBMAAMAACaY5EkwAAABYigQTAADAQGE8aL2wIsEEAACApUgwAQAADLgTYBqjwAQAADDAErk5lsgBAABgKRJMAAAAAxxTZI4EEwAAAJYiwQQAADDAHkxzJJgAAACwFAkmAACAAY4pMkeBiSIlPS1N786P0a/bf9GOX39VcnKSXnltrLre282p38cf/VdfrPhc8fF2pSQnq0rVqmrYqLGeeOpp+fr6XXT8n37cqr69H5Ekrd2wSRUrVsrXzwPg4l58tLXGPNlRv+07ooYPT3Jcd3NzU797Gqt/t6aq7VdZaZlZ+vn3BI2bt0bf/7rfaYzaNW7QywM7qFn9WqpoK6uDRxK1ZPU2TVmwThl/Z1/rjwRcNygwUaScTjytWTOn68Ybq+vWwEBt/WHLBfv9vmunfH391KJVa9lsNiUcOqRPln6kb9d9o/9+8pmqVvVxuefs2bMa9/prKlOmrDIy0vP7owC4BN+q3nrx0TZKTf/bpW3sM5307CMt9OGXP2r2x9+pQvky6ndvE61+50m1HjBdW3celCT5VfXWt/OeUXJqpt756DudSk5X4+CbNOrxDgq9zU8PvPDuNf5UKOrYg2mOAhNFSpUqVRW3doNuqFJFv+34VQ8/2P2C/V4aNdrlWus2bfXQA/dp+Wefqd+Ax13al360REeP/KVu93XXwgXvWz11AHkwdnBnbdmxXx7u7qpcoZzjuoeHuwbc11SfxP2ifqMXO65/HPeLfl82XD3uCnUUmA91vEMVbWXV5vEZ2hV/VJI0b9lmubu5qWenhqrgVUaJKRnX9oOhSOOYInM85IMixdPTUzdUqXJF91b39ZUkpaQku7QlJSZq+tQpemrQYHnZbFc1RwBXJyzEX/e2CtYLkz93aStZwl1lS3vq2KlUp+vHT6fqzJmzysj837K3rVwpSdKxUylOfY+cSNaZM2eVlZ2TD7MHIFFgophLTDytkydP6rcdv2rUS8MkSY2bNHXpN33aW6p8QxV1f6DHtZ4igH9wd3fTm8/fo/mfb9Fv+464tGf+naMtO/arZ6eG6tEhVDV8KqjuzTdqzqgHdTolQzHLNjv6rv/JLkmaOeIB1buluvyqeqt72/oacF9TzfjvBqVnsgcTeeOWj3/FDUvkKNbatYpQVlaWJKlChQqKGj5CTZuFOfXZ/cfvWvrREr09c7Y8PDwKYpoA/r8B3ZqqZrWK6jRo9kX79H15kT74T0/Nf+VhxzX7oZNqPWC6/jx8ynHtq+//0Oh3VurFR1urS8Ttjuvj5q3RmFmr8ucDAJBUBAvM06dPa+/evWrUqFFBTwVFwPR35igr62/Z99n1xYrPlZHuut/qjbH/UVh4hJqFhRfADAGcV8lWViMfb69x89boRGLaRfulpv+tXfaj2vLrfn3zw175VPbS871b6b/j+6jtwBk6mfS/h/T2/3VaG7bFa9k323UqKV13hQXpxUdb6+jJFL2z9Ltr8bFQjLizCdNYkSswt2zZoiFDhmjXrl0FPRUUAXc2biJJCm/eQq1at9F993RW2bJl9dAjPSVJK7+M1c/btunjz5YX5DQBSHr5ibt0OjldM/678aJ9PDzc9cW0x/XtT/v03KTPHNe//mGPflr0fxras6VGTI+VJN3frr6mD7tP9e4fr4RjSZKkz9bukLu7m14b1En/Xf2zTiVzYgSQH9iDietGjZo1dVtQHcV+8b9icvLE8WrfoYNKliyphIRDSkg4pJTkcw8BHTlyRMeOHS2o6QLXldo1blC/exprxpKNurGKTTVvrKiaN1ZU6VIlVLKEu2reWFEVbWUUHuKvujffqBXf7nS6f9/BE/r9z2NqWr+W49rj9zXTL38cdhSX532xfqfKlfFU/UDfa/HRUIywB9NcoUkwu3TpYtQvLe3iyybA5WRmZir7/+/JlKQjR/5S7BcrFPvFCpe+Pbrfq8DA2/TfTz5zaQNgrepVbPLwcNebz9+jN5+/x6X9j2XD9fbib/XDbwckSR7urvlIyRIeKuHxv+tVK5W/4DFEJUuc6/PPvgCsVWgKTLvdrptvvll16tS5ZL+EhAT99ddf12hWKIpycnKUnpYmm7e30/Vft2/X3j271bFTZ8e1yVOnu9y/8ssvtOrLWL029g35+FTL9/kCkHbuO3LBg89ffuIueZUtpeff/Ez2hJPyLHnuQbz724Xoq+//cPQLCfTVrTWrOD1FvufACbVtfKturnGD9h484bj+QPtQnTlzVjv28t8lyKPiGDXmk0JTYN5yyy266aabNHbs2Ev2W7VqlX744YdrNCsURosWLlBKSrKOHzsmSVq39hsdPXruOJOHHuml3NxctW/TUh06dlTt2reoTNky2rN7tz5b9onKl/fS40885RirdZu2LuP/8fu5/b3hzSP4qUjgGjmZlK7l639zuT6oR3NJcmpbs3m3enVuKFu5Ulqzebeq3WDTk/eHKePvbL29+FtHv8kL1qpD00Ctmf3UuV/ySUpTx/Ag3dUsSPOWbdZfJ1zPxAUuhV/yMVdoCsx69erp22+/vXxHSbm5ufk8GxRm7787T4cPJzhex61Zrbg1qyVJnbrcrapVqqrbfd31w5bNWrN6lTIz/1bVqlXVMbKTBgx88pK/RQ6g8Lv/hfka8khL3d+uvto1DVRW9hlt/Dler8xapT0Hjjv6bfw5Xq0GTNdLA9rp8fuaqrJ3Wf15+JRGzfhSby5YW3AfALgOuOUWkmrtwIED2rNnj9q0aXPJfpmZmTp58qR8fa9uc3YmP+AAFFsVw14o6CkAyCcZmycU2HtvsSddvtMVujPA+/KdipBCk2DWrFlTNWvWvGy/0qVLX3VxCQAAgPxTaApMAACAwowdmOY4owEAAACWIsEEAAAwQYRpjAQTAAAAliLBBAAAMMA5mOYoMAEAAAy4UV8aY4kcAAAAliLBBAAAMECAaY4EEwAAAJYiwQQAADBBhGmMBBMAAACWIsEEAAAwwDFF5kgwAQAAYCkSTAAAAAOcg2mOAhMAAMAA9aU5lsgBAABgKRJMAAAAE0SYxkgwAQAAYCkKTAAAAANu+fiPK/Xll1/qySefVEREhEJCQtS1a1ctXbpUubm5Tv0++ugjdejQQcHBwbr77rv1zTffuIyVkpKi4cOH684771RoaKgGDx6sY8eOXdG8KDABAACKqHfffVdlypRRdHS0Zs6cqYiICI0cOVLTp0939Pniiy80cuRIdezYUXPmzFFISIgGDRqkn3/+2WmsIUOGaOPGjRo9erQmTpyo+Ph4DRgwQDk5OXmel1vuv0vc60Rm3r8rAEVExbAXCnoKAPJJxuYJBfbevx5Kzbexg/3KX9F9p06dUqVKlZyujRw5UrGxsfrhhx/k7u6uDh06qG7dupo0aZKjT48ePeTl5aU5c+ZIkrZt26YePXooJiZG4eHhkiS73a7IyEi9+eabioyMzNO8SDABAACKqH8Xl5IUFBSk1NRUpaen6+DBg/rzzz/VsWNHpz6RkZHatGmTsrKyJEnr16+XzWZTWFiYo09AQICCgoK0fv36PM+LAhMAAMCAWz7+WenHH3+Uj4+PypcvL7vdLkny9/d36lO7dm1lZ2fr4MGDks6llf7+/nL712nyAQEBjjHygmOKAAAATOTjMUVt2rS5ZHtcXJzROFu3blVsbKyioqIkSUlJSZIkm83m1O/86/PtycnJ8vLychnP29tbO3bsMHrvfyLBBAAAKAaOHDmioUOHqnHjxurdu3eBzoUEEwAAwMDVHCd0OaYJ5cUkJydrwIABqlChgqZNmyZ393MZore3t6RzRxBVqVLFqf8/2202m44cOeIyblJSkqNPXpBgAgAAFGGZmZkaOHCgUlJSNHfuXKel7oCAAEly2Udpt9tVsmRJ1ahRw9EvPj7e5fzM+Ph4xxh5QYEJAABgwM0t//6uVE5OjoYMGSK73a65c+fKx8fHqb1GjRqqVauWVq5c6XQ9NjZWTZs2laenpyQpIiJCSUlJ2rRpk6NPfHy8du7cqYiIiDzPiyVyAACAImrMmDH65ptvFB0drdTUVKfD0+vUqSNPT08988wzev7551WzZk01btxYsbGx2r59uxYsWODoGxoaqvDwcA0fPlxRUVEqVaqUJk+erMDAQLVv3z7P8+KgdQDFDgetA8VXQR60vutwWr6NHVS93BXd17p1ayUkJFywLS4uTn5+fpLO/VTknDlzdPjwYfn7++u5555Tq1atnPqnpKRo7Nix+uqrr5STk6Pw8HCNGDHCJRU1QYEJoNihwASKLwrMooElcgAAABP5eA5mcUOBCQAAYCA/jykqbniKHAAAAJYiwQQAADBwNccJXW9IMAEAAGApEkwAAAADBJjmSDABAABgKRJMAAAAE0SYxkgwAQAAYCkSTAAAAAOcg2mOAhMAAMAAxxSZY4kcAAAAliLBBAAAMECAaY4EEwAAAJYiwQQAADBBhGmMBBMAAACWIsEEAAAwwDFF5kgwAQAAYCkSTAAAAAOcg2mOBBMAAACWIsEEAAAwQIBpjgITAADABBWmMZbIAQAAYCkSTAAAAAMcU2SOBBMAAACWIsEEAAAwwDFF5kgwAQAAYCkSTAAAAAMEmOZIMAEAAGApEkwAAAAD7ME0R4EJAABghArTFEvkAAAAsBQJJgAAgAGWyM2RYAIAAMBSJJgAAAAGCDDNkWACAADAUiSYAAAABtiDaY4EEwAAAJYiwQQAADDgxi5MYxSYAAAAJqgvjbFEDgAAAEuRYAIAABggwDRHggkAAABLkWACAAAY4JgicySYAAAAsBQJJgAAgAGOKTJHggkAAABLkWACAACYIMA0RoEJAABggPrSHEvkAAAAsBQJJgAAgAGOKTJHgQkAAFCE7d+/XzExMfrll1+0Z88eBQQEaMWKFU59evXqpS1btrjcGxsbq9q1aztep6SkaOzYsVqzZo2ys7PVvHlzjRgxQlWrVs3TnCgwAQAADBTWY4r27NmjdevWqX79+jp79qxyc3Mv2K9BgwaKiopyuubn5+f0esiQIdq7d69Gjx6tUqVKacqUKRowYIA+/vhjlShhXjZSYAIAABRhrVu3Vtu2bSVJ0dHR2rFjxwX72Ww2hYSEXHScbdu2acOGDYqJiVF4eLgkyd/fX5GRkVq9erUiIyON58RDPgAAAAbc3PLv72q4u1tTzq1fv142m01hYWGOawEBAQoKCtL69evzNidLZgQAAIBCbcuWLQoJCVFwcLB69uypH374wandbrfL399fbv+qeAMCAmS32/P0XiyRAwAAFLA2bdpcsj0uLu6qxm/UqJG6du2qWrVq6dixY4qJiVHfvn31wQcfKDQ0VJKUnJwsLy8vl3u9vb0vuux+MRSYAAAABoryMUWDBw92et2yZUt17txZM2bM0Jw5cyx/PwpMAACAAna1CWVelS1bVi1atNCqVasc12w2m44cOeLSNykpSd7e3nkanz2YAAAABtzy8R+FQUBAgOLj412OOYqPj1dAQECexqLABAAAuM6kp6dr7dq1Cg4OdlyLiIhQUlKSNm3a5LgWHx+vnTt3KiIiIk/js0QOAABgoLDuwczIyNC6deskSQkJCUpNTdXKlSslSXfeeafsdrvmzp2rdu3aydfXV8eOHdP8+fN1/PhxvfXWW45xQkNDFR4eruHDhysqKkqlSpXS5MmTFRgYqPbt2+dpTm65FzvuvZjLzCnoGQDILxXDXijoKQDIJxmbJxTYeydnns23sW2lr3xR+dChQxd9Cv39999XtWrV9Morr+iPP/5QYmKiypQpo9DQUA0aNEj16tVz6n/+pyK/+uor5eTkKDw8XCNGjJCPj0+e5kSBCaDYocAEiq+CLDBT8rHA9LqKArMwKl6fBgAAAAWOPZgAAAAmCukezMKIAhMAAMBAYTlOqChgiRwAAACWIsEEAAAwUFiPKSqMSDABAABgKRJMAAAAAwSY5kgwAQAAYCkSTAAAABNEmMZIMAEAAGApEkwAAAADnINpjgITAADAAMcUmWOJHAAAAJZyy83NzS3oSQAAAKD4IMEEAACApSgwAQAAYCkKTAAAAFiKAhMAAACWosAEAACApSgwAQAAYCkKTAAAAFiKAhMAAACWosAEAACApSgwAQAAYCkKTAAAAFiKAhMAAACWosAEAACApSgwUWzt27dPffv2VUhIiMLCwjR+/HhlZWUV9LQAWGD//v0aNWqUunbtqjp16qhz584FPSUA/1CioCcA5IekpCT16dNHtWrV0rRp03T06FGNGzdOmZmZGjVqVEFPD8BV2rNnj9atW6f69evr7Nmzys3NLegpAfgHCkwUS4sXL1ZaWprefvttVahQQZJ05swZjRkzRgMHDpSPj0/BThDAVWndurXatm0rSYqOjtaOHTsKeEYA/oklchRL69evV9OmTR3FpSR17NhRZ8+e1caNGwtuYgAs4e7Of30BhRn/CUWxZLfbFRAQ4HTNZrOpSpUqstvtBTQrAACuDxSYKJaSk5Nls9lcrnt7eyspKakAZgQAwPWDAhMAAACWosBEsWSz2ZSSkuJyPSkpSd7e3gUwIwAArh8UmCiWAgICXPZapqSk6Pjx4y57MwEAgLUoMFEsRURE6LvvvlNycrLj2sqVK+Xu7q6wsLACnBkAAMUf52CiWOrRo4c++OADPf300xo4cKCOHj2q8ePHq0ePHpyBCRQDGRkZWrdunSQpISFBqampWrlypSTpzjvvVKVKlQpyesB1zy2Xnz9AMbVv3z69+uqr2rZtm8qVK6euXbtq6NCh8vT0LOipAbhKhw4dUps2bS7Y9v7776tx48bXeEYA/okCEwAAAJZiDyYAAAAsRYEJAAAAS1FgAgAAwFIUmAAAALAUBSYAAAAsRYEJAAAAS1FgAgAAwFIUmACKnNatWys6OtrxevPmzQoMDNTmzZste4/AwEBNmzbNsvEA4HpCgQkgzz755BMFBgY6/oKDg9WhQwe98sorOnHiREFPz9i6desoIgEgH/Bb5ACu2ODBg+Xn56esrCz9+OOPWrRokdatW6cVK1aoTJky12wejRo10vbt21WyZMk83bdu3TotXLhQzzzzjEvb9u3b5eHhYdUUAeC6QoEJ4IpFREQoODhYknT//ferQoUKmj9/vuLi4tS5c2eX/unp6Spbtqzl83B3d1epUqUsHdPq8QDgesISOQDLNGnSRJJ06NAhRUdHKzQ0VAcOHNCAAQMUGhqq559/XpJ09uxZvfvuu+rUqZOCg4PVrFkzjRo1SklJSU7j5ebmasaMGYqIiFD9+vXVq1cv7dmzx+V9L7YH85dfftGAAQPUqFEjhYSEqEuXLnrvvfckSdHR0Vq4cKEkOS33n3ehPZg7d+5U//791aBBA4WGhqpPnz76+eefnfqc3z7w448/auzYsWrSpIlCQkL09NNP69SpU1fwrQJA0UOCCcAyBw4ckCRVqFBBkpSTk6N+/frpjjvuUFRUlEqXLi1JGjVqlD799FN169ZNvXr10qFDh7Rw4ULt3LlTixYtcix1v/XWW5o5c6ZatGihFi1a6LffftNjjz2m7Ozsy85l48aNGjhwoKpWrarevXvrhhtu0L59+7R27Vr16dNHDz74oI4dO6aNGzdq/Pjxlx1vz549euSRR1SuXDn1799fJUqU0JIlS9SrVy8tWLBA9evXd+r/2muvyWazadCgQUpISNB7772nV155RVOmTMnDNwoARRMFJoArlpqaqlOnTikrK0s//fSTpk+frtKlS6tVq1b6+eeflZWVpbvuukv/93//57hn69at+uijjzRx4kR16dLFcb1x48bq37+/Vq5cqS5duujUqVOaO3euWrZsqXfeeUdubm6SpMmTJ+udd9655LzOnDmjUaNGqWrVqlq2bJlsNpujLTc3V5IUGhqqWrVqaePGjeratetlP+uUKVOUnZ2tRYsWqUaNGpKke+65R3fddZcmTJigBQsWOPWvUKGC5s2b55j32bNn9cEHHyglJUVeXl6XfT8AKMpYIgdwxR599FE1bdpULVq00NChQ1WuXDm9/fbb8vHxcfR56KGHnO5ZuXKlvLy8FBYWplOnTjn+br/9dpUtW9axzP3dd98pOztbPXv2dBRpktSnT5/Lzmvnzp06dOiQevfu7VRcSnIay9SZM2e0ceNGtW3b1lFcSlLVqlXVuXNn/fjjj0pNTXW654EHHnB6r4YNG+rMmTNKSEjI8/sDQFFDggngio0aNUr+/v7y8PDQDTfcIH9/f7m7/+9/t5YoUULVqlVzumf//v1KSUlR06ZNLzjmyZMnJUmHDx+WJNWqVcupvVKlSvL29r7kvA4ePChJuvXWW/P0eS7m1KlTysjIkL+/v0tb7dq1dfbsWf3111+65ZZbHNerV6/u1O98oZucnGzJnACgMKPABHDF6tWr53iK/EI8PT2dCk7p3FJx5cqVNXHixAveU6lSJUvnWFD+/bnPO79EDwDFGQUmgGuqZs2a2rRpkxo0aOB46OdCzieAf/75p9Oy9KlTp1yeNv+38/13796tZs2aXbSf6XJ5pUqVVKZMGcXHx7u02e12ubu768YbbzQaCwCuB+zBBHBNdezYUWfOnNGMGTNc2nJychxLyM2aNVPJkiW1YMECp9Tv/DFDl3L77bfLz89P77//vsuS9D/HOn8Y/OWWrT08PBQWFqa4uDgdOnTIcf3EiRNasWKF7rjjDpUvX/6y8wKA6wUJJoBr6s4779SDDz6oWbNmadeuXQoLC1PJkiX1559/auXKlXrppZd01113qVKlSnrsscc0a9YsDRw4UC1atNDOnTu1fv16VaxY8ZLv4e7urtGjR+vJJ5/UPffco27duqlKlSqy2+3au3evYmJiJJ0rRKVzRwqFh4fLw8NDnTp1uuCYQ4YM0XfffaeHH35YDz/8sDw8PLRkyRJlZWXphRdesPZLAoAijgITwDX3yiuvqG7dulq8eLEmT54sDw8P+fr66u6771aDBg0c/YYMGSJPT08tXrxYmzdvVr169TRv3jwNHDjwsu/RvHlzvffee5o+fbrmzZun3Nxc1ahRQw888ICjT/v27dWrVy998cUX+vzzz5Wbm3vRAvOWW27RwoULNWnSJM2aNUu5ubmqV6+eJkyY4HIGJgBc79xy2XEOAAAAC7EHEwAAAJaiwAQAAIClKDABAABgKQpMAAAAWIoCEwAAAJaiwAQAAIClKDABAABgKQpMAAAAWIoCEwAAAJaiwAQAAIClKDABAABgKQpMAAAAWIoCEwAAAJb6f9c4eBmmPhlSAAAAAElFTkSuQmCC\n"
+          },
+          "metadata": {}
+        }
+      ],
+      "source": [
+        "print('------Test set 1 (Tweets):------')\n",
+        "evaluate(test_dataloader_tweets)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 34,
+      "metadata": {
+        "id": "vS9ybeVFPspM",
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 781
+        },
+        "outputId": "2b07c597-fa18-44f5-f177-bfdc63cf315d"
+      },
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "------Test set 2 (News):------\n",
+            "Accuracy: [364/500] 0.7280\n",
+            "Classification Report:\n",
+            "               precision    recall  f1-score   support\n",
+            "\n",
+            "           0     0.7084    0.9749    0.8206       319\n",
+            "           1     0.8689    0.2928    0.4380       181\n",
+            "\n",
+            "    accuracy                         0.7280       500\n",
+            "   macro avg     0.7886    0.6339    0.6293       500\n",
+            "weighted avg     0.7665    0.7280    0.6821       500\n",
+            "\n"
+          ]
+        },
+        {
+          "output_type": "display_data",
+          "data": {
+            "text/plain": [
+              "<Figure size 800x600 with 2 Axes>"
+            ],
+            "image/png": "iVBORw0KGgoAAAANSUhEUgAAApgAAAIsCAYAAABWatmqAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjguMCwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy81sbWrAAAACXBIWXMAAA9hAAAPYQGoP6dpAABE+UlEQVR4nO3de3zPdf/H8ec2hrHvZg6TOW0rMzU2YdjMYQ5tyFWXojKSXFSErrqMcOlwpRwihyQkpXB1oGg5JCwjSkqF0OZ8jOzg0Dbb7w+X769vc3hvPl87eNyv2/d29f183t/39/X9Xgcvz/f78/m65Obm5goAAACwiGthFwAAAICShQYTAAAAlqLBBAAAgKVoMAEAAGApGkwAAABYigYTAAAAlqLBBAAAgKVoMAEAAGApGkwAAABYigYTwHXbu3evHnnkEd15550KCgrSF198Yen8Bw8eVFBQkD7++GNL5y3O4uLiFBcXV9hlAMBl0WACJcT+/fs1evRoRUdHKyQkRI0aNVKPHj00b948nT9/3qnvHR8fr127dmno0KEaN26c7rjjDqe+340UHx+voKAgNWrU6LLf4969exUUFKSgoCDNmTMn3/MfO3ZMU6dO1Y4dO6woFwCKhFKFXQCA67d27VoNHjxY7u7u6tq1q+rWrausrCxt2bJF48eP1549e/TCCy845b3Pnz+vrVu3asCAAerZs6dT3sPPz0/btm1TqVKF839ZpUqV0vnz5/Xll18qNjbW4dzSpUtVpkwZ/fHHHwWa+/jx45o2bZr8/PwUHBxs/LqCNLMAcKPQYALF3IEDBzR06FBVr15d8+bNU9WqVe3nHnroIe3bt09r16512vufOnVKkmSz2Zz2Hi4uLipTpozT5r8Wd3d3NWrUSJ999lmeBnPZsmVq3bq1VqxYcUNqOXfunMqVKyd3d/cb8n4AUBAskQPF3OzZs3X27Fn95z//cWguL6ldu7Z69+5tf56dna3p06erXbt2uuOOO9S2bVu9+uqryszMdHhd27Zt1b9/f3377bfq1q2bQkJCFB0drSVLltjHTJ06VW3atJEkjRs3TkFBQWrbtq2ki0vLl/75z6ZOnaqgoCCHY0lJSXrggQfUuHFjhYWFqWPHjnr11Vft56+0B3Pjxo168MEHFRoaqsaNG+uxxx7Tr7/+etn327dvn+Lj49W4cWPdeeedGj58uM6dO3e1r9ZB586dlZiYqLS0NPuxbdu2ae/evercuXOe8adPn9Yrr7yiLl26KCwsTI0aNdKjjz6qnTt32sds2rRJ3bp1kyQNHz7cvtR+6XPGxcWpc+fO+umnn/TQQw+pYcOG9u/lr3swhw0bppCQkDyfv2/fvmrSpImOHTtm/FkB4HrRYALF3Jo1a1SzZk01atTIaPzIkSM1ZcoU1a9fX8OHD1eTJk00c+ZMDR06NM/Yffv2afDgwYqIiFB8fLy8vLwUHx+v3bt3S5Lat2+v4cOHS7rYgI0bN04jRozIV/27d+9W//79lZmZqSeffFLDhg1T27Zt9d133131dRs2bNCjjz6qkydPauDAgXr44Ye1detWPfDAAzp48GCe8UOGDNGZM2f01FNPKSYmRh9//LGmTZtmXGf79u3l4uKilStX2o8tW7ZMAQEBql+/fp7xBw4c0BdffKHWrVsrPj5effv21a5du9SzZ097sxcYGKgnn3xSktS9e3eNGzdO48aNU5MmTezznD59Wv369VNwcLBGjBih8PDwy9b37LPPysfHR8OGDdOFCxckSQsXLtT69es1cuRI+fr6Gn9WALheLJEDxVhGRoaOHTum6Ohoo/E7d+7U4sWLdd999+nFF1+UdHEZ3cfHR2+99Za+/vprNWvWzD4+JSVF7733nho3bixJiomJUatWrfTxxx9r2LBhqlevnipUqKCxY8eqfv366tq1a74/Q1JSkrKysjRr1iz5+PgYv27cuHHy8vLSokWL5O3tLUlq166d7rnnHk2dOlWvvPKKw/jg4GC99NJL9uenT5/Whx9+qGeeecbo/SpUqKDWrVtr2bJl6tatm3JycpSQkKAePXpcdnxQUJBWrFghV9f//3t8165dFRMTow8//FBPPPGEKleurKioKE2ZMkWhoaGX/f5OnDih55577orvc4nNZtN//vMf9e3bV2+++aY6d+6sV155Re3atSvQfy4AcD1IMIFiLCMjQ5JUvnx5o/Hr1q2TJPXp08fh+COPPOJw/pJbb73V3lxKko+Pj/z9/XXgwIEC1/xXl/Zurl69Wjk5OUavOX78uHbs2KF77rnH3lxKUr169dSiRYs8n0NSngatcePGOn36tP07NNGlSxdt3rxZJ06c0Ndff60TJ06oS5culx3r7u5uby4vXLig33//XR4eHvL399f27duN39Pd3V333nuv0djIyEh1795d06dP16BBg1SmTBk9//zzxu8FAFahwQSKsQoVKkiSzpw5YzT+0KFDcnV1Va1atRyOV6lSRTabTYcOHXI4fsstt+SZw8vLS6mpqQWsOK/Y2Fg1atRII0eOVIsWLTR06FAlJCRctdk8fPiwJMnf3z/PucDAQP3+++86e/asw/Hq1as7PL/U2Obns7Rq1Urly5dXQkKCli5dqpCQENWuXfuyY3NycvT222+rQ4cOCgkJUbNmzdS8eXP98ssvSk9PN35PX1/ffF3QM2zYMHl7e2vHjh0aOXKkKlWqZPxaALAKS+RAMVahQgVVrVrVvifSlIuLi9E4Nze3gpR11fe4tD/wkrJly+q9997Tpk2btHbtWn311VdKSEjQokWL9NZbb11XDX/256XqP8vNzTWew93dXe3bt9eSJUt04MABDRw48Ipj33jjDb322mv6+9//rsGDB8vLy0uurq566aWX8vWeZcuWNR4rSTt27NDJkyclSbt27crXawHAKiSYQDHXpk0b7d+/X1u3br3mWD8/P+Xk5Gjfvn0Ox3/77TelpaXJz8/PsrpsNpvDFdeXXEof/8zV1VXNmzfX8OHDlZCQoKFDh+rrr7/Wpk2bLjv3pTQyJSUlz7nk5GRVrFhRHh4e1/kJLq9Lly7avn27zpw5o06dOl1x3IoVKxQeHq6XXnpJnTp1UmRkpFq0aJHnOzFt9k2cPXtWw4cP16233qru3btr9uzZ2rZtm2XzA4ApGkygmHv00Ufl4eGhkSNH6rfffstzfv/+/Zo3b56ki0u8kuzPL5k7d67DeSvUqlVL6enpDrflOX78uFatWuUw7vTp03lee+mG43+9ddIlVatWVXBwsJYsWeLQsO3atUtJSUmWfo6/Cg8P1+DBgzVq1ChVqVLliuPc3NzyJJWff/55ntsFlStXTpIu24zn14QJE3TkyBG9/PLLio+Pl5+fn+Lj46/4PQKAs7BEDhRztWrV0oQJEzR06FDFxsbaf8knMzNTW7du1fLly+0XidSrV0/33HOPFi1apLS0NDVp0kQ//vijFi9erHbt2jlcQX69YmNjNWHCBA0cOFBxcXE6f/68FixYIH9/f/3888/2cdOnT9e3336rVq1ayc/PTydPntT777+vatWq6c4777zi/P/617/Ur18/de/eXd26ddP58+c1f/58eXp6XnXp+nq5urrq8ccfv+a41q1ba/r06Ro+fLjCwsK0a9cuLV26VDVr1nQYV6tWLdlsNi1cuFDly5eXh4eHGjRokGfctWzcuFHvv/++Bg4cqNtvv12SNHbsWMXFxWny5Mn617/+la/5AOB60GACJUB0dLQ+/fRTzZkzR6tXr9aCBQvk7u6uoKAgxcfH6/7777ePffHFF1WjRg0tXrxYX3zxhSpXrqz+/ftb3pRVrFhR06ZN08svv6zx48erRo0aeuqpp7Rv3z6HBrNt27Y6dOiQPvroI/3++++qWLGimjZtqkGDBsnT0/OK87do0UKzZ8/WlClTNGXKFJUqVUpNmjTRM888k+/mzBkGDBigc+fOaenSpUpISFD9+vU1c+ZMTZw40WFc6dKl9fLLL+vVV1/VmDFjlJ2drbFjx+brM2RkZOjZZ59V/fr1NWDAAPvxxo0bq1evXpo7d646dOig0NBQqz4eAFyVS25+dpsDAAAA18AeTAAAAFiKBhMAAACWosEEAACApWgwAQAAYCkaTAAAAFiKBhMAAACWosEEAACApW7aG62XC3PeL30AKFy/fzOtsEsA4CRlC7FzcWbvcG5ryfr/LRJMAAAAWOqmTTABAADyxYVczhTfFAAAACxFggkAAGDCxaWwKyg2SDABAABgKRJMAAAAE+zBNEaDCQAAYIIlcmO04gAAALAUCSYAAIAJlsiN8U0BAADAUjSYAAAAJlxcnPcooHXr1qlnz55q1qyZ7rjjDkVHR2vs2LFKT093GPfll1/q7rvvVkhIiDp27KiPPvooz1yZmZl65ZVXFBERodDQUPXp00fJyckFqosGEwAAoJg6ffq0GjRooOeee05z5sxRnz59tGTJEg0ePNg+5ttvv9XAgQMVGhqqWbNmKSYmRs8++6yWL1/uMNeLL76oDz74QEOHDtXUqVOVmZmphx9+OE+zaoI9mAAAACaK4B7Mrl27OjwPDw+Xu7u7Ro0apWPHjsnX11czZsxQgwYN9Pzzz0uSmjVrpgMHDmjKlCm66667JElHjx7Vhx9+qH//+9/q1q2bJCkkJERt2rTRwoUL1a9fv3zVVfS+KQAAABSYt7e3JCkrK0uZmZnatGmTvZG8JDY2Vr/++qsOHjwoSVq/fr1ycnIcxnl7eysiIkKJiYn5roEGEwAAwEQR3IN5yYULF/THH3/o559/1vTp09W2bVvVqFFD+/fvV1ZWlgICAhzGBwYGSpJ9j2VycrIqVaokLy+vPOMKsg+TJXIAAAATTlwij46Ovur51atXX/V8mzZtdOzYMUlSy5YtNXHiRElSamqqJMlmszmMv/T80vm0tDR5enrmmddms9nH5AcNJgAAQDH35ptv6ty5c9qzZ49mzJihAQMGaO7cuYVWDw0mAACACSf+VOS1EsprqVevniQpLCxMISEh6tq1q1atWqVbb71VkvJcCZ6WliZJ9iVxm82mjIyMPPOmpaXlWTY3wR5MAACAEiQoKEilS5fW/v37VatWLZUuXTrPPspLzy/tzQwICNBvv/2WZzk8OTk5z/5NEzSYAAAAJlxcnfew0A8//KCsrCzVqFFD7u7uCg8P14oVKxzGJCQkKDAwUDVq1JAkRUZGytXVVStXrrSPSU1N1fr16xUVFZXvGlgiBwAAKKYGDhyoO+64Q0FBQSpbtqx27typOXPmKCgoSO3atZMkPfbYY+rVq5fGjBmjmJgYbdq0ScuWLdOkSZPs81SrVk3dunXTuHHj5OrqKl9fX82cOVOenp7q0aNHvuuiwQQAADDhxD2YBdWgQQMlJCTozTffVG5urvz8/HTfffepb9++cnd3lyQ1btxYU6dO1eTJk/Xhhx+qevXqevHFFxUTE+Mw18iRI1W+fHlNnDhRZ86cUaNGjTR37tzLXl1+LS65ubm5lnzCYqZc2MDCLgGAk/z+zbTCLgGAk5QtxGisXMvRTpv73FfPO23uwkCCCQAAYKII/lRkUcU3BQAAAEuRYAIAAJggwTRGgwkAAGDCtehd5FNU0YoDAADAUiSYAAAAJlgiN8Y3BQAAAEuRYAIAAJgogjdaL6pIMAEAAGApEkwAAAAT7ME0xjcFAAAAS5FgAgAAmGAPpjEaTAAAABMskRvjmwIAAIClSDABAABMsERujAQTAAAAliLBBAAAMMEeTGN8UwAAALAUCSYAAIAJ9mAaI8EEAACApUgwAQAATLAH0xgNJgAAgAmWyI3RigMAAMBSJJgAAAAmWCI3xjcFAAAAS5FgAgAAmCDBNMY3BQAAAEuRYAIAAJjgKnJjJJgAAACwFAkmAACACfZgGqPBBAAAMMESuTFacQAAAFiKBBMAAMAES+TG+KYAAABgKRJMAAAAE+zBNEaCCQAAAEuRYAIAABhwIcE0RoIJAAAAS5FgAgAAGCDBNEeDCQAAYIL+0hhL5AAAALAUCSYAAIABlsjNkWACAADAUiSYAAAABkgwzZFgAgAAwFIkmAAAAAZIMM2RYAIAAMBSJJgAAAAGSDDN0WACAACYoL80xhI5AAAALEWCCQAAYIAlcnMkmAAAALAUCSYAAIABEkxzJJgAAACwFAkmAACAARJMcySYAAAAsBQJJgAAgAESTHM0mAAAACboL42xRA4AAABLkWACAAAYYIncHAkmAAAALEWCCQAAYIAE0xwJJgAAACxFggkAAGCgKCaYn3/+uT799FP9/PPPSktLU+3atRUXF6e///3v9nrj4uK0efPmPK9NSEhQYGCg/Xl6errGjh2rL774QllZWWrZsqVGjhypqlWr5rsuGkwAAIBi6u2335afn5/i4+NVsWJFbdiwQaNGjdLRo0c1cOBA+7hGjRpp2LBhDq+tUaOGw/MhQ4Zoz549GjNmjMqUKaPJkyerX79++uijj1SqVP5aRhpMAAAAE0UvwNSMGTPk4+Njf968eXOdPn1ac+fO1eOPPy5X14u7IW02m0JDQ684z9atW7V+/XrNmTNHkZGRkiR/f3/FxsZq5cqVio2NzVdd7MEEAAAw4OLi4rRHQf25ubwkODhYGRkZOnv2rPE8iYmJstlsioiIsB8LCAhQcHCwEhMT810XDSYAAEAJsmXLFvn6+qpChQr2Y5s3b1ZoaKhCQkLUs2dPffPNNw6vSU5Olr+/f55mNyAgQMnJyfmugSVyAAAAA868yCc6Ovqq51evXm00z7fffquEhASH/ZZNmjRR165dVadOHR0/flxz5sxRnz599O677yosLEySlJaWJk9PzzzzeXl56aeffsrHJ7mIBhMAAKAEOHr0qIYOHarw8HD16tXLfvzJJ590GNe6dWt17txZr7/+umbNmuWUWmgwAQAADDgzwTRNKK8kLS1N/fr1k7e3t6ZOnWq/uOdyPDw81KpVK61YscJ+zGaz6ejRo3nGpqamysvLK9/1sAcTAACgGDt//rz69++v9PR0zZ49+7JL3dcSEBCglJQU5ebmOhxPSUlRQEBAvuejwQQAADBQFK8iz87O1pAhQ5ScnKzZs2fL19f3mq85e/as1q5dq5CQEPuxqKgopaamauPGjfZjKSkp2r59u6KiovJdF0vkAAAAxdRzzz2nNWvWKD4+XhkZGfr+++/t5+rXr69t27Zp9uzZat++vfz8/HT8+HHNnTtXJ06c0GuvvWYfGxYWpsjISI0YMULDhg1TmTJlNGnSJAUFBalDhw75rosGEwAAwEQRvNF6UlKSJOnll1/Oc2716tWqUqWKsrKyNGnSJJ0+fVrlypVTWFiYnnvuOTVo0MBh/OTJkzV27FiNHj1a2dnZioyM1MiRI/P9Kz6S5JL718X2m0S5sIHXHgSgWPr9m2mFXQIAJylbiNFY9QEfO23uw2/c67S5CwMJJgAAgAFnXkVe0tBgAgAAGKDBNMdV5AAAALAUCSYAAIABEkxzJJgAAACwFAkmAACACQJMYySYAAAAsBQJJgAAgAH2YJqjwUSxERxQTSMHxCosuJZ8K9l09nymdqYc1aR5Xygh8Sf7uMa311bPu8PV5I46CrnNT6VLu13xxvr97otU6yZ11eSOOqp5i4/e/fRr/ePf82/URwJQQPv27dX0qa9p63dblJaaqmq33KKY2M7q3aevypUrV9jlATc9GkwUG7Wq+6iCR1nNX7pJR06kyqOsu/7WLlQfvTZAT7ywQG99fPHnsjpG3q4+97TQj7sPK+XQb6pbx/eKc/7z4faq4FFW3/68V9Uqe92ojwLgOhw9ckQP9bhPnhU81eOBnvLy8tIPP3yvGdOnasf2n/XatBmFXSJKKBJMczSYKDZWrN+uFeu3OxybsWidNrw/TE/2bGNvMGd98JUmvr1K5//I0qRh9121wezw6GTtP/K7JOlE0kTnFQ/AMsuWfqL0tDS9/e77uvXW2yRJ3e7vrtycHC39dInSUlNl8+IvjLAeDaY5LvJBsZaTk6uDR3+Xl6eH/djxU+k6/0eW0esvNZcAio+MjAxJUqVKlRyOV65SRa6uripVunRhlAXgT2gwUex4lHVXJe/y8q9RWYMeaqOOEfW1dvMvhV0WgBukSZOmkqQxo57Vzh07dPTIES3/PEEfLFqgBx+Kk4eHxzVmAArGxcXFaY+ShiVyFDsv//Ne9esWKUm6cCFHn3z5vYa+/N9CrgrAjRLRMkpPDBqsObNmau2aL+3H+/1jgAYOHlqIlQG4pMg1mCdOnFBSUpKSk5N1+vRpSZK3t7cCAgIUERGhKlWqFG6BKHTT3lujxV9s1S1VvPT39o3k5uoq99JF7r/KAJyoup+fGt3ZWO3ad5SXt7e+Slyr2bNmqlLlKnrgoZ6FXR5KqpIXNDpNkflTOSsrS6+88ooWLlyoCxcuqEqVKvL63ybt1NRUnThxQm5uburRo4fi4+NVqlSRKR032K69x7Rr7zFJ0vvLNmvp60/oo9f6q2XchEKuDMCN8HnCZ3phzGh9+tkK+VarJklq176DcnJyNXnSBMV06iRv74qFXCVwcysyXdrkyZP1ySefaPTo0YqJiZGnp6fD+YyMDH3++ecaP368ypYtq6effrqQKkVRs/iL7zV91AO6rXZV7d53vLDLAeBk/134vurVC7Y3l5e0btNWny75WDt37FCz5i0KqTqUZCVxr6SzFJmLfD755BMNHz5c999/f57mUpIqVKig++67T8OGDdOSJUtufIEossqVuXjFqFcFbq4M3AxOnvxNF3Jy8hzPzr5494gL2dk3uiQAf1FkGswzZ86o2l/+Nno51apV05kzZ25ARShqqlSskOdYqVKuerBzU509l6kdyUcKoSoAN1rt2v7auWO79u5NcTj+ecJncnV11W1BQYVUGUo6riI3V2SWyENDQ/XGG28oJCTksgmmdHGZ/I033lBYWNgNrg5FwbSRD8izfFmt/26PDp84Ld9KNvWIaaJ6AdU0bOLHOnMuU5JU65aKeqDTxduYNKpfS5I07NGOkqT9R05pwWff2OeMjbpDIXX9JEmlS7nqjtv87GM/W/ejftp9+IZ9PgBmHn6kr5LWJ6pPr4fU44GH5O3trcR1a7X+q0Td+/f7VLXqlX9cAbgeJbAPdBqX3Nzc3MIuQpKSk5PVu3dvnTlzRi1atFBAQIC90czIyFBycrI2bNig8uXL6+2331ZAQMB1vd+VfpsaRdd9He9U77811+23Vlclr/JKP3teW3cc0IyF6/TZuh/t41reeZtWzh582TkSv92tjv1esz9/87meiru72WXH9hv9ruYv3WTth8AN8fs30wq7BDjZj9u26Y3Xp2rnjh06ffq0/Gr46e6u9+jhRx7lItASrmwh/sd769OfO23uPRNinDZ3YSgyDaYkpaWlacGCBfrqq6+UnJystLQ0SZLNZlNAQICioqLUo0cP2Wy2634vGkyg5KLBBEquwmwwb3tmudPm3j3+LqfNXRiK1F/zbDab+vfvr/79+xd2KQAAACigItVgAgAAFFXswTRXZK4iBwAAQMlAggkAAGCgJN5OyFlIMAEAAGApEkwAAAADBJjmaDABAAAMuLrSYZpiiRwAAACWIsEEAAAwwBK5ORJMAAAAWIoEEwAAwAC3KTJHggkAAABLkWACAAAYIMA0R4IJAAAAS5FgAgAAGGAPpjkaTAAAAAM0mOZYIgcAAIClSDABAAAMEGCaI8EEAACApUgwAQAADLAH0xwJJgAAACxFggkAAGCAANMcCSYAAAAsRYIJAABggD2Y5mgwAQAADNBfmmOJHAAAAJYiwQQAADDAErk5EkwAAABYigQTAADAAAGmORJMAAAAWIoEEwAAwAB7MM2RYAIAAMBSJJgAAAAGCDDN0WACAAAYYIncHEvkAAAAsBQJJgAAgAECTHMkmAAAALAUCSYAAIAB9mCaI8EEAACApUgwAQAADBBgmiPBBAAAgKVIMAEAAAywB9McCSYAAIABFxcXpz0K6vPPP9djjz2mqKgohYaGqmvXrvrwww+Vm5vrMO6DDz5Qx44dFRISorvvvltr1qzJM1d6erpGjBihpk2bKiwsTE8++aSOHz9eoLpoMAEAAIqpt99+W+XKlVN8fLxmzJihqKgojRo1StOnT7eP+eyzzzRq1CjFxMRo1qxZCg0N1cCBA/X99987zDVkyBAlJSVpzJgxmjBhglJSUtSvXz9lZ2fnuy6WyAEAAAwUxRXyGTNmyMfHx/68efPmOn36tObOnavHH39crq6umjJlijp16qQhQ4ZIkpo1a6Zdu3Zp+vTpmjVrliRp69atWr9+vebMmaPIyEhJkr+/v2JjY7Vy5UrFxsbmqy4STAAAgGLqz83lJcHBwcrIyNDZs2d14MAB7d27VzExMQ5jYmNjtXHjRmVmZkqSEhMTZbPZFBERYR8TEBCg4OBgJSYm5rsuEkwAAAADzrzIJzo6+qrnV69ebTzXli1b5OvrqwoVKmjLli2SLqaRfxYYGKisrCwdOHBAgYGBSk5Olr+/f57PGBAQoOTkZOP3voQEEwAAoIT49ttvlZCQoEceeUSSlJqaKkmy2WwO4y49v3Q+LS1Nnp6eeebz8vKyj8kPEkwAAAADztyDmZ+E8kqOHj2qoUOHKjw8XL169bKgqoIjwQQAACjm0tLS1K9fP3l7e2vq1Klydb3Y4nl5eUm6eAuiv47/83mbzaaMjIw886amptrH5AcNJgAAgIGieB9MSTp//rz69++v9PR0zZ4922GpOyAgQJLy7KNMTk5W6dKlVbNmTfu4lJSUPPfPTElJsc+RHzSYAAAAxVR2draGDBmi5ORkzZ49W76+vg7na9asqTp16mj58uUOxxMSEtS8eXO5u7tLkqKiopSamqqNGzfax6SkpGj79u2KiorKd13swQQAADBQFO+D+dxzz2nNmjWKj49XRkaGw83T69evL3d3dw0aNEhPP/20atWqpfDwcCUkJGjbtm2aP3++fWxYWJgiIyM1YsQIDRs2TGXKlNGkSZMUFBSkDh065Lsul9y/ZqE3iXJhAwu7BABO8vs30wq7BABOUrYQo7H207522tyrBjYr0Ovatm2rQ4cOXfbc6tWrVaNGDUkXfypy1qxZOnz4sPz9/fXUU0+pTZs2DuPT09M1duxYrVq1StnZ2YqMjNTIkSPzpKImaDABlDg0mEDJRYNZPLBEDgAAYKAoLpEXVVzkAwAAAEuRYAIAABhw5k9FljQkmAAAALAUCSYAAIABVwJMYySYAAAAsBQJJgAAgAH2YJqjwQQAADBAf2mOJXIAAABYigQTAADAgIuIME2RYAIAAMBSJJgAAAAGuE2RORJMAAAAWIoEEwAAwAC3KTJHggkAAABLkWACAAAYIMA0R4MJAABgwJUO0xhL5AAAALAUCSYAAIABAkxzJJgAAACwFAkmAACAAW5TZI4EEwAAAJYiwQQAADBAgGmOBBMAAACWIsEEAAAwwH0wzdFgAgAAGKC9NMcSOQAAACxFggkAAGCA2xSZI8EEAACApUgwAQAADLgSYBojwQQAAIClSDABAAAMsAfTHAkmAAAALEWCCQAAYIAA0xwNJgAAgAGWyM2xRA4AAABLkWACAAAY4DZF5kgwAQAAYCnjBHP48OH5ntzFxUUvvfRSvl8HAABQ1LAH05xxg7lp06Y8x86fP69Tp05Jkry8vCRJqampkiQfHx+VK1fOihoBAABQjBg3mF9++aXD8z179uiRRx5R//791bt3b/n4+EiSTp06pXnz5mnJkiV68803ra0WAACgkJBfmivwHswXXnhBUVFRGjp0qL25lC4ml0OHDlXLli31wgsvWFIkAAAAio8CN5g//PCD6tevf8XzwcHB+uGHHwo6PQAAQJHi6uLitEdJU+AG08vLS4mJiVc8n5iYKE9Pz4JODwAAUKS4uDjvUdIUuMHs3r271q5dq8cee0wbNmzQwYMHdfDgQSUlJWnAgAFKTExUjx49rKwVAAAAxUCBb7T++OOPKzMzU3PmzNHatWsdzrm5uekf//iHHn/88eutDwAAoEjgNkXmruuXfIYMGaJevXpp48aNOnTokCTJz89PzZs3d7jwBwAAADeP6/6pSB8fH3Xq1MmKWgAAAIosAkxzxg3m4cOHC/QG1atXL9DrAAAAUDwZN5ht27Yt0N6DHTt25Ps1AAAARU1JvJ2Qsxg3mC+99BKbWwEAAHBNxg3mvffe68w6AAAAijRyNnPXfZHPJefPn5cklS1b1qopAQAAigxWcs1dV4N5+PBhTZ06VevWrdPvv/8uSapYsaJatWqlgQMHys/Pz5IiAQAAUHwUuMH89ddf9eCDDyo9PV0tWrRQYGCgJCk5OVmffPKJ1qxZo/fff18BAQGWFWulidOfLuwSADjJ/pNnC7sEAE5S19ej0N67wD9/eBMqcIM5ceJEubq6avHixQoKCnI4t2vXLj388MOaOHGipk+fft1FAgAAoPgocDP+zTffKC4uLk9zKUl169bVQw89pM2bN19XcQAAAEWFi4uL0x4lTYEbzOzs7Kte0FOuXDllZ2cXdHoAAAAUUwVuMIODg/XBBx8oPT09z7mMjAx9+OGHql+//nUVBwAAUFS4ujjvUdIUeA/moEGD1K9fP8XExOjee+9VnTp1JEkpKSlavHixTp8+rdGjR1tVJwAAAIqJAjeYzZs315tvvqlx48bpzTffdDgXHBys8ePHq1mzZtddIAAAQFFQEpNGZ7mu+2C2aNFCS5Ys0YkTJ3T48GFJUvXq1VWlShVLigMAACgqSuLFOM6S7wbzyJEjcnV1la+vryTpjz/+0LJly+znv/vuO0mSr6+vYmNjLSoTAAAAxUW+GsxffvlF99xzj0aMGKGePXtKks6ePatXXnlFLi4uys3NtY91c3NTYGDgZW9jBAAAUNwU1SXyffv2ac6cOfrhhx+0e/duBQQEOIR/khQXF3fZ20cmJCTYfyxHktLT0zV27Fh98cUXysrKUsuWLTVy5EhVrVo1XzXlq8FctGiRqlevrgcffDDPufHjxyssLEySlJOTo169emnRokVc6AMAAOBEu3fv1rp169SwYUPl5OQ4BH5/1qhRIw0bNszhWI0aNRyeDxkyRHv27NGYMWNUpkwZTZ48Wf369dNHH32kUqXM28Z8NZibNm1S+/bt5eqa9+5GlSpVcvjt8c6dO+vLL7/Mz/QAAABFVlHdgtm2bVu1a9dOkhQfH6+ffvrpsuNsNptCQ0OvOM/WrVu1fv16zZkzR5GRkZIkf39/xcbGauXKlfna+piv+2AeOnQoz2+LlypVSvXq1VP58uUdjteoUcN+4Q8AAACc43LBX0EkJibKZrMpIiLCfiwgIEDBwcFKTEzM11z5vsjnr7Grp6enlixZkmfcX/dkAgAAFGeuRTXCNLR582aFhobqwoULatiwoQYPHqwmTZrYzycnJ8vf3z/P1fIBAQFKTk7O13vlq8H09fXVzp07jcbu3LnTfqU5AAAAriw6Ovqq51evXn1d8zdp0kRdu3ZVnTp1dPz4cc2ZM0d9+vTRu+++a7+GJi0tTZ6ennle6+XldcVl9yvJV6YaERGhpUuX6uTJk1cdd/LkSS1dutQhYgUAACjOXJ34cLYnn3xS3bp1U+PGjRUbG6t3331XVatW1euvv+6U98tXgvnII49o8eLFevjhh/XSSy8pJCQkz5gff/xRI0aMUHZ2tvr06WNZoQAAAIXJmSvk15tQ5peHh4datWqlFStW2I/ZbDYdPXo0z9jU1FR5eXnla/58NZg1atTQq6++qqeeekr333+/atWqpbp168rDw0Nnz57Vrl27tH//fpUtW1YTJkxQzZo181UMAAAACkdAQIA2btyo3Nxch32YKSkpqlu3br7myncq26ZNG3366ae67777dO7cOa1atUqffPKJVq1apbNnz6pbt25asmTJNfcSAAAAFCeuLi5Oe9xoZ8+e1dq1ax1Wo6OiopSamqqNGzfaj6WkpGj79u2KiorK1/wF+i3ymjVr6vnnn5ckZWRk6MyZMypfvrwqVKhQkOkAAABQQOfOndO6deskXbylZEZGhpYvXy5Jatq0qZKTkzV79my1b99efn5+On78uObOnasTJ07otddes88TFhamyMhIjRgxQsOGDVOZMmU0adIkBQUFqUOHDvmqqUAN5p9VqFCBxhIAAJR4RfUuRSdPntTgwYMdjl16/s4776hatWrKysrSpEmTdPr0aZUrV05hYWF67rnn1KBBA4fXTZ48WWPHjtXo0aOVnZ2tyMhIjRw5Ml+/4iNJLrk36c0qX9+wt7BLAOAk7QLz95u5AIqPur4ehfbeo1fsdtrcz3e8zWlzF4brTjABAABuBq5FNMEsim7ErZcAAABwEyHBBAAAMFDcfyryRiLBBAAAgKVIMAEAAAwQYJqjwQQAADDART7mWCIHAACApUgwAQAADLiICNMUCSYAAAAsRYIJAABggD2Y5kgwAQAAYCkSTAAAAAMkmOZIMAEAAGApEkwAAAADLtxp3RgNJgAAgAGWyM2xRA4AAABLkWACAAAYYIXcHAkmAAAALEWCCQAAYMCVCNMYCSYAAAAsRYIJAABggKvIzZFgAgAAwFIkmAAAAAbYgmmOBhMAAMCAq+gwTbFEDgAAAEuRYAIAABhgidwcCSYAAAAsRYIJAABggNsUmSPBBAAAgKVIMAEAAAzwU5HmSDABAABgKRJMAAAAAwSY5mgwAQAADLBEbo4lcgAAAFiKBBMAAMAAAaY5EkwAAABYigQTAADAAKmcOb4rAAAAWIoEEwAAwIALmzCNkWACAADAUiSYAAAABsgvzdFgAgAAGOBG6+ZYIgcAAIClSDABAAAMkF+aI8EEAACApUgwAQAADLAF0xwJJgAAACxFggkAAGCAG62bI8EEAACApUgwAQAADJDKmaPBBAAAMMASuTmacQAAAFiKBBMAAMAA+aU5EkwAAABYigQTAADAAHswzZFgAgAAwFIkmAAAAAZI5czxXQEAAMBSJJgAAAAG2INpjgYTAADAAO2lOZbIAQAAYCkSTAAAAAOskJsjwQQAAIClaDABAAAMuMrFaY/rsW/fPo0ePVpdu3ZV/fr11blz58uO++CDD9SxY0eFhITo7rvv1po1a/KMSU9P14gRI9S0aVOFhYXpySef1PHjx/NdEw0mAABAMbZ7926tW7dOtWvXVmBg4GXHfPbZZxo1apRiYmI0a9YshYaGauDAgfr+++8dxg0ZMkRJSUkaM2aMJkyYoJSUFPXr10/Z2dn5qok9mAAAAAaK6h7Mtm3bql27dpKk+Ph4/fTTT3nGTJkyRZ06ddKQIUMkSc2aNdOuXbs0ffp0zZo1S5K0detWrV+/XnPmzFFkZKQkyd/fX7GxsVq5cqViY2ONayLBBAAAKMZcXa/ezh04cEB79+5VTEyMw/HY2Fht3LhRmZmZkqTExETZbDZFRETYxwQEBCg4OFiJiYn5qylfowEAAG5SLk78lzMlJydLuphG/llgYKCysrJ04MAB+zh/f/88N5QPCAiwz2GKJXIAAAADzlwij46Ovur51atXF3ju1NRUSZLNZnM4fun5pfNpaWny9PTM83ovL6/LLrtfDQkmAAAALEWCCQAAYOB6byd0NdeTUF6Ll5eXpIu3IKpSpYr9eFpamsN5m82mo0eP5nl9amqqfYwpEkwAAIASLCAgQJLy7KNMTk5W6dKlVbNmTfu4lJQU5ebmOoxLSUmxz2GKBhMAAMCAi4vzHs5Us2ZN1alTR8uXL3c4npCQoObNm8vd3V2SFBUVpdTUVG3cuNE+JiUlRdu3b1dUVFS+3pMlcgAAgGLs3LlzWrdunSTp0KFDysjIsDeTTZs2lY+PjwYNGqSnn35atWrVUnh4uBISErRt2zbNnz/fPk9YWJgiIyM1YsQIDRs2TGXKlNGkSZMUFBSkDh065Ksml9y/5qA3idc37C3sEgA4SbvAqoVdAgAnqevrUWjvvXLHCafN3SG4yrUHXcHBgweveBX6O++8o/DwcEkXfypy1qxZOnz4sPz9/fXUU0+pTZs2DuPT09M1duxYrVq1StnZ2YqMjNTIkSPl6+ubr5poMAGUODSYQMlFg1k8sEQOAABgwNk3RC9JuMgHAAAAliLBBAAAMOBKgGmMBhMAAMAAS+TmWCIHAACApUgwAQAADDj7huglCQkmAAAALEWCCQAAYIA9mOZIMAEAAGApEkwAAAAD3KbIHA0mipXM8+e05fMPdCx5p46m/KI/zmSofd9/qn5kB/uY3Jwc7djwhfZsSdKJfXt0/ky6vKpUU92mrdUopptKlXZ3mPOPs2f0zbIF2rMlSRm//yYPm7dq1g9TeNeeslXiJweBwvLj1m81YnC/y54bP2Oe6t3eQJL033fnaHPSOh05dEDnzp1V5Sq+atK8pe7v1Vde3j43smQA/0ODiWLlfEaqNn/6njwrVVWVmgE6uHNbnjFZmX9o1ZyJqhYYrJA2neRh89aRPTv09ZJ3dWDHVt37r3Fy+d+lgLk5OVo8IV6nDu9Xg7Zd5O3rp9PHD+vHL5dp/09bFPefWXIvV3i/ewtA6vL3B3Rb8O0Ox27xq2n/5z2/bJf/rXXVsm1HlfPw0IF9KVq5bLG+2fiVpry1SGXLlbvRJaOEYg+mORpMFCseXj56dPIClffy0bGUXVr4/KA8Y9xKldJ9I15V9dv+/w+kO1rFylbZ92KTuX2rat3eSJJ05NcdOpayS617PqGG0Xfbx1esVkNfvPWq9m/fqlvvjHD+BwNwRbc3DFNE6/ZXPD/ixYl5jtW7vYFeHv2MNm9Yp6jou5xZHm4i3KbIHBf5oFgpVdpd5b2uvuTlVqq0Q3N5SWCji43iqSMH7Mcyz5+VJHnYKjqMLf+/ZbVS7o7L6QAKx9mzZ3QhO9t4vO8t1SVJZzLSnVUSgKsgwcRN40zaKUlSuQo2+zHfOnVVukxZbVw8T2XLe6riLTV0+thhrf/vHPn611Wt+o0Kq1wA//Pa2DE6d+6sXN3cdHuDMPV5bIhuq+f4l8jc3FylpZ5WzoULOnxwv+bNnCJXNzfdEdq4kKpGSUSAaY4GEzeNLQkfyL2ch+o0aGI/Vs7TSzGPjdDqtyfr4/HD7Mdr33GnYp8YJVc3t8IoFYCkUqVKqUWraDVuFimbl7f2703W4kXvKn5gX417/W0F1q1nH3v61En1uuf/l9ErV/HV06NeUs3a/oVROnDTK3YN5u+//649e/aoSZMm1x4M/M/mZQt0YPtWtYkbqDIeFRzOlfP0UpVat6pBdH1Vql5bJ/Yna8vn/9WqORPV6YmRhVQxgOCQUAWHhNqfh0e2VkTrdhrUp7veeXOqnpsw3X6ugs1LL7w6Q5mZmUrevVMbE7/U+XNnC6FqlGSubMI0VuwazM2bN2vIkCHasWNHYZeCYmLXprXa+PE83d7yLjVo28XhXOrxI/rolX+pQ79ndFvjlpKkwEYtZKvsq1VzJmjvtm8cEk8Ahat6jVpqFtlKGxK/1IULF+T2v1WG0qVLK7RxM0lS0xZRatioqf71RB95VfRR0xZRhVkycFPiIh+UaPt+3qKVsyfIv0FTte39ZJ7z25NW6kJWlvwbhjscDwi7+AfV4d0/35A6AZirXLWasrOy9Mf5c1ccExwSKp9KlbVuVcINrAwlnYsTHyVNkUkwu3Tpcu1Bks6cOePkSlBSHP11pz6b+ryq1rlNsY8/e9n9lGdTTytXucrNyXE4nnPhwsV/z7lwQ2oFYO7o4YNydy+jste4R21mZqbOZGTcoKoA/FmRaTCTk5N16623qn79+lcdd+jQIR05cuQGVYXi6tTh/fpk8ijZKvvq7iHPq5R7mcuOq1jNT8rN1e5vEh1+DeiXr9dIkqrWCrwh9QLIK/X0qTy/xJOy5xdtTlqnO8Mj5OrqqvPnzkkuUtmyjjdTT1r7hTLS03Rrvav/mQLkS0mMGp2kyDSYt912m2rXrq2xY8deddyKFSv0zTff3KCqUBT98MUn+uPsGWWcPilJSv7+a2Wc+k2S1LBdV7m4uGjxxBH640yG7ryrm/b+sNnh9V5Vb9Ett178Qyc4soO2LP9IX86bohP7fpWPX20d37dbPycuVyW/2grkJutAoRn373i5lymjenc0lHdFH+3fm6wVSz9SmbJl1bv/xS0vhw/u18inBqhlmw6qUbuOXF1ctfuX7Vq7MkFVq1XX3d0eLORPgZKEX/IxV2QazAYNGuirr74yGpubm+vkalCUbVn+kdJPHrM//3VLkn7dkiRJqteirSQp49QJSVLSh2/leX1wRHt7g1mugk0P/HuqNi5+R8k/fK0f136mshU8dXvLjmrx9z5yK1Xa2R8HwBWEt2ytdas+1yf/na+zZ87Iy9tbzaOi9cDD/1D1GrUkSZWqVFWLqGht++4bfbliqbKzs1XV9xZ1ure77o/rK5uXd+F+COAm5ZJbRLq1/fv3a/fu3YqOjr7quPPnz+vkyZPy8/O7rvd7fcPe63o9gKKrXWDVwi4BgJPU9b363ltn2pyc6rS5mwZ4OW3uwlBkEsxatWqpVq1a1xxXtmzZ624uAQAA4DxFpsEEAAAoytiBaY77YAIAAMBSJJgAAAAmiDCNkWACAADAUiSYAAAABrgPpjkaTAAAAAMu9JfGWCIHAACApUgwAQAADBBgmiPBBAAAgKVIMAEAAEwQYRojwQQAAIClSDABAAAMcJsicySYAAAAsBQJJgAAgAHug2mOBhMAAMAA/aU5lsgBAABgKRJMAAAAE0SYxkgwAQAAYCkSTAAAAAPcpsgcCSYAAAAsRYIJAABggNsUmSPBBAAAgKVIMAEAAAwQYJqjwQQAADBBh2mMJXIAAABYigQTAADAALcpMkeCCQAAAEuRYAIAABjgNkXmSDABAABgKRJMAAAAAwSY5kgwAQAAYCkSTAAAABNEmMZoMAEAAAxwmyJzLJEDAADAUiSYAAAABrhNkTkSTAAAAFiKBBMAAMAAAaY5EkwAAABYigYTAADAhIsTHwX08ccfKygoKM9jwoQJDuM++OADdezYUSEhIbr77ru1Zs2agr+pAZbIAQAAirnZs2fL09PT/tzX19f+z5999plGjRqlAQMGqFmzZkpISNDAgQP13nvvKTQ01Cn10GACAAAYKMr3wbz99tvl4+Nz2XNTpkxRp06dNGTIEElSs2bNtGvXLk2fPl2zZs1ySj0skQMAABhwcXHew1kOHDigvXv3KiYmxuF4bGysNm7cqMzMTKe8Lw0mAABAMde5c2cFBwcrOjpaM2fO1IULFyRJycnJkiR/f3+H8YGBgcrKytKBAwecUg9L5AAAAAacuUAeHR191fOrV6++7PEqVapo0KBBatiwoVxcXPTll19q8uTJOnbsmEaPHq3U1FRJks1mc3jdpeeXzluNBhMAAKCYatmypVq2bGl/HhkZqTJlymjevHkaMGBAodVFgwkAAGDCiRHmlRLKgoiJidFbb72lHTt2yMvLS5KUnp6uKlWq2MekpaVJkv281diDCQAAUEIFBARI+v+9mJckJyerdOnSqlmzplPelwYTAADAgIsT/2WlhIQEubm5qX79+qpZs6bq1Kmj5cuX5xnTvHlzubu7W/rel7BEDgAAUEz17dtX4eHhCgoKknRxqf2///2vevXqZV8SHzRokJ5++mnVqlVL4eHhSkhI0LZt2zR//nyn1UWDCQAAYMCZ96ssKH9/f3300Uc6evSocnJyVKdOHY0YMUJxcXH2MZ07d9a5c+c0a9Ysvfnmm/L399e0adMUFhbmtLpccnNzc502exH2+oa9hV0CACdpF1i1sEsA4CR1fT0K7b1TfjvvtLn9K5d12tyFgQQTAADAQBEMMIssGkwAAAATdJjGuIocAAAAliLBBAAAMGD17YRKMhJMAAAAWIoEEwAAwEBRvE1RUUWCCQAAAEuRYAIAABggwDRHggkAAABLkWACAAAYYA+mORpMAAAAI3SYplgiBwAAgKVIMAEAAAywRG6OBBMAAACWIsEEAAAwQIBpjgQTAAAAliLBBAAAMMAeTHMkmAAAALAUCSYAAIABF3ZhGqPBBAAAMEF/aYwlcgAAAFiKBBMAAMAAAaY5EkwAAABYigQTAADAALcpMkeCCQAAAEuRYAIAABjgNkXmSDABAABgKRJMAAAAEwSYxmgwAQAADNBfmmOJHAAAAJYiwQQAADDAbYrMkWACAADAUiSYAAAABrhNkTkSTAAAAFiKBBMAAMAAezDNkWACAADAUjSYAAAAsBRL5AAAAAZYIjdHggkAAABLkWACAAAY4DZF5kgwAQAAYCkSTAAAAAPswTRHggkAAABLkWACAAAYIMA0R4IJAAAAS5FgAgAAmCDCNEaDCQAAYIDbFJljiRwAAACWIsEEAAAwwG2KzJFgAgAAwFIkmAAAAAYIMM2RYAIAAMBSJJgAAAAmiDCNkWACAADAUiSYAAAABrgPpjkaTAAAAAPcpsgcS+QAAACwlEtubm5uYRcBAACAkoMEEwAAAJaiwQQAAIClaDABAABgKRpMAAAAWIoGEwAAAJaiwQQAAIClaDABAABgKRpMAAAAWIoGEwAAAJaiwQQAAIClaDABAABgKRpMAAAAWIoGEwAAAJaiwUSJ9euvv6pPnz4KDQ1VRESExo0bp8zMzMIuC4AF9u3bp9GjR6tr166qX7++OnfuXNglAfiTUoVdAOAMqamp6t27t+rUqaOpU6fq2LFjevnll3X+/HmNHj26sMsDcJ12796tdevWqWHDhsrJyVFubm5hlwTgT2gwUSItXLhQZ86c0bRp0+Tt7S1JunDhgp577jn1799fvr6+hVsggOvStm1btWvXTpIUHx+vn376qZArAvBnLJGjREpMTFTz5s3tzaUkxcTEKCcnR0lJSYVXGABLuLryxxdQlPG/UJRIycnJCggIcDhms9lUpUoVJScnF1JVAADcHGgwUSKlpaXJZrPlOe7l5aXU1NRCqAgAgJsHDSYAAAAsRYOJEslmsyk9PT3P8dTUVHl5eRVCRQAA3DxoMFEiBQQE5NlrmZ6erhMnTuTZmwkAAKxFg4kSKSoqShs2bFBaWpr92PLly+Xq6qqIiIhCrAwAgJKP+2CiROrRo4feffddPfHEE+rfv7+OHTumcePGqUePHtwDEygBzp07p3Xr1kmSDh06pIyMDC1fvlyS1LRpU/n4+BRmecBNzyWXnz9ACfXrr7/qhRde0NatW1W+fHl17dpVQ4cOlbu7e2GXBuA6HTx4UNHR0Zc998477yg8PPwGVwTgz2gwAQAAYCn2YAIAAMBSNJgAAACwFA0mAAAALEWDCQAAAEvRYAIAAMBSNJgAAACwFA0mAAAALEWDCaDYadu2reLj4+3PN23apKCgIG3atMmy9wgKCtLUqVMtmw8AbiY0mADy7eOPP1ZQUJD9ERISoo4dO+r555/Xb7/9VtjlGVu3bh1NJAA4Ab9FDqDAnnzySdWoUUOZmZnasmWLFixYoHXr1mnZsmUqV67cDaujSZMm2rZtm0qXLp2v161bt07vvfeeBg0alOfctm3b5ObmZlWJAHBTocEEUGBRUVEKCQmRJN13333y9vbW3LlztXr1anXu3DnP+LNnz8rDw8PyOlxdXVWmTBlL57R6PgC4mbBEDsAyzZo1kyQdPHhQ8fHxCgsL0/79+9WvXz+FhYXp6aefliTl5OTo7bffVqdOnRQSEqIWLVpo9OjRSk1NdZgvNzdXr7/+uqKiotSwYUPFxcVp9+7ded73Snswf/jhB/Xr109NmjRRaGiounTponnz5kmS4uPj9d5770mSw3L/JZfbg7l9+3Y9+uijatSokcLCwtS7d299//33DmMubR/YsmWLxo4dq2bNmik0NFRPPPGETp06VYBvFQCKHxJMAJbZv3+/JMnb21uSlJ2drb59++rOO+/UsGHDVLZsWUnS6NGjtXjxYt17772Ki4vTwYMH9d5772n79u1asGCBfan7tdde04wZM9SqVSu1atVKP//8sx555BFlZWVds5akpCT1799fVatWVa9evVS5cmX9+uuvWrt2rXr37q3u3bvr+PHjSkpK0rhx46453+7du/XQQw+pfPnyevTRR1WqVCktWrRIcXFxmj9/vho2bOgw/sUXX5TNZtPAgQN16NAhzZs3T88//7wmT56cj28UAIonGkwABZaRkaFTp04pMzNT3333naZPn66yZcuqTZs2+v7775WZmam77rpL//znP+2v+fbbb/XBBx9owoQJ6tKli/14eHi4Hn30US1fvlxdunTRqVOnNHv2bLVu3VpvvPGGXFxcJEmTJk3SG2+8cdW6Lly4oNGjR6tq1apasmSJbDab/Vxubq4kKSwsTHXq1FFSUpK6du16zc86efJkZWVlacGCBapZs6Yk6W9/+5vuuusujR8/XvPnz3cY7+3trbfeested05Ojt59912lp6fL09Pzmu8HAMUZS+QACuzhhx9W8+bN1apVKw0dOlTly5fXtGnT5Ovrax/zwAMPOLxm+fLl8vT0VEREhE6dOmV/3H777fLw8LAvc2/YsEFZWVnq2bOnvUmTpN69e1+zru3bt+vgwYPq1auXQ3MpyWEuUxcuXFBSUpLatWtnby4lqWrVqurcubO2bNmijIwMh9fcf//9Du/VuHFjXbhwQYcOHcr3+wNAcUOCCaDARo8eLX9/f7m5ualy5cry9/eXq+v//721VKlSqlatmsNr9u3bp/T0dDVv3vyyc548eVKSdPjwYUlSnTp1HM77+PjIy8vrqnUdOHBAklS3bt18fZ4rOXXqlM6dOyd/f/885wIDA5WTk6MjR47otttusx+vXr26w7hLjW5aWpolNQFAUUaDCaDAGjRoYL+K/HLc3d0dGk7p4lJxpUqVNGHChMu+xsfHx9IaC8tfP/cll5boAaAko8EEcEPVqlVLGzduVKNGjewX/VzOpQRw7969DsvSp06dynO1+V9dGr9r1y61aNHiiuNMl8t9fHxUrlw5paSk5DmXnJwsV1dX3XLLLUZzAcDNgD2YAG6omJgYXbhwQa+//nqec9nZ2fYl5BYtWqh06dKaP3++Q+p36TZDV3P77berRo0aeuedd/IsSf95rks3g7/WsrWbm5siIiK0evVqHTx40H78t99+07Jly3TnnXeqQoUK16wLAG4WJJgAbqimTZuqe/fumjlzpnbs2KGIiAiVLl1ae/fu1fLly/Xss8/qrrvuko+Pjx555BHNnDlT/fv3V6tWrbR9+3YlJiaqYsWKV30PV1dXjRkzRo899pj+9re/6d5771WVKlWUnJysPXv2aM6cOZIuNqLSxVsKRUZGys3NTZ06dbrsnEOGDNGGDRv04IMP6sEHH5Sbm5sWLVqkzMxMPfPMM9Z+SQBQzNFgArjhnn/+ed1xxx1auHChJk2aJDc3N/n5+enuu+9Wo0aN7OOGDBkid3d3LVy4UJs2bVKDBg301ltvqX///td8j5YtW2revHmaPn263nrrLeXm5qpmzZq6//777WM6dOiguLg4ffbZZ/r000+Vm5t7xQbztttu03vvvaeJEydq5syZys3NVYMGDTR+/Pg898AEgJudSy47zgEAAGAh9mACAADAUjSYAAAAsBQNJgAAACxFgwkAAABL0WACAADAUjSYAAAAsBQNJgAAACxFgwkAAABL0WACAADAUjSYAAAAsBQNJgAAACxFgwkAAABL0WACAADAUv8HLG2RHt5NdQEAAAAASUVORK5CYII=\n"
+          },
+          "metadata": {}
+        }
+      ],
+      "source": [
+        "print('------Test set 2 (News):------')\n",
+        "evaluate(test_dataloader_news)"
+      ]
+    }
+  ],
+  "metadata": {
+    "colab": {
+      "provenance": [],
+      "gpuType": "T4"
+    },
+    "kernelspec": {
+      "display_name": "Python 3",
+      "name": "python3"
+    },
+    "language_info": {
+      "name": "python"
+    },
+    "widgets": {
+      "application/vnd.jupyter.widget-state+json": {
+        "5764a78b7242483fab28116500345003": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_name": "HBoxModel",
+          "model_module_version": "1.5.0",
+          "state": {
+            "_dom_classes": [],
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "HBoxModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/controls",
+            "_view_module_version": "1.5.0",
+            "_view_name": "HBoxView",
+            "box_style": "",
+            "children": [
+              "IPY_MODEL_c13f371182494d5ca7f940ac92ca14fe",
+              "IPY_MODEL_a344d30bb9ae42eca1e5af923ee2bff2",
+              "IPY_MODEL_10fb94afa63649aa9bbcb057775f9b5b"
+            ],
+            "layout": "IPY_MODEL_ae5acaca56584953a7d3ef1cbfe779c4"
+          }
+        },
+        "c13f371182494d5ca7f940ac92ca14fe": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_name": "HTMLModel",
+          "model_module_version": "1.5.0",
+          "state": {
+            "_dom_classes": [],
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "HTMLModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/controls",
+            "_view_module_version": "1.5.0",
+            "_view_name": "HTMLView",
+            "description": "",
+            "description_tooltip": null,
+            "layout": "IPY_MODEL_1e153593a4f549f99dcdb6d35ebabd5e",
+            "placeholder": "​",
+            "style": "IPY_MODEL_4218d75eac164226933371e51607580d",
+            "value": "tokenizer_config.json: 100%"
+          }
+        },
+        "a344d30bb9ae42eca1e5af923ee2bff2": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_name": "FloatProgressModel",
+          "model_module_version": "1.5.0",
+          "state": {
+            "_dom_classes": [],
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "FloatProgressModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/controls",
+            "_view_module_version": "1.5.0",
+            "_view_name": "ProgressView",
+            "bar_style": "success",
+            "description": "",
+            "description_tooltip": null,
+            "layout": "IPY_MODEL_f3ed6977f76347bd8eda7a844ddea5a8",
+            "max": 59,
+            "min": 0,
+            "orientation": "horizontal",
+            "style": "IPY_MODEL_8f29f53629044124bd82c4343448f239",
+            "value": 59
+          }
+        },
+        "10fb94afa63649aa9bbcb057775f9b5b": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_name": "HTMLModel",
+          "model_module_version": "1.5.0",
+          "state": {
+            "_dom_classes": [],
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "HTMLModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/controls",
+            "_view_module_version": "1.5.0",
+            "_view_name": "HTMLView",
+            "description": "",
+            "description_tooltip": null,
+            "layout": "IPY_MODEL_77da3aed82c84d48b6c53f69461b6e7d",
+            "placeholder": "​",
+            "style": "IPY_MODEL_1e2cd445d6c04845b480ec744953d0e3",
+            "value": " 59.0/59.0 [00:00&lt;00:00, 2.37kB/s]"
+          }
+        },
+        "ae5acaca56584953a7d3ef1cbfe779c4": {
+          "model_module": "@jupyter-widgets/base",
+          "model_name": "LayoutModel",
+          "model_module_version": "1.2.0",
+          "state": {
+            "_model_module": "@jupyter-widgets/base",
+            "_model_module_version": "1.2.0",
+            "_model_name": "LayoutModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "LayoutView",
+            "align_content": null,
+            "align_items": null,
+            "align_self": null,
+            "border": null,
+            "bottom": null,
+            "display": null,
+            "flex": null,
+            "flex_flow": null,
+            "grid_area": null,
+            "grid_auto_columns": null,
+            "grid_auto_flow": null,
+            "grid_auto_rows": null,
+            "grid_column": null,
+            "grid_gap": null,
+            "grid_row": null,
+            "grid_template_areas": null,
+            "grid_template_columns": null,
+            "grid_template_rows": null,
+            "height": null,
+            "justify_content": null,
+            "justify_items": null,
+            "left": null,
+            "margin": null,
+            "max_height": null,
+            "max_width": null,
+            "min_height": null,
+            "min_width": null,
+            "object_fit": null,
+            "object_position": null,
+            "order": null,
+            "overflow": null,
+            "overflow_x": null,
+            "overflow_y": null,
+            "padding": null,
+            "right": null,
+            "top": null,
+            "visibility": null,
+            "width": null
+          }
+        },
+        "1e153593a4f549f99dcdb6d35ebabd5e": {
+          "model_module": "@jupyter-widgets/base",
+          "model_name": "LayoutModel",
+          "model_module_version": "1.2.0",
+          "state": {
+            "_model_module": "@jupyter-widgets/base",
+            "_model_module_version": "1.2.0",
+            "_model_name": "LayoutModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "LayoutView",
+            "align_content": null,
+            "align_items": null,
+            "align_self": null,
+            "border": null,
+            "bottom": null,
+            "display": null,
+            "flex": null,
+            "flex_flow": null,
+            "grid_area": null,
+            "grid_auto_columns": null,
+            "grid_auto_flow": null,
+            "grid_auto_rows": null,
+            "grid_column": null,
+            "grid_gap": null,
+            "grid_row": null,
+            "grid_template_areas": null,
+            "grid_template_columns": null,
+            "grid_template_rows": null,
+            "height": null,
+            "justify_content": null,
+            "justify_items": null,
+            "left": null,
+            "margin": null,
+            "max_height": null,
+            "max_width": null,
+            "min_height": null,
+            "min_width": null,
+            "object_fit": null,
+            "object_position": null,
+            "order": null,
+            "overflow": null,
+            "overflow_x": null,
+            "overflow_y": null,
+            "padding": null,
+            "right": null,
+            "top": null,
+            "visibility": null,
+            "width": null
+          }
+        },
+        "4218d75eac164226933371e51607580d": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_name": "DescriptionStyleModel",
+          "model_module_version": "1.5.0",
+          "state": {
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "DescriptionStyleModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "StyleView",
+            "description_width": ""
+          }
+        },
+        "f3ed6977f76347bd8eda7a844ddea5a8": {
+          "model_module": "@jupyter-widgets/base",
+          "model_name": "LayoutModel",
+          "model_module_version": "1.2.0",
+          "state": {
+            "_model_module": "@jupyter-widgets/base",
+            "_model_module_version": "1.2.0",
+            "_model_name": "LayoutModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "LayoutView",
+            "align_content": null,
+            "align_items": null,
+            "align_self": null,
+            "border": null,
+            "bottom": null,
+            "display": null,
+            "flex": null,
+            "flex_flow": null,
+            "grid_area": null,
+            "grid_auto_columns": null,
+            "grid_auto_flow": null,
+            "grid_auto_rows": null,
+            "grid_column": null,
+            "grid_gap": null,
+            "grid_row": null,
+            "grid_template_areas": null,
+            "grid_template_columns": null,
+            "grid_template_rows": null,
+            "height": null,
+            "justify_content": null,
+            "justify_items": null,
+            "left": null,
+            "margin": null,
+            "max_height": null,
+            "max_width": null,
+            "min_height": null,
+            "min_width": null,
+            "object_fit": null,
+            "object_position": null,
+            "order": null,
+            "overflow": null,
+            "overflow_x": null,
+            "overflow_y": null,
+            "padding": null,
+            "right": null,
+            "top": null,
+            "visibility": null,
+            "width": null
+          }
+        },
+        "8f29f53629044124bd82c4343448f239": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_name": "ProgressStyleModel",
+          "model_module_version": "1.5.0",
+          "state": {
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "ProgressStyleModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "StyleView",
+            "bar_color": null,
+            "description_width": ""
+          }
+        },
+        "77da3aed82c84d48b6c53f69461b6e7d": {
+          "model_module": "@jupyter-widgets/base",
+          "model_name": "LayoutModel",
+          "model_module_version": "1.2.0",
+          "state": {
+            "_model_module": "@jupyter-widgets/base",
+            "_model_module_version": "1.2.0",
+            "_model_name": "LayoutModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "LayoutView",
+            "align_content": null,
+            "align_items": null,
+            "align_self": null,
+            "border": null,
+            "bottom": null,
+            "display": null,
+            "flex": null,
+            "flex_flow": null,
+            "grid_area": null,
+            "grid_auto_columns": null,
+            "grid_auto_flow": null,
+            "grid_auto_rows": null,
+            "grid_column": null,
+            "grid_gap": null,
+            "grid_row": null,
+            "grid_template_areas": null,
+            "grid_template_columns": null,
+            "grid_template_rows": null,
+            "height": null,
+            "justify_content": null,
+            "justify_items": null,
+            "left": null,
+            "margin": null,
+            "max_height": null,
+            "max_width": null,
+            "min_height": null,
+            "min_width": null,
+            "object_fit": null,
+            "object_position": null,
+            "order": null,
+            "overflow": null,
+            "overflow_x": null,
+            "overflow_y": null,
+            "padding": null,
+            "right": null,
+            "top": null,
+            "visibility": null,
+            "width": null
+          }
+        },
+        "1e2cd445d6c04845b480ec744953d0e3": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_name": "DescriptionStyleModel",
+          "model_module_version": "1.5.0",
+          "state": {
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "DescriptionStyleModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "StyleView",
+            "description_width": ""
+          }
+        },
+        "0ddc49566bbd4f9fa7a6b107b8e9c529": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_name": "HBoxModel",
+          "model_module_version": "1.5.0",
+          "state": {
+            "_dom_classes": [],
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "HBoxModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/controls",
+            "_view_module_version": "1.5.0",
+            "_view_name": "HBoxView",
+            "box_style": "",
+            "children": [
+              "IPY_MODEL_7d70ddf69a2247a095f057f480b9ec4f",
+              "IPY_MODEL_4b95509bb3a647619e7b9322cd611998",
+              "IPY_MODEL_ef0211e7837e4f9898f3021d03b70980"
+            ],
+            "layout": "IPY_MODEL_d12728f0487c4cca948e22affd369fa6"
+          }
+        },
+        "7d70ddf69a2247a095f057f480b9ec4f": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_name": "HTMLModel",
+          "model_module_version": "1.5.0",
+          "state": {
+            "_dom_classes": [],
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "HTMLModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/controls",
+            "_view_module_version": "1.5.0",
+            "_view_name": "HTMLView",
+            "description": "",
+            "description_tooltip": null,
+            "layout": "IPY_MODEL_6ebfd5780446489e9515c0ee8c19fa96",
+            "placeholder": "​",
+            "style": "IPY_MODEL_7b395281b4a340bfb535e779123d4f0a",
+            "value": "vocab.txt: 100%"
+          }
+        },
+        "4b95509bb3a647619e7b9322cd611998": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_name": "FloatProgressModel",
+          "model_module_version": "1.5.0",
+          "state": {
+            "_dom_classes": [],
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "FloatProgressModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/controls",
+            "_view_module_version": "1.5.0",
+            "_view_name": "ProgressView",
+            "bar_style": "success",
+            "description": "",
+            "description_tooltip": null,
+            "layout": "IPY_MODEL_1792006a7f204f08800ecfd00347fca7",
+            "max": 235127,
+            "min": 0,
+            "orientation": "horizontal",
+            "style": "IPY_MODEL_1e246c312fb94a409104fe49193dbb3d",
+            "value": 235127
+          }
+        },
+        "ef0211e7837e4f9898f3021d03b70980": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_name": "HTMLModel",
+          "model_module_version": "1.5.0",
+          "state": {
+            "_dom_classes": [],
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "HTMLModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/controls",
+            "_view_module_version": "1.5.0",
+            "_view_name": "HTMLView",
+            "description": "",
+            "description_tooltip": null,
+            "layout": "IPY_MODEL_4a15e7cace0c4f269654c43f0b560c8e",
+            "placeholder": "​",
+            "style": "IPY_MODEL_e1b2481b7a9848188d15177e774f536c",
+            "value": " 235k/235k [00:00&lt;00:00, 3.10MB/s]"
+          }
+        },
+        "d12728f0487c4cca948e22affd369fa6": {
+          "model_module": "@jupyter-widgets/base",
+          "model_name": "LayoutModel",
+          "model_module_version": "1.2.0",
+          "state": {
+            "_model_module": "@jupyter-widgets/base",
+            "_model_module_version": "1.2.0",
+            "_model_name": "LayoutModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "LayoutView",
+            "align_content": null,
+            "align_items": null,
+            "align_self": null,
+            "border": null,
+            "bottom": null,
+            "display": null,
+            "flex": null,
+            "flex_flow": null,
+            "grid_area": null,
+            "grid_auto_columns": null,
+            "grid_auto_flow": null,
+            "grid_auto_rows": null,
+            "grid_column": null,
+            "grid_gap": null,
+            "grid_row": null,
+            "grid_template_areas": null,
+            "grid_template_columns": null,
+            "grid_template_rows": null,
+            "height": null,
+            "justify_content": null,
+            "justify_items": null,
+            "left": null,
+            "margin": null,
+            "max_height": null,
+            "max_width": null,
+            "min_height": null,
+            "min_width": null,
+            "object_fit": null,
+            "object_position": null,
+            "order": null,
+            "overflow": null,
+            "overflow_x": null,
+            "overflow_y": null,
+            "padding": null,
+            "right": null,
+            "top": null,
+            "visibility": null,
+            "width": null
+          }
+        },
+        "6ebfd5780446489e9515c0ee8c19fa96": {
+          "model_module": "@jupyter-widgets/base",
+          "model_name": "LayoutModel",
+          "model_module_version": "1.2.0",
+          "state": {
+            "_model_module": "@jupyter-widgets/base",
+            "_model_module_version": "1.2.0",
+            "_model_name": "LayoutModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "LayoutView",
+            "align_content": null,
+            "align_items": null,
+            "align_self": null,
+            "border": null,
+            "bottom": null,
+            "display": null,
+            "flex": null,
+            "flex_flow": null,
+            "grid_area": null,
+            "grid_auto_columns": null,
+            "grid_auto_flow": null,
+            "grid_auto_rows": null,
+            "grid_column": null,
+            "grid_gap": null,
+            "grid_row": null,
+            "grid_template_areas": null,
+            "grid_template_columns": null,
+            "grid_template_rows": null,
+            "height": null,
+            "justify_content": null,
+            "justify_items": null,
+            "left": null,
+            "margin": null,
+            "max_height": null,
+            "max_width": null,
+            "min_height": null,
+            "min_width": null,
+            "object_fit": null,
+            "object_position": null,
+            "order": null,
+            "overflow": null,
+            "overflow_x": null,
+            "overflow_y": null,
+            "padding": null,
+            "right": null,
+            "top": null,
+            "visibility": null,
+            "width": null
+          }
+        },
+        "7b395281b4a340bfb535e779123d4f0a": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_name": "DescriptionStyleModel",
+          "model_module_version": "1.5.0",
+          "state": {
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "DescriptionStyleModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "StyleView",
+            "description_width": ""
+          }
+        },
+        "1792006a7f204f08800ecfd00347fca7": {
+          "model_module": "@jupyter-widgets/base",
+          "model_name": "LayoutModel",
+          "model_module_version": "1.2.0",
+          "state": {
+            "_model_module": "@jupyter-widgets/base",
+            "_model_module_version": "1.2.0",
+            "_model_name": "LayoutModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "LayoutView",
+            "align_content": null,
+            "align_items": null,
+            "align_self": null,
+            "border": null,
+            "bottom": null,
+            "display": null,
+            "flex": null,
+            "flex_flow": null,
+            "grid_area": null,
+            "grid_auto_columns": null,
+            "grid_auto_flow": null,
+            "grid_auto_rows": null,
+            "grid_column": null,
+            "grid_gap": null,
+            "grid_row": null,
+            "grid_template_areas": null,
+            "grid_template_columns": null,
+            "grid_template_rows": null,
+            "height": null,
+            "justify_content": null,
+            "justify_items": null,
+            "left": null,
+            "margin": null,
+            "max_height": null,
+            "max_width": null,
+            "min_height": null,
+            "min_width": null,
+            "object_fit": null,
+            "object_position": null,
+            "order": null,
+            "overflow": null,
+            "overflow_x": null,
+            "overflow_y": null,
+            "padding": null,
+            "right": null,
+            "top": null,
+            "visibility": null,
+            "width": null
+          }
+        },
+        "1e246c312fb94a409104fe49193dbb3d": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_name": "ProgressStyleModel",
+          "model_module_version": "1.5.0",
+          "state": {
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "ProgressStyleModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "StyleView",
+            "bar_color": null,
+            "description_width": ""
+          }
+        },
+        "4a15e7cace0c4f269654c43f0b560c8e": {
+          "model_module": "@jupyter-widgets/base",
+          "model_name": "LayoutModel",
+          "model_module_version": "1.2.0",
+          "state": {
+            "_model_module": "@jupyter-widgets/base",
+            "_model_module_version": "1.2.0",
+            "_model_name": "LayoutModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "LayoutView",
+            "align_content": null,
+            "align_items": null,
+            "align_self": null,
+            "border": null,
+            "bottom": null,
+            "display": null,
+            "flex": null,
+            "flex_flow": null,
+            "grid_area": null,
+            "grid_auto_columns": null,
+            "grid_auto_flow": null,
+            "grid_auto_rows": null,
+            "grid_column": null,
+            "grid_gap": null,
+            "grid_row": null,
+            "grid_template_areas": null,
+            "grid_template_columns": null,
+            "grid_template_rows": null,
+            "height": null,
+            "justify_content": null,
+            "justify_items": null,
+            "left": null,
+            "margin": null,
+            "max_height": null,
+            "max_width": null,
+            "min_height": null,
+            "min_width": null,
+            "object_fit": null,
+            "object_position": null,
+            "order": null,
+            "overflow": null,
+            "overflow_x": null,
+            "overflow_y": null,
+            "padding": null,
+            "right": null,
+            "top": null,
+            "visibility": null,
+            "width": null
+          }
+        },
+        "e1b2481b7a9848188d15177e774f536c": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_name": "DescriptionStyleModel",
+          "model_module_version": "1.5.0",
+          "state": {
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "DescriptionStyleModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "StyleView",
+            "description_width": ""
+          }
+        },
+        "5b9bc639210f44798081a477505adad1": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_name": "HBoxModel",
+          "model_module_version": "1.5.0",
+          "state": {
+            "_dom_classes": [],
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "HBoxModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/controls",
+            "_view_module_version": "1.5.0",
+            "_view_name": "HBoxView",
+            "box_style": "",
+            "children": [
+              "IPY_MODEL_dd42d1ad6883442db6ea2b7d64cf066e",
+              "IPY_MODEL_87c875520b144e649a854a31e911dd93",
+              "IPY_MODEL_c39ea49c0a5943bca9f44d9dd26a7bff"
+            ],
+            "layout": "IPY_MODEL_130526a132634d06b5e93729481ee639"
+          }
+        },
+        "dd42d1ad6883442db6ea2b7d64cf066e": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_name": "HTMLModel",
+          "model_module_version": "1.5.0",
+          "state": {
+            "_dom_classes": [],
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "HTMLModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/controls",
+            "_view_module_version": "1.5.0",
+            "_view_name": "HTMLView",
+            "description": "",
+            "description_tooltip": null,
+            "layout": "IPY_MODEL_bc98480a55db4099a54f981d21d168c4",
+            "placeholder": "​",
+            "style": "IPY_MODEL_557e1bfcdb144468a1d3f0500e564b40",
+            "value": "config.json: 100%"
+          }
+        },
+        "87c875520b144e649a854a31e911dd93": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_name": "FloatProgressModel",
+          "model_module_version": "1.5.0",
+          "state": {
+            "_dom_classes": [],
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "FloatProgressModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/controls",
+            "_view_module_version": "1.5.0",
+            "_view_name": "ProgressView",
+            "bar_style": "success",
+            "description": "",
+            "description_tooltip": null,
+            "layout": "IPY_MODEL_0c8c7aba4cf94821900f633721105840",
+            "max": 433,
+            "min": 0,
+            "orientation": "horizontal",
+            "style": "IPY_MODEL_628ed27a64c046e0a38ad2da58bf8088",
+            "value": 433
+          }
+        },
+        "c39ea49c0a5943bca9f44d9dd26a7bff": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_name": "HTMLModel",
+          "model_module_version": "1.5.0",
+          "state": {
+            "_dom_classes": [],
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "HTMLModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/controls",
+            "_view_module_version": "1.5.0",
+            "_view_name": "HTMLView",
+            "description": "",
+            "description_tooltip": null,
+            "layout": "IPY_MODEL_a4ebb362a8d6459d800684c6d1aa0ca6",
+            "placeholder": "​",
+            "style": "IPY_MODEL_e69e2a4898b34b2680006fd6e2418190",
+            "value": " 433/433 [00:00&lt;00:00, 7.28kB/s]"
+          }
+        },
+        "130526a132634d06b5e93729481ee639": {
+          "model_module": "@jupyter-widgets/base",
+          "model_name": "LayoutModel",
+          "model_module_version": "1.2.0",
+          "state": {
+            "_model_module": "@jupyter-widgets/base",
+            "_model_module_version": "1.2.0",
+            "_model_name": "LayoutModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "LayoutView",
+            "align_content": null,
+            "align_items": null,
+            "align_self": null,
+            "border": null,
+            "bottom": null,
+            "display": null,
+            "flex": null,
+            "flex_flow": null,
+            "grid_area": null,
+            "grid_auto_columns": null,
+            "grid_auto_flow": null,
+            "grid_auto_rows": null,
+            "grid_column": null,
+            "grid_gap": null,
+            "grid_row": null,
+            "grid_template_areas": null,
+            "grid_template_columns": null,
+            "grid_template_rows": null,
+            "height": null,
+            "justify_content": null,
+            "justify_items": null,
+            "left": null,
+            "margin": null,
+            "max_height": null,
+            "max_width": null,
+            "min_height": null,
+            "min_width": null,
+            "object_fit": null,
+            "object_position": null,
+            "order": null,
+            "overflow": null,
+            "overflow_x": null,
+            "overflow_y": null,
+            "padding": null,
+            "right": null,
+            "top": null,
+            "visibility": null,
+            "width": null
+          }
+        },
+        "bc98480a55db4099a54f981d21d168c4": {
+          "model_module": "@jupyter-widgets/base",
+          "model_name": "LayoutModel",
+          "model_module_version": "1.2.0",
+          "state": {
+            "_model_module": "@jupyter-widgets/base",
+            "_model_module_version": "1.2.0",
+            "_model_name": "LayoutModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "LayoutView",
+            "align_content": null,
+            "align_items": null,
+            "align_self": null,
+            "border": null,
+            "bottom": null,
+            "display": null,
+            "flex": null,
+            "flex_flow": null,
+            "grid_area": null,
+            "grid_auto_columns": null,
+            "grid_auto_flow": null,
+            "grid_auto_rows": null,
+            "grid_column": null,
+            "grid_gap": null,
+            "grid_row": null,
+            "grid_template_areas": null,
+            "grid_template_columns": null,
+            "grid_template_rows": null,
+            "height": null,
+            "justify_content": null,
+            "justify_items": null,
+            "left": null,
+            "margin": null,
+            "max_height": null,
+            "max_width": null,
+            "min_height": null,
+            "min_width": null,
+            "object_fit": null,
+            "object_position": null,
+            "order": null,
+            "overflow": null,
+            "overflow_x": null,
+            "overflow_y": null,
+            "padding": null,
+            "right": null,
+            "top": null,
+            "visibility": null,
+            "width": null
+          }
+        },
+        "557e1bfcdb144468a1d3f0500e564b40": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_name": "DescriptionStyleModel",
+          "model_module_version": "1.5.0",
+          "state": {
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "DescriptionStyleModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "StyleView",
+            "description_width": ""
+          }
+        },
+        "0c8c7aba4cf94821900f633721105840": {
+          "model_module": "@jupyter-widgets/base",
+          "model_name": "LayoutModel",
+          "model_module_version": "1.2.0",
+          "state": {
+            "_model_module": "@jupyter-widgets/base",
+            "_model_module_version": "1.2.0",
+            "_model_name": "LayoutModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "LayoutView",
+            "align_content": null,
+            "align_items": null,
+            "align_self": null,
+            "border": null,
+            "bottom": null,
+            "display": null,
+            "flex": null,
+            "flex_flow": null,
+            "grid_area": null,
+            "grid_auto_columns": null,
+            "grid_auto_flow": null,
+            "grid_auto_rows": null,
+            "grid_column": null,
+            "grid_gap": null,
+            "grid_row": null,
+            "grid_template_areas": null,
+            "grid_template_columns": null,
+            "grid_template_rows": null,
+            "height": null,
+            "justify_content": null,
+            "justify_items": null,
+            "left": null,
+            "margin": null,
+            "max_height": null,
+            "max_width": null,
+            "min_height": null,
+            "min_width": null,
+            "object_fit": null,
+            "object_position": null,
+            "order": null,
+            "overflow": null,
+            "overflow_x": null,
+            "overflow_y": null,
+            "padding": null,
+            "right": null,
+            "top": null,
+            "visibility": null,
+            "width": null
+          }
+        },
+        "628ed27a64c046e0a38ad2da58bf8088": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_name": "ProgressStyleModel",
+          "model_module_version": "1.5.0",
+          "state": {
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "ProgressStyleModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "StyleView",
+            "bar_color": null,
+            "description_width": ""
+          }
+        },
+        "a4ebb362a8d6459d800684c6d1aa0ca6": {
+          "model_module": "@jupyter-widgets/base",
+          "model_name": "LayoutModel",
+          "model_module_version": "1.2.0",
+          "state": {
+            "_model_module": "@jupyter-widgets/base",
+            "_model_module_version": "1.2.0",
+            "_model_name": "LayoutModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "LayoutView",
+            "align_content": null,
+            "align_items": null,
+            "align_self": null,
+            "border": null,
+            "bottom": null,
+            "display": null,
+            "flex": null,
+            "flex_flow": null,
+            "grid_area": null,
+            "grid_auto_columns": null,
+            "grid_auto_flow": null,
+            "grid_auto_rows": null,
+            "grid_column": null,
+            "grid_gap": null,
+            "grid_row": null,
+            "grid_template_areas": null,
+            "grid_template_columns": null,
+            "grid_template_rows": null,
+            "height": null,
+            "justify_content": null,
+            "justify_items": null,
+            "left": null,
+            "margin": null,
+            "max_height": null,
+            "max_width": null,
+            "min_height": null,
+            "min_width": null,
+            "object_fit": null,
+            "object_position": null,
+            "order": null,
+            "overflow": null,
+            "overflow_x": null,
+            "overflow_y": null,
+            "padding": null,
+            "right": null,
+            "top": null,
+            "visibility": null,
+            "width": null
+          }
+        },
+        "e69e2a4898b34b2680006fd6e2418190": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_name": "DescriptionStyleModel",
+          "model_module_version": "1.5.0",
+          "state": {
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "DescriptionStyleModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "StyleView",
+            "description_width": ""
+          }
+        },
+        "9ac9cdeb7b914268b903be1671cd08af": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_name": "HBoxModel",
+          "model_module_version": "1.5.0",
+          "state": {
+            "_dom_classes": [],
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "HBoxModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/controls",
+            "_view_module_version": "1.5.0",
+            "_view_name": "HBoxView",
+            "box_style": "",
+            "children": [
+              "IPY_MODEL_84a0117cb0b542c48ce69aa9d70e4fff",
+              "IPY_MODEL_55ca22a2ce42460aa61182edeada6661",
+              "IPY_MODEL_7e6fa7f2f34a4da499bb264b18ba05a2"
+            ],
+            "layout": "IPY_MODEL_c8820fd13dd6454cb22bee7ada5142a1"
+          }
+        },
+        "84a0117cb0b542c48ce69aa9d70e4fff": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_name": "HTMLModel",
+          "model_module_version": "1.5.0",
+          "state": {
+            "_dom_classes": [],
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "HTMLModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/controls",
+            "_view_module_version": "1.5.0",
+            "_view_name": "HTMLView",
+            "description": "",
+            "description_tooltip": null,
+            "layout": "IPY_MODEL_8e0634b7de8a44d6b58b885e8e1fd528",
+            "placeholder": "​",
+            "style": "IPY_MODEL_ba3c2b0e6cf44e5391c5110039e6ba6b",
+            "value": "model.safetensors: 100%"
+          }
+        },
+        "55ca22a2ce42460aa61182edeada6661": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_name": "FloatProgressModel",
+          "model_module_version": "1.5.0",
+          "state": {
+            "_dom_classes": [],
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "FloatProgressModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/controls",
+            "_view_module_version": "1.5.0",
+            "_view_name": "ProgressView",
+            "bar_style": "success",
+            "description": "",
+            "description_tooltip": null,
+            "layout": "IPY_MODEL_4bfb4cec9af34046beee263e12ce9750",
+            "max": 442233876,
+            "min": 0,
+            "orientation": "horizontal",
+            "style": "IPY_MODEL_07021d0b3a8041dbae9e91004498b6b1",
+            "value": 442233876
+          }
+        },
+        "7e6fa7f2f34a4da499bb264b18ba05a2": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_name": "HTMLModel",
+          "model_module_version": "1.5.0",
+          "state": {
+            "_dom_classes": [],
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "HTMLModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/controls",
+            "_view_module_version": "1.5.0",
+            "_view_name": "HTMLView",
+            "description": "",
+            "description_tooltip": null,
+            "layout": "IPY_MODEL_0a73ae8491e748629fb0d2450538656a",
+            "placeholder": "​",
+            "style": "IPY_MODEL_fd56c87f4afb44ae886eefed08bb4a69",
+            "value": " 442M/442M [00:05&lt;00:00, 86.3MB/s]"
+          }
+        },
+        "c8820fd13dd6454cb22bee7ada5142a1": {
+          "model_module": "@jupyter-widgets/base",
+          "model_name": "LayoutModel",
+          "model_module_version": "1.2.0",
+          "state": {
+            "_model_module": "@jupyter-widgets/base",
+            "_model_module_version": "1.2.0",
+            "_model_name": "LayoutModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "LayoutView",
+            "align_content": null,
+            "align_items": null,
+            "align_self": null,
+            "border": null,
+            "bottom": null,
+            "display": null,
+            "flex": null,
+            "flex_flow": null,
+            "grid_area": null,
+            "grid_auto_columns": null,
+            "grid_auto_flow": null,
+            "grid_auto_rows": null,
+            "grid_column": null,
+            "grid_gap": null,
+            "grid_row": null,
+            "grid_template_areas": null,
+            "grid_template_columns": null,
+            "grid_template_rows": null,
+            "height": null,
+            "justify_content": null,
+            "justify_items": null,
+            "left": null,
+            "margin": null,
+            "max_height": null,
+            "max_width": null,
+            "min_height": null,
+            "min_width": null,
+            "object_fit": null,
+            "object_position": null,
+            "order": null,
+            "overflow": null,
+            "overflow_x": null,
+            "overflow_y": null,
+            "padding": null,
+            "right": null,
+            "top": null,
+            "visibility": null,
+            "width": null
+          }
+        },
+        "8e0634b7de8a44d6b58b885e8e1fd528": {
+          "model_module": "@jupyter-widgets/base",
+          "model_name": "LayoutModel",
+          "model_module_version": "1.2.0",
+          "state": {
+            "_model_module": "@jupyter-widgets/base",
+            "_model_module_version": "1.2.0",
+            "_model_name": "LayoutModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "LayoutView",
+            "align_content": null,
+            "align_items": null,
+            "align_self": null,
+            "border": null,
+            "bottom": null,
+            "display": null,
+            "flex": null,
+            "flex_flow": null,
+            "grid_area": null,
+            "grid_auto_columns": null,
+            "grid_auto_flow": null,
+            "grid_auto_rows": null,
+            "grid_column": null,
+            "grid_gap": null,
+            "grid_row": null,
+            "grid_template_areas": null,
+            "grid_template_columns": null,
+            "grid_template_rows": null,
+            "height": null,
+            "justify_content": null,
+            "justify_items": null,
+            "left": null,
+            "margin": null,
+            "max_height": null,
+            "max_width": null,
+            "min_height": null,
+            "min_width": null,
+            "object_fit": null,
+            "object_position": null,
+            "order": null,
+            "overflow": null,
+            "overflow_x": null,
+            "overflow_y": null,
+            "padding": null,
+            "right": null,
+            "top": null,
+            "visibility": null,
+            "width": null
+          }
+        },
+        "ba3c2b0e6cf44e5391c5110039e6ba6b": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_name": "DescriptionStyleModel",
+          "model_module_version": "1.5.0",
+          "state": {
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "DescriptionStyleModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "StyleView",
+            "description_width": ""
+          }
+        },
+        "4bfb4cec9af34046beee263e12ce9750": {
+          "model_module": "@jupyter-widgets/base",
+          "model_name": "LayoutModel",
+          "model_module_version": "1.2.0",
+          "state": {
+            "_model_module": "@jupyter-widgets/base",
+            "_model_module_version": "1.2.0",
+            "_model_name": "LayoutModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "LayoutView",
+            "align_content": null,
+            "align_items": null,
+            "align_self": null,
+            "border": null,
+            "bottom": null,
+            "display": null,
+            "flex": null,
+            "flex_flow": null,
+            "grid_area": null,
+            "grid_auto_columns": null,
+            "grid_auto_flow": null,
+            "grid_auto_rows": null,
+            "grid_column": null,
+            "grid_gap": null,
+            "grid_row": null,
+            "grid_template_areas": null,
+            "grid_template_columns": null,
+            "grid_template_rows": null,
+            "height": null,
+            "justify_content": null,
+            "justify_items": null,
+            "left": null,
+            "margin": null,
+            "max_height": null,
+            "max_width": null,
+            "min_height": null,
+            "min_width": null,
+            "object_fit": null,
+            "object_position": null,
+            "order": null,
+            "overflow": null,
+            "overflow_x": null,
+            "overflow_y": null,
+            "padding": null,
+            "right": null,
+            "top": null,
+            "visibility": null,
+            "width": null
+          }
+        },
+        "07021d0b3a8041dbae9e91004498b6b1": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_name": "ProgressStyleModel",
+          "model_module_version": "1.5.0",
+          "state": {
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "ProgressStyleModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "StyleView",
+            "bar_color": null,
+            "description_width": ""
+          }
+        },
+        "0a73ae8491e748629fb0d2450538656a": {
+          "model_module": "@jupyter-widgets/base",
+          "model_name": "LayoutModel",
+          "model_module_version": "1.2.0",
+          "state": {
+            "_model_module": "@jupyter-widgets/base",
+            "_model_module_version": "1.2.0",
+            "_model_name": "LayoutModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "LayoutView",
+            "align_content": null,
+            "align_items": null,
+            "align_self": null,
+            "border": null,
+            "bottom": null,
+            "display": null,
+            "flex": null,
+            "flex_flow": null,
+            "grid_area": null,
+            "grid_auto_columns": null,
+            "grid_auto_flow": null,
+            "grid_auto_rows": null,
+            "grid_column": null,
+            "grid_gap": null,
+            "grid_row": null,
+            "grid_template_areas": null,
+            "grid_template_columns": null,
+            "grid_template_rows": null,
+            "height": null,
+            "justify_content": null,
+            "justify_items": null,
+            "left": null,
+            "margin": null,
+            "max_height": null,
+            "max_width": null,
+            "min_height": null,
+            "min_width": null,
+            "object_fit": null,
+            "object_position": null,
+            "order": null,
+            "overflow": null,
+            "overflow_x": null,
+            "overflow_y": null,
+            "padding": null,
+            "right": null,
+            "top": null,
+            "visibility": null,
+            "width": null
+          }
+        },
+        "fd56c87f4afb44ae886eefed08bb4a69": {
+          "model_module": "@jupyter-widgets/controls",
+          "model_name": "DescriptionStyleModel",
+          "model_module_version": "1.5.0",
+          "state": {
+            "_model_module": "@jupyter-widgets/controls",
+            "_model_module_version": "1.5.0",
+            "_model_name": "DescriptionStyleModel",
+            "_view_count": null,
+            "_view_module": "@jupyter-widgets/base",
+            "_view_module_version": "1.2.0",
+            "_view_name": "StyleView",
+            "description_width": ""
+          }
+        }
+      }
+    },
+    "accelerator": "GPU"
+  },
+  "nbformat": 4,
+  "nbformat_minor": 0
+}


### PR DESCRIPTION
Fine-tuning of the two BERT models we've already used to extract embeddings. Both show signs of overfitting, but achieve good and comparable results in the in-domain task. Surprisingly, Alberto's performance doesn't have as dramatic of a decay for the out-of-domain task as expected.